### PR TITLE
fix: harden pytest conftest example URL handling and XML patching

### DIFF
--- a/examples/pytest-junitxml/conftest_junit_ai_utils.py
+++ b/examples/pytest-junitxml/conftest_junit_ai_utils.py
@@ -91,7 +91,7 @@ def enrich_junit_xml(session) -> None:
     analysis_map, html_report_url = _fetch_analysis_from_server(
         server_url=server_url, payload=payload
     )
-    if not analysis_map:
+    if not analysis_map and not html_report_url:
         return
 
     _apply_analysis_to_xml(
@@ -150,11 +150,11 @@ def _fetch_analysis_from_server(
         payload: Request payload containing failures and AI config.
 
     Returns:
-        Tuple of (analysis_map, html_report_url).
-        analysis_map: Mapping of (classname, test_name) to analysis results.
-        html_report_url: The HTML report URL, extracted from the server response
-            or constructed from job_id and server_url when the response omits it.
-            Empty string if neither is available.
+        tuple[dict[tuple[str, str], dict[str, Any]], str]: Two-element tuple of:
+            analysis_map: Mapping of (classname, test_name) to analysis results.
+            html_report_url: URL from server response, or constructed from
+                job_id and server_url, or empty string if neither is available.
+
         Returns ({}, "") on request failure.
     """
     try:
@@ -185,6 +185,12 @@ def _fetch_analysis_from_server(
     html_report_url = result.get("html_report_url") or (
         f"{server_url.rstrip('/')}/results/{job_id}.html" if job_id else ""
     )
+    if html_report_url and not html_report_url.startswith(("http://", "https://")):
+        logger.warning(
+            "jenkins-job-insight: Invalid html_report_url scheme, ignoring: %s",
+            html_report_url,
+        )
+        html_report_url = ""
 
     analysis_map: dict[tuple[str, str], dict[str, Any]] = {}
     for failure in result.get("failures", []):
@@ -206,7 +212,7 @@ def _apply_analysis_to_xml(
     analysis_map: dict[tuple[str, str], dict[str, Any]],
     html_report_url: str = "",
 ) -> None:
-    """Apply AI analysis results to JUnit XML testcase elements.
+    """Apply AI analysis results and HTML report URL to JUnit XML.
 
     Uses exact (classname, name) matching since failures are extracted from
     the same XML file, guaranteeing identical attribute values.
@@ -215,7 +221,7 @@ def _apply_analysis_to_xml(
     Args:
         xml_path: Path to the JUnit XML report file.
         analysis_map: Mapping of (classname, test_name) to analysis results.
-        html_report_url: URL to the HTML report, added as a testsuite-level property.
+        html_report_url (str): URL to the HTML report, added as a testsuite-level property.
     """
     backup_path = xml_path.with_suffix(".xml.bak")
     shutil.copy2(xml_path, backup_path)
@@ -238,13 +244,14 @@ def _apply_analysis_to_xml(
                 unmatched,
             )
 
-        # Add html_report_url as a testsuite-level property
+        # Add html_report_url to the first testsuite only (pytest JUnit XML does not use namespaces)
         if html_report_url:
-            for testsuite in tree.iter("testsuite"):
-                ts_props = testsuite.find("properties")
+            first_testsuite = next(tree.iter("testsuite"), None)
+            if first_testsuite is not None:
+                ts_props = first_testsuite.find("properties")
                 if ts_props is None:
                     ts_props = ET.Element("properties")
-                    testsuite.insert(0, ts_props)
+                    first_testsuite.insert(0, ts_props)
                 _add_property(ts_props, "html_report_url", html_report_url)
 
         tree.write(str(xml_path), encoding="unicode", xml_declaration=True)


### PR DESCRIPTION
- Validate html_report_url scheme before use, discard non-HTTP(S) values
- Only add html_report_url property to first testsuite element
- Allow returning html_report_url even when analysis_map is empty
- Clean up docstring formatting for _fetch_analysis_from_server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * XML enrichment now processes when either analysis results or HTML report URL is present.
  * Added validation for HTML report URLs; non-http/https URLs are now rejected.
  * HTML report URL is now applied to the first test suite instead of all test suites.

* **Documentation**
  * Updated descriptions for analysis results and HTML report URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->