### PR TITLE
fix: remaining changes from issue #59 — Select All checkbox, remove test dropdown

### DIFF
--- a/src/jenkins_job_insight/html_report.py
+++ b/src/jenkins_job_insight/html_report.py
@@ -1924,11 +1924,6 @@ def _render_child_jobs(
             )
 
         if child_groups:
-            parts.append(
-                '    <label class="reviewed-toggle select-all-toggle" onclick="event.stopPropagation(); toggleAllReviewed(this)" style="margin-bottom:8px;font-weight:700;">\n'
-                '      <input type="checkbox"> Select All\n'
-                "    </label>\n"
-            )
             for group in child_groups:
                 _render_group_card(
                     parts,


### PR DESCRIPTION
## Summary

Contains changes that were committed locally but not pushed before PR #60 was merged:

- Select All / Deselect All parent checkbox for reviewed tests in bug cards
- Individual test checkboxes visually nested under Select All
- Removed redundant child job level Select All (keep per-bug-card only)
- Removed test selector dropdown from comments (use representative test automatically)

Part of #59

## Test plan
- [x] Select All toggles all checkboxes and syncs with server
- [x] Individual checkbox toggle updates Select All state
- [x] Comments use representative test without dropdown