### PR TITLE
feat: clickable file links, grouped comments, and branch ref support

### DIFF
--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -1,0 +1,29 @@
+import { useMemo, type ReactNode } from 'react'
+import { autoLinkAnalysis, type RepoUrl, type LinkSegment } from '@/lib/autoLink'
+
+interface LinkedTextProps {
+  text: string
+  repoUrls: RepoUrl[]
+  /** Custom renderer for link segments. Must return a React element with a stable `key` (typically the `index` parameter). */
+  renderLink?: (seg: LinkSegment, index: number) => ReactNode
+}
+
+export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
+  const segments = useMemo<LinkSegment[]>(() => autoLinkAnalysis(text, repoUrls), [text, repoUrls])
+
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.type === 'link' ? (
+          renderLink ? renderLink(seg, i) : (
+            <a key={i} href={seg.href} target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">
+              {seg.text}
+            </a>
+          )
+        ) : (
+          <span key={i}>{seg.text}</span>
+        )
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -1,20 +1,11 @@
 import { useMemo, type ReactNode } from 'react'
-import { autoLinkAnalysis, type RepoUrl, type LinkSegment } from '@/lib/autoLink'
+import { autoLinkAnalysis, isSafeHref, type RepoUrl, type LinkSegment } from '@/lib/autoLink'
 
 interface LinkedTextProps {
   text: string
   repoUrls: RepoUrl[]
   /** Custom renderer for link segments. Must return a React element with a stable `key` (typically the `index` parameter). */
   renderLink?: (seg: LinkSegment, index: number) => ReactNode
-}
-
-function isSafeHref(href: string): boolean {
-  try {
-    const url = new URL(href, 'https://example.invalid')
-    return url.protocol === 'http:' || url.protocol === 'https:'
-  } catch {
-    return false
-  }
 }
 
 export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {

--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -8,13 +8,22 @@ interface LinkedTextProps {
   renderLink?: (seg: LinkSegment, index: number) => ReactNode
 }
 
+function isSafeHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://example.invalid')
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
   const segments = useMemo<LinkSegment[]>(() => autoLinkAnalysis(text, repoUrls), [text, repoUrls])
 
   return (
     <>
       {segments.map((seg, i) =>
-        seg.type === 'link' ? (
+        seg.type === 'link' && isSafeHref(seg.href!) ? (
           renderLink ? renderLink(seg, i) : (
             <a key={i} href={seg.href} target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">
               {seg.text}

--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -14,7 +14,7 @@ export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
   return (
     <>
       {segments.map((seg, i) =>
-        seg.type === 'link' && isSafeHref(seg.href!) ? (
+        seg.type === 'link' && seg.href && isSafeHref(seg.href) ? (
           renderLink ? renderLink(seg, i) : (
             <a key={i} href={seg.href} target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">
               {seg.text}

--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -1,10 +1,10 @@
-import { useMemo, type ReactNode } from 'react'
+import { Fragment, useMemo, type ReactNode } from 'react'
 import { autoLinkAnalysis, isSafeHref, type RepoUrl, type LinkSegment } from '@/lib/autoLink'
 
 interface LinkedTextProps {
   text: string
   repoUrls: RepoUrl[]
-  /** Custom renderer for link segments. Must return a React element with a stable `key` (typically the `index` parameter). */
+  /** Custom renderer for link segments. */
   renderLink?: (seg: LinkSegment, index: number) => ReactNode
 }
 
@@ -15,7 +15,7 @@ export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
     <>
       {segments.map((seg, i) =>
         seg.type === 'link' && seg.href && isSafeHref(seg.href) ? (
-          renderLink ? renderLink(seg, i) : (
+          renderLink ? <Fragment key={i}>{renderLink(seg, i)}</Fragment> : (
             <a key={i} href={seg.href} target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">
               {seg.text}
             </a>

--- a/frontend/src/components/shared/PeerRoundEntry.tsx
+++ b/frontend/src/components/shared/PeerRoundEntry.tsx
@@ -1,14 +1,17 @@
 import { useState } from 'react'
 import type { PeerRound } from '@/types'
+import type { RepoUrl } from '@/lib/autoLink'
 import { Badge } from '@/components/ui/badge'
 import { ClassificationBadge } from '@/components/shared/ClassificationBadge'
+import { LinkedText } from '@/components/shared/LinkedText'
 
 interface PeerRoundEntryProps {
   entry: PeerRound
+  repoUrls: RepoUrl[]
   compact?: boolean
 }
 
-export function PeerRoundEntry({ entry, compact = false }: PeerRoundEntryProps) {
+export function PeerRoundEntry({ entry, repoUrls, compact = false }: PeerRoundEntryProps) {
   const [detailsExpanded, setDetailsExpanded] = useState(false)
   const isOrchestrator = entry.role === 'orchestrator'
 
@@ -36,7 +39,9 @@ export function PeerRoundEntry({ entry, compact = false }: PeerRoundEntryProps) 
       </div>
       {entry.details && (
         <div>
-          <p className="text-xs text-text-secondary whitespace-pre-wrap">{displayDetails}</p>
+          <p className="text-xs text-text-secondary whitespace-pre-wrap">
+            <LinkedText text={displayDetails} repoUrls={repoUrls} />
+          </p>
           {needsTruncation && (
             <button
               type="button"

--- a/frontend/src/components/shared/__tests__/LinkedText.test.tsx
+++ b/frontend/src/components/shared/__tests__/LinkedText.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LinkedText } from '../LinkedText'
+import type { RepoUrl } from '@/lib/autoLink'
+
+describe('LinkedText', () => {
+  it('renders plain text without links', () => {
+    render(<LinkedText text="no links here" repoUrls={[]} />)
+    expect(screen.getByText('no links here')).toBeDefined()
+  })
+
+  it('renders URLs as anchor tags with target _blank', () => {
+    render(<LinkedText text="see https://example.com for details" repoUrls={[]} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://example.com')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+  })
+
+  it('renders file paths as links when repoUrls provided', () => {
+    const repos: RepoUrl[] = [{ name: 'repo', url: 'https://github.com/org/repo', ref: 'main' }]
+    render(<LinkedText text="edit conftest.py now" repoUrls={repos} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://github.com/org/repo/blob/main/conftest.py')
+  })
+
+  it('uses renderLink callback when provided', () => {
+    render(
+      <LinkedText
+        text="see https://example.com here"
+        repoUrls={[]}
+        renderLink={(seg, i) => <span key={i} data-testid="custom-link">{seg.text}</span>}
+      />
+    )
+    expect(screen.getByTestId('custom-link')).toBeDefined()
+  })
+})

--- a/frontend/src/lib/__tests__/autoLink.test.ts
+++ b/frontend/src/lib/__tests__/autoLink.test.ts
@@ -4,6 +4,7 @@ import {
   deduplicateMatches,
   autoLinkAnalysis,
   buildFileUrl,
+  matchRepo,
   type LinkMatch,
   type RepoUrl,
 } from '../autoLink'
@@ -282,11 +283,26 @@ describe('autoLinkAnalysis', () => {
 
   it('does not match version-string directory paths', () => {
     const segments = autoLinkAnalysis('Python 3.11/path.py is broken', repo)
-    // Should NOT match '3.11/path.py' or '11/path.py' since the dot lookbehind
-    // blocks matches starting right after a dot (the '.' in '3.11').
-    // '1/path.py' still matches (preceded by '1', not a dot).
+    // Should NOT match any substring of '3.11/path.py' — the dot and digit
+    // lookbehinds block matches starting after dots or digits.
+    const links = segments.filter(s => s.type === 'link')
+    expect(links).toHaveLength(0)
+  })
+
+  it('still matches directory paths whose name ends with a digit', () => {
+    const segments = autoLinkAnalysis('see test1/file.py for details', repo)
     const links = segments.filter(s => s.type === 'link')
     expect(links).toHaveLength(1)
-    expect(links[0].text).toBe('1/path.py')
+    expect(links[0].text).toBe('test1/file.py')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  matchRepo                                                          */
+/* ------------------------------------------------------------------ */
+
+describe('matchRepo', () => {
+  it('throws when repos is empty', () => {
+    expect(() => matchRepo('some/file.py', [])).toThrow('matchRepo requires at least one repo')
   })
 })

--- a/frontend/src/lib/__tests__/autoLink.test.ts
+++ b/frontend/src/lib/__tests__/autoLink.test.ts
@@ -281,6 +281,16 @@ describe('autoLinkAnalysis', () => {
     expect(link?.href).toBe('https://github.com/org/my-repo/blob/v2.0.0/conftest.py')
   })
 
+  it('skips unmatched file paths in multi-repo mode', () => {
+    const repos: RepoUrl[] = [
+      { name: 'tests', url: 'https://github.com/org/tests', ref: 'main' },
+      { name: 'infra', url: 'https://github.com/org/infra', ref: 'develop' },
+    ]
+    const segments = autoLinkAnalysis('see conftest.py for setup', repos)
+    // conftest.py doesn't match any repo prefix, so it should NOT be linked
+    expect(segments).toEqual([{ type: 'text', text: 'see conftest.py for setup' }])
+  })
+
   it('does not match version-string directory paths', () => {
     const segments = autoLinkAnalysis('Python 3.11/path.py is broken', repo)
     // Should NOT match any substring of '3.11/path.py' — the dot and digit
@@ -304,5 +314,30 @@ describe('autoLinkAnalysis', () => {
 describe('matchRepo', () => {
   it('throws when repos is empty', () => {
     expect(() => matchRepo('some/file.py', [])).toThrow('matchRepo requires at least one repo')
+  })
+
+  it('returns repo with prefixMatched true when path starts with repo name', () => {
+    const repos: RepoUrl[] = [
+      { name: 'tests', url: 'https://github.com/org/tests', ref: 'main' },
+      { name: 'infra', url: 'https://github.com/org/infra', ref: 'develop' },
+    ]
+    const result = matchRepo('infra/config.yaml', repos)
+    expect(result).toEqual({ repo: repos[1], prefixMatched: true })
+  })
+
+  it('falls back to first repo in single-repo mode when no prefix matches', () => {
+    const repos: RepoUrl[] = [{ name: 'my-repo', url: 'https://github.com/org/my-repo', ref: 'main' }]
+    const result = matchRepo('conftest.py', repos)
+    expect(result).toEqual({ repo: repos[0], prefixMatched: false })
+  })
+
+  it('returns no repo in multi-repo mode when no prefix matches', () => {
+    const repos: RepoUrl[] = [
+      { name: 'tests', url: 'https://github.com/org/tests', ref: 'main' },
+      { name: 'infra', url: 'https://github.com/org/infra', ref: 'develop' },
+    ]
+    const result = matchRepo('conftest.py', repos)
+    expect(result).toEqual({ prefixMatched: false })
+    expect(result.repo).toBeUndefined()
   })
 })

--- a/frontend/src/lib/__tests__/autoLink.test.ts
+++ b/frontend/src/lib/__tests__/autoLink.test.ts
@@ -282,11 +282,11 @@ describe('autoLinkAnalysis', () => {
 
   it('does not match version-string directory paths', () => {
     const segments = autoLinkAnalysis('Python 3.11/path.py is broken', repo)
-    // Should NOT match '3.11/path.py' since directory segment contains dots
+    // Should NOT match '3.11/path.py' or '11/path.py' since the dot lookbehind
+    // blocks matches starting right after a dot (the '.' in '3.11').
+    // '1/path.py' still matches (preceded by '1', not a dot).
     const links = segments.filter(s => s.type === 'link')
     expect(links).toHaveLength(1)
-    // '11/path.py' matches since '11' is a valid directory segment (no dots);
-    // the key point is that '3.11/path.py' is NOT matched as a single path.
-    expect(links[0].text).toBe('11/path.py')
+    expect(links[0].text).toBe('1/path.py')
   })
 })

--- a/frontend/src/lib/__tests__/autoLink.test.ts
+++ b/frontend/src/lib/__tests__/autoLink.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest'
+import {
+  trimTrailingPunctuation,
+  deduplicateMatches,
+  autoLinkAnalysis,
+  buildFileUrl,
+  type LinkMatch,
+  type RepoUrl,
+} from '../autoLink'
+
+/* ------------------------------------------------------------------ */
+/*  trimTrailingPunctuation                                            */
+/* ------------------------------------------------------------------ */
+
+describe('trimTrailingPunctuation', () => {
+  it('strips trailing period', () => {
+    expect(trimTrailingPunctuation('https://example.com.')).toBe('https://example.com')
+  })
+
+  it('strips trailing comma and semicolon', () => {
+    expect(trimTrailingPunctuation('https://example.com,')).toBe('https://example.com')
+    expect(trimTrailingPunctuation('https://example.com;')).toBe('https://example.com')
+  })
+
+  it('strips trailing angle bracket', () => {
+    expect(trimTrailingPunctuation('https://example.com>')).toBe('https://example.com')
+  })
+
+  it('strips unbalanced trailing paren', () => {
+    expect(trimTrailingPunctuation('https://example.com/path)')).toBe('https://example.com/path')
+  })
+
+  it('keeps balanced parens', () => {
+    expect(trimTrailingPunctuation('https://en.wikipedia.org/wiki/Foo_(bar)')).toBe(
+      'https://en.wikipedia.org/wiki/Foo_(bar)',
+    )
+  })
+
+  it('strips multiple trailing punctuation chars', () => {
+    // Period is stripped first, then the unbalanced paren
+    expect(trimTrailingPunctuation('https://example.com/path).')).toBe('https://example.com/path')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  deduplicateMatches                                                 */
+/* ------------------------------------------------------------------ */
+
+describe('deduplicateMatches', () => {
+  it('removes overlapping matches keeping earlier one', () => {
+    const matches: LinkMatch[] = [
+      { start: 0, end: 30, text: 'first', href: 'https://a.com' },
+      { start: 10, end: 40, text: 'overlap', href: 'https://b.com' },
+      { start: 50, end: 70, text: 'no-overlap', href: 'https://c.com' },
+    ]
+    const result = deduplicateMatches(matches)
+    expect(result).toHaveLength(2)
+    expect(result[0].text).toBe('first')
+    expect(result[1].text).toBe('no-overlap')
+  })
+
+  it('returns empty for empty input', () => {
+    expect(deduplicateMatches([])).toEqual([])
+  })
+
+  it('keeps all non-overlapping matches', () => {
+    const matches: LinkMatch[] = [
+      { start: 0, end: 5, text: 'a', href: 'x' },
+      { start: 5, end: 10, text: 'b', href: 'y' },
+      { start: 10, end: 15, text: 'c', href: 'z' },
+    ]
+    expect(deduplicateMatches(matches)).toHaveLength(3)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  buildFileUrl                                                       */
+/* ------------------------------------------------------------------ */
+
+describe('buildFileUrl', () => {
+  it('builds URL without line number', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'src/main.py')).toBe(
+      'https://github.com/org/repo/blob/HEAD/src/main.py',
+    )
+  })
+
+  it('builds URL with numeric line number', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'src/main.py', 42)).toBe(
+      'https://github.com/org/repo/blob/HEAD/src/main.py#L42',
+    )
+  })
+
+  it('builds URL with string line number', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'src/main.py', '99')).toBe(
+      'https://github.com/org/repo/blob/HEAD/src/main.py#L99',
+    )
+  })
+
+  it('strips trailing slash from base URL', () => {
+    expect(buildFileUrl('https://github.com/org/repo/', 'conftest.py')).toBe(
+      'https://github.com/org/repo/blob/HEAD/conftest.py',
+    )
+  })
+
+  it('handles undefined line number', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'file.ts', undefined)).toBe(
+      'https://github.com/org/repo/blob/HEAD/file.ts',
+    )
+  })
+
+  it('uses custom ref in URL', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'src/main.py', undefined, 'develop')).toBe(
+      'https://github.com/org/repo/blob/develop/src/main.py',
+    )
+  })
+
+  it('handles line number 0', () => {
+    expect(buildFileUrl('https://github.com/org/repo', 'file.py', 0)).toBe(
+      'https://github.com/org/repo/blob/HEAD/file.py#L0',
+    )
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  autoLinkAnalysis with empty repoUrls (URL-only mode)               */
+/* ------------------------------------------------------------------ */
+
+describe('autoLinkAnalysis with empty repoUrls (URL-only mode)', () => {
+  it('converts GitHub PR URL to named link', () => {
+    const segments = autoLinkAnalysis('see https://github.com/org/repo/pull/42 for details', [])
+    expect(segments).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'link', text: 'org/repo#42', href: 'https://github.com/org/repo/pull/42' },
+      { type: 'text', text: ' for details' },
+    ])
+  })
+
+  it('converts GitHub issue URL to named link', () => {
+    const segments = autoLinkAnalysis('fix https://github.com/org/repo/issues/99', [])
+    expect(segments).toEqual([
+      { type: 'text', text: 'fix ' },
+      { type: 'link', text: 'org/repo#99', href: 'https://github.com/org/repo/issues/99' },
+    ])
+  })
+
+  it('converts Jira browse URL to ticket key', () => {
+    const segments = autoLinkAnalysis('tracked in https://jira.example.com/browse/PROJ-123 already', [])
+    expect(segments).toEqual([
+      { type: 'text', text: 'tracked in ' },
+      { type: 'link', text: 'PROJ-123', href: 'https://jira.example.com/browse/PROJ-123' },
+      { type: 'text', text: ' already' },
+    ])
+  })
+
+  it('converts generic URL to clickable link', () => {
+    const segments = autoLinkAnalysis('visit https://docs.example.com/guide please', [])
+    expect(segments).toEqual([
+      { type: 'text', text: 'visit ' },
+      { type: 'link', text: 'https://docs.example.com/guide', href: 'https://docs.example.com/guide' },
+      { type: 'text', text: ' please' },
+    ])
+  })
+
+  it('returns text-only segment when no URLs present', () => {
+    const segments = autoLinkAnalysis('plain text without links', [])
+    expect(segments).toEqual([{ type: 'text', text: 'plain text without links' }])
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  autoLinkAnalysis                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('autoLinkAnalysis', () => {
+  const repo: RepoUrl[] = [{ name: 'my-repo', url: 'https://github.com/org/my-repo', ref: 'main' }]
+
+  it('links conftest.py with repo URL', () => {
+    const segments = autoLinkAnalysis('see conftest.py for setup', repo)
+    expect(segments).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'link', text: 'conftest.py', href: 'https://github.com/org/my-repo/blob/main/conftest.py' },
+      { type: 'text', text: ' for setup' },
+    ])
+  })
+
+  it('links file path with line number', () => {
+    const segments = autoLinkAnalysis('error at utilities/utils.py:361', repo)
+    expect(segments).toEqual([
+      { type: 'text', text: 'error at ' },
+      {
+        type: 'link',
+        text: 'utilities/utils.py:361',
+        href: 'https://github.com/org/my-repo/blob/main/utilities/utils.py#L361',
+      },
+    ])
+  })
+
+  it('links deep nested file path', () => {
+    const segments = autoLinkAnalysis('check path/to/deep/file.yaml', repo)
+    expect(segments).toEqual([
+      { type: 'text', text: 'check ' },
+      {
+        type: 'link',
+        text: 'path/to/deep/file.yaml',
+        href: 'https://github.com/org/my-repo/blob/main/path/to/deep/file.yaml',
+      },
+    ])
+  })
+
+  it('returns text-only segments when no file paths present', () => {
+    const segments = autoLinkAnalysis('no files here', repo)
+    expect(segments).toEqual([{ type: 'text', text: 'no files here' }])
+  })
+
+  it('skips file-path matching when repoUrls is empty', () => {
+    const segments = autoLinkAnalysis('see conftest.py for setup', [])
+    expect(segments).toEqual([{ type: 'text', text: 'see conftest.py for setup' }])
+  })
+
+  it('does not double-match URLs containing .py (URL takes priority)', () => {
+    const text = 'see https://github.com/org/repo/blob/main/conftest.py for details'
+    const segments = autoLinkAnalysis(text, repo)
+    // The whole URL should be a single link, not split into URL + file path
+    const links = segments.filter((s) => s.type === 'link')
+    expect(links).toHaveLength(1)
+    expect(links[0].href).toBe('https://github.com/org/repo/blob/main/conftest.py')
+  })
+
+  it('handles mixed text with both URLs and file paths', () => {
+    const text = 'Fix conftest.py as shown in https://github.com/org/repo/pull/10 review'
+    const segments = autoLinkAnalysis(text, repo)
+    const links = segments.filter((s) => s.type === 'link')
+    expect(links).toHaveLength(2)
+    expect(links[0].text).toBe('conftest.py')
+    expect(links[0].href).toBe('https://github.com/org/my-repo/blob/main/conftest.py')
+    expect(links[1].text).toBe('org/repo#10')
+    expect(links[1].href).toBe('https://github.com/org/repo/pull/10')
+  })
+
+  it('strips trailing slash from repo URL before building href', () => {
+    const repoWithSlash: RepoUrl[] = [{ name: 'repo', url: 'https://github.com/org/repo/', ref: 'main' }]
+    const segments = autoLinkAnalysis('edit main.py now', repoWithSlash)
+    const link = segments.find((s) => s.type === 'link')
+    expect(link?.href).toBe('https://github.com/org/repo/blob/main/main.py')
+  })
+
+  it('matches various file extensions', () => {
+    const extensions = ['yaml', 'yml', 'json', 'toml', 'sh', 'js', 'ts', 'go', 'java', 'groovy', 'rs']
+    for (const ext of extensions) {
+      const segments = autoLinkAnalysis(`file config.${ext} here`, repo)
+      const links = segments.filter((s) => s.type === 'link')
+      expect(links).toHaveLength(1)
+      expect(links[0].text).toBe(`config.${ext}`)
+    }
+  })
+
+  it('also detects URLs via the URL matchers', () => {
+    const text = 'see https://jira.example.com/browse/BUG-42 for context'
+    const segments = autoLinkAnalysis(text, repo)
+    const links = segments.filter((s) => s.type === 'link')
+    expect(links).toHaveLength(1)
+    expect(links[0].text).toBe('BUG-42')
+  })
+
+  it('matches file path to correct repo by name prefix', () => {
+    const repos: RepoUrl[] = [
+      { name: 'tests', url: 'https://github.com/org/tests', ref: 'main' },
+      { name: 'infra', url: 'https://github.com/org/infra', ref: 'develop' },
+    ]
+    const segments = autoLinkAnalysis('check infra/config.yaml here', repos)
+    const link = segments.find(s => s.type === 'link')
+    // Path should be config.yaml (stripped prefix), not infra/config.yaml
+    expect(link?.href).toBe('https://github.com/org/infra/blob/develop/config.yaml')
+  })
+
+  it('uses repo ref in file links', () => {
+    const repos: RepoUrl[] = [{ name: 'my-repo', url: 'https://github.com/org/my-repo', ref: 'v2.0.0' }]
+    const segments = autoLinkAnalysis('see conftest.py for setup', repos)
+    const link = segments.find(s => s.type === 'link')
+    expect(link?.href).toBe('https://github.com/org/my-repo/blob/v2.0.0/conftest.py')
+  })
+
+  it('does not match version-string directory paths', () => {
+    const segments = autoLinkAnalysis('Python 3.11/path.py is broken', repo)
+    // Should NOT match '3.11/path.py' since directory segment contains dots
+    const links = segments.filter(s => s.type === 'link')
+    expect(links).toHaveLength(1)
+    // '11/path.py' matches since '11' is a valid directory segment (no dots);
+    // the key point is that '3.11/path.py' is NOT matched as a single path.
+    expect(links[0].text).toBe('11/path.py')
+  })
+})

--- a/frontend/src/lib/autoLink.ts
+++ b/frontend/src/lib/autoLink.ts
@@ -21,7 +21,7 @@ export const GENERIC_URL_RE = /https?:\/\/\S+/g
  * Use new RegExp(...) for stateful operations.
  */
 export const FILE_PATH_RE =
-  /(?<![:\/])(?:(?:[a-zA-Z0-9_-]+\/)+[a-zA-Z0-9_.-]+|[a-zA-Z0-9_-]+)\.(?:py|yaml|yml|json|cfg|ini|toml|sh|js|ts|go|java|xml|html|md|txt|conf|properties|groovy|rb|rs)(?::(\d+))?/g
+  /(?<![:\/.])(?:(?:[a-zA-Z0-9_-]+\/)+[a-zA-Z0-9_.-]+|[a-zA-Z0-9_-]+)\.(?:py|yaml|yml|json|cfg|ini|toml|sh|js|ts|go|java|xml|html|md|txt|conf|properties|groovy|rb|rs)(?::(\d+))?/g
 
 export type LinkMatch = { start: number; end: number; text: string; href: string }
 
@@ -105,7 +105,9 @@ function collectUrlMatches(text: string, matches: LinkMatch[]) {
 export function buildFileUrl(baseUrl: string, filePath: string, lineNumber?: string | number, ref: string = 'HEAD'): string {
   const normalized = baseUrl.replace(/\/$/, '')
   const anchor = lineNumber != null && lineNumber !== '' ? `#L${lineNumber}` : ''
-  return `${normalized}/blob/${ref || 'HEAD'}/${filePath}${anchor}`
+  const encodedRef = encodeURIComponent(ref || 'HEAD')
+  const encodedPath = filePath.split('/').map(encodeURIComponent).join('/')
+  return `${normalized}/blob/${encodedRef}/${encodedPath}${anchor}`
 }
 
 /** Build RepoUrl[] from analysis result request_params. */

--- a/frontend/src/lib/autoLink.ts
+++ b/frontend/src/lib/autoLink.ts
@@ -38,6 +38,16 @@ export interface RepoUrl {
   ref: string
 }
 
+/** Check if a URL is safe to render as a clickable link (HTTP/HTTPS only). */
+export function isSafeHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://example.invalid')
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 export function trimTrailingPunctuation(url: string): string {
   let result = url
   while (result.length > 0) {

--- a/frontend/src/lib/autoLink.ts
+++ b/frontend/src/lib/autoLink.ts
@@ -1,0 +1,178 @@
+/* ------------------------------------------------------------------ */
+/*  Auto-link: convert URLs and file paths in text to clickable links  */
+/* ------------------------------------------------------------------ */
+
+import { repoNameFromUrl } from '@/lib/utils'
+
+/** Pattern constant for GitHub PR URLs. Use new RegExp(...) for stateful operations. */
+export const GITHUB_PR_RE = /https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\S*/g
+/** Pattern constant for GitHub issue URLs. Use new RegExp(...) for stateful operations. */
+export const GITHUB_ISSUE_RE = /https?:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)\S*/g
+/** Pattern constant for Jira browse URLs. Use new RegExp(...) for stateful operations. */
+export const JIRA_BROWSE_RE = /https?:\/\/[^/]+\/browse\/([A-Z][A-Z0-9]+-\d+)\S*/g
+/** Pattern constant for generic URLs. Use new RegExp(...) for stateful operations. */
+export const GENERIC_URL_RE = /https?:\/\/\S+/g
+
+/**
+ * Matches file paths like `conftest.py`, `utils/helpers.py:42`,
+ * `path/to/deep/file.yaml`, etc. Uses negative lookbehind for `://`
+ * and `/` to avoid matching tails of URLs as file paths.
+ * Directory segments exclude dots to avoid matching version strings like `3.11/`.
+ * Use new RegExp(...) for stateful operations.
+ */
+export const FILE_PATH_RE =
+  /(?<![:\/])(?:(?:[a-zA-Z0-9_-]+\/)+[a-zA-Z0-9_.-]+|[a-zA-Z0-9_-]+)\.(?:py|yaml|yml|json|cfg|ini|toml|sh|js|ts|go|java|xml|html|md|txt|conf|properties|groovy|rb|rs)(?::(\d+))?/g
+
+export type LinkMatch = { start: number; end: number; text: string; href: string }
+
+export interface LinkSegment {
+  type: 'text' | 'link'
+  text: string
+  href?: string
+}
+
+export interface RepoUrl {
+  name: string
+  url: string
+  ref: string
+}
+
+export function trimTrailingPunctuation(url: string): string {
+  let result = url
+  while (result.length > 0) {
+    const last = result[result.length - 1]
+    if (last === '>') {
+      result = result.slice(0, -1)
+      continue
+    }
+    if (last === ')') {
+      const opens = (result.match(/\(/g) || []).length
+      const closes = (result.match(/\)/g) || []).length
+      if (closes > opens) {
+        result = result.slice(0, -1)
+        continue
+      }
+      break
+    }
+    if (/[.,;:!?]/.test(last)) {
+      result = result.slice(0, -1)
+      continue
+    }
+    break
+  }
+  return result
+}
+
+export function collectMatches(
+  raw: string,
+  pattern: RegExp,
+  matches: LinkMatch[],
+  textFn: (m: RegExpMatchArray) => string,
+) {
+  for (const m of raw.matchAll(pattern)) {
+    const start = m.index!
+    const href = trimTrailingPunctuation(m[0])
+    const end = start + href.length
+    const text = textFn(m)
+    matches.push({ start, end, text, href })
+  }
+}
+
+/** Remove overlapping matches, preferring earlier entries (specific patterns added first). */
+export function deduplicateMatches(matches: LinkMatch[]): LinkMatch[] {
+  const sorted = [...matches].sort((a, b) => a.start - b.start)
+  const result: typeof matches = []
+  for (const m of sorted) {
+    if (result.length > 0 && m.start < result[result.length - 1].end) continue
+    result.push(m)
+  }
+  return result
+}
+
+/** Run all URL matchers (GitHub PRs, issues, Jira, generic) and push results into matches. */
+function collectUrlMatches(text: string, matches: LinkMatch[]) {
+  collectMatches(text, new RegExp(GITHUB_PR_RE.source, GITHUB_PR_RE.flags), matches, (m) => `${m[1]}#${m[2]}`)
+  collectMatches(text, new RegExp(GITHUB_ISSUE_RE.source, GITHUB_ISSUE_RE.flags), matches, (m) => `${m[1]}#${m[2]}`)
+  collectMatches(text, new RegExp(JIRA_BROWSE_RE.source, JIRA_BROWSE_RE.flags), matches, (m) => m[1])
+  collectMatches(text, new RegExp(GENERIC_URL_RE.source, GENERIC_URL_RE.flags), matches, (m) => trimTrailingPunctuation(m[0]))
+}
+
+/**
+ * Build a file URL from a base repo URL, file path, optional line number, and git ref.
+ * Handles trailing-slash stripping and `/blob/{ref}/` + `#L` construction.
+ * Defaults to 'HEAD' when ref is empty or not provided.
+ */
+export function buildFileUrl(baseUrl: string, filePath: string, lineNumber?: string | number, ref: string = 'HEAD'): string {
+  const normalized = baseUrl.replace(/\/$/, '')
+  const anchor = lineNumber != null && lineNumber !== '' ? `#L${lineNumber}` : ''
+  return `${normalized}/blob/${ref || 'HEAD'}/${filePath}${anchor}`
+}
+
+/** Build RepoUrl[] from analysis result request_params. */
+export function buildRepoUrls(requestParams?: {
+  tests_repo_url?: string
+  tests_repo_ref?: string
+  additional_repos?: Array<{ name: string; url: string; ref?: string }>
+  [key: string]: unknown
+}): RepoUrl[] {
+  if (!requestParams) return []
+  const urls: RepoUrl[] = []
+  const testsUrl = requestParams.tests_repo_url
+  const testsRef = (requestParams.tests_repo_ref as string) ?? ''
+  if (testsUrl) urls.push({ name: repoNameFromUrl(String(testsUrl)), url: String(testsUrl), ref: testsRef || 'HEAD' })
+  const additional = requestParams.additional_repos
+  if (additional) {
+    for (const ar of additional) {
+      if (ar.url) urls.push({ name: ar.name || repoNameFromUrl(ar.url), url: ar.url, ref: ar.ref || 'HEAD' })
+    }
+  }
+  return urls
+}
+
+/** Match a file path to the repo whose name is a prefix of the path. Falls back to first repo. */
+export function matchRepo(filePath: string, repos: RepoUrl[]): { repo: RepoUrl; prefixMatched: boolean } {
+  for (const repo of repos) {
+    if (filePath.startsWith(repo.name + '/')) return { repo, prefixMatched: true }
+  }
+  return { repo: repos[0], prefixMatched: false }
+}
+
+/** Convert plain text to link segments by detecting URLs AND file paths (for analysis text). */
+export function autoLinkAnalysis(text: string, repoUrls: RepoUrl[]): LinkSegment[] {
+  const matches: LinkMatch[] = []
+
+  // URL matchers (added first so they take priority during dedup)
+  collectUrlMatches(text, matches)
+
+  // File-path matcher (only if we have repo URLs to link to)
+  if (repoUrls.length > 0) {
+    for (const m of text.matchAll(new RegExp(FILE_PATH_RE.source, FILE_PATH_RE.flags))) {
+      const start = m.index!
+      const fullMatch = m[0]
+      const lineNumber = m[1] // capture group for :lineNumber
+      const filePath = lineNumber ? fullMatch.slice(0, fullMatch.lastIndexOf(':')) : fullMatch
+      const { repo, prefixMatched } = matchRepo(filePath, repoUrls)
+      const relPath = prefixMatched ? filePath.slice(repo.name.length + 1) : filePath
+      const href = buildFileUrl(repo.url, relPath, lineNumber, repo.ref)
+      matches.push({ start, end: start + fullMatch.length, text: fullMatch, href })
+    }
+  }
+
+  const deduplicated = deduplicateMatches(matches)
+
+  return buildSegments(text, deduplicated)
+}
+
+/** Build LinkSegment[] from raw text and sorted, deduplicated matches. */
+function buildSegments(raw: string, matches: LinkMatch[]): LinkSegment[] {
+  const segments: LinkSegment[] = []
+  let cursor = 0
+  for (const m of matches) {
+    if (m.start > cursor) segments.push({ type: 'text', text: raw.slice(cursor, m.start) })
+    segments.push({ type: 'link', text: m.text, href: m.href })
+    cursor = m.end
+  }
+  if (cursor < raw.length) segments.push({ type: 'text', text: raw.slice(cursor) })
+
+  return segments.length > 0 ? segments : [{ type: 'text', text: raw }]
+}

--- a/frontend/src/lib/autoLink.ts
+++ b/frontend/src/lib/autoLink.ts
@@ -90,12 +90,17 @@ export function deduplicateMatches(matches: LinkMatch[]): LinkMatch[] {
   return result
 }
 
+/** Clone a RegExp to reset its lastIndex (required for stateful `g` flag regexes). */
+function cloneRegex(pattern: RegExp): RegExp {
+  return new RegExp(pattern.source, pattern.flags)
+}
+
 /** Run all URL matchers (GitHub PRs, issues, Jira, generic) and push results into matches. */
 function collectUrlMatches(text: string, matches: LinkMatch[]) {
-  collectMatches(text, new RegExp(GITHUB_PR_RE.source, GITHUB_PR_RE.flags), matches, (m) => `${m[1]}#${m[2]}`)
-  collectMatches(text, new RegExp(GITHUB_ISSUE_RE.source, GITHUB_ISSUE_RE.flags), matches, (m) => `${m[1]}#${m[2]}`)
-  collectMatches(text, new RegExp(JIRA_BROWSE_RE.source, JIRA_BROWSE_RE.flags), matches, (m) => m[1])
-  collectMatches(text, new RegExp(GENERIC_URL_RE.source, GENERIC_URL_RE.flags), matches, (m) => trimTrailingPunctuation(m[0]))
+  collectMatches(text, cloneRegex(GITHUB_PR_RE), matches, (m) => `${m[1]}#${m[2]}`)
+  collectMatches(text, cloneRegex(GITHUB_ISSUE_RE), matches, (m) => `${m[1]}#${m[2]}`)
+  collectMatches(text, cloneRegex(JIRA_BROWSE_RE), matches, (m) => m[1])
+  collectMatches(text, cloneRegex(GENERIC_URL_RE), matches, (m) => trimTrailingPunctuation(m[0]))
 }
 
 /**
@@ -132,13 +137,15 @@ export function buildRepoUrls(requestParams?: {
   return urls
 }
 
-/** Match a file path to the repo whose name is a prefix of the path. Falls back to first repo. */
-export function matchRepo(filePath: string, repos: RepoUrl[]): { repo: RepoUrl; prefixMatched: boolean } {
+/** Match a file path to the repo whose name is a prefix of the path. Falls back to first repo only in single-repo mode. */
+export function matchRepo(filePath: string, repos: RepoUrl[]): { repo?: RepoUrl; prefixMatched: boolean } {
   if (repos.length === 0) throw new Error('matchRepo requires at least one repo')
   for (const repo of repos) {
     if (filePath.startsWith(repo.name + '/')) return { repo, prefixMatched: true }
   }
-  return { repo: repos[0], prefixMatched: false }
+  return repos.length === 1
+    ? { repo: repos[0], prefixMatched: false }
+    : { prefixMatched: false }
 }
 
 /** Convert plain text to link segments by detecting URLs AND file paths (for analysis text). */
@@ -150,12 +157,13 @@ export function autoLinkAnalysis(text: string, repoUrls: RepoUrl[]): LinkSegment
 
   // File-path matcher (only if we have repo URLs to link to)
   if (repoUrls.length > 0) {
-    for (const m of text.matchAll(new RegExp(FILE_PATH_RE.source, FILE_PATH_RE.flags))) {
+    for (const m of text.matchAll(cloneRegex(FILE_PATH_RE))) {
       const start = m.index!
       const fullMatch = m[0]
       const lineNumber = m[1] // capture group for :lineNumber
       const filePath = lineNumber ? fullMatch.slice(0, fullMatch.lastIndexOf(':')) : fullMatch
       const { repo, prefixMatched } = matchRepo(filePath, repoUrls)
+      if (!repo) continue
       const relPath = prefixMatched ? filePath.slice(repo.name.length + 1) : filePath
       const href = buildFileUrl(repo.url, relPath, lineNumber, repo.ref)
       matches.push({ start, end: start + fullMatch.length, text: fullMatch, href })

--- a/frontend/src/lib/autoLink.ts
+++ b/frontend/src/lib/autoLink.ts
@@ -15,13 +15,14 @@ export const GENERIC_URL_RE = /https?:\/\/\S+/g
 
 /**
  * Matches file paths like `conftest.py`, `utils/helpers.py:42`,
- * `path/to/deep/file.yaml`, etc. Uses negative lookbehind for `://`
- * and `/` to avoid matching tails of URLs as file paths.
- * Directory segments exclude dots to avoid matching version strings like `3.11/`.
+ * `path/to/deep/file.yaml`, etc. Uses negative lookbehind for `://`,
+ * `/`, `.`, word characters, and hyphens to avoid matching tails of
+ * URLs, partial words, or fragments from version strings like
+ * `3.11/path.py`.
  * Use new RegExp(...) for stateful operations.
  */
 export const FILE_PATH_RE =
-  /(?<![:\/.])(?:(?:[a-zA-Z0-9_-]+\/)+[a-zA-Z0-9_.-]+|[a-zA-Z0-9_-]+)\.(?:py|yaml|yml|json|cfg|ini|toml|sh|js|ts|go|java|xml|html|md|txt|conf|properties|groovy|rb|rs)(?::(\d+))?/g
+  /(?<![:\\/.\w-])(?:(?:[a-zA-Z0-9_-]+\/)+[a-zA-Z0-9_.-]+|[a-zA-Z0-9_-]+)\.(?:py|yaml|yml|json|cfg|ini|toml|sh|js|ts|go|java|xml|html|md|txt|conf|properties|groovy|rb|rs)(?::(\d+))?/g
 
 export type LinkMatch = { start: number; end: number; text: string; href: string }
 
@@ -133,6 +134,7 @@ export function buildRepoUrls(requestParams?: {
 
 /** Match a file path to the repo whose name is a prefix of the path. Falls back to first repo. */
 export function matchRepo(filePath: string, repos: RepoUrl[]): { repo: RepoUrl; prefixMatched: boolean } {
+  if (repos.length === 0) throw new Error('matchRepo requires at least one repo')
   for (const repo of repos) {
     if (filePath.startsWith(repo.name + '/')) return { repo, prefixMatched: true }
   }

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { api } from '@/lib/api'
-import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp, repoNameFromUrl } from '@/lib/utils'
+import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp } from '@/lib/utils'
 import { buildRepoUrls, type RepoUrl } from '@/lib/autoLink'
 import { groupFailures } from '@/lib/grouping'
 import { useExpandCollapseAll } from '@/lib/useExpandCollapseAll'
@@ -425,39 +425,26 @@ function ReportContent() {
               {formatAiLabel(result.ai_provider, result.ai_model)}
             </span>
           )}
-          {(() => {
-            const allRepos: Array<{name: string; url: string}> = []
-            const testsUrl = result.request_params?.tests_repo_url
-            if (testsUrl) {
-              const name = repoNameFromUrl(String(testsUrl))
-              allRepos.push({ name, url: String(testsUrl) })
-            }
-            const additional = result.request_params?.additional_repos
-            if (additional) {
-              allRepos.push(...additional)
-            }
-            if (allRepos.length === 0) return null
-            return (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex items-center gap-1 cursor-default">
-                    <FolderGit2 className="h-3 w-3" />
-                    {allRepos.length} repo{allRepos.length !== 1 ? 's' : ''}: {allRepos.map(r => r.name).join(', ')}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-sm">
-                  <div className="flex flex-col gap-1">
-                    {allRepos.map((r) => (
-                      <div key={`${r.name}::${r.url}`} className="flex flex-col">
-                        <span className="font-medium">{r.name}</span>
-                        <span className="text-text-tertiary break-all">{r.url}</span>
-                      </div>
-                    ))}
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            )
-          })()}
+          {repoUrls.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex items-center gap-1 cursor-default">
+                  <FolderGit2 className="h-3 w-3" />
+                  {repoUrls.length} repo{repoUrls.length !== 1 ? 's' : ''}: {repoUrls.map(r => r.name).join(', ')}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-sm">
+                <div className="flex flex-col gap-1">
+                  {repoUrls.map((r) => (
+                    <div key={`${r.name}::${r.url}`} className="flex flex-col">
+                      <span className="font-medium">{r.name}</span>
+                      <span className="text-text-tertiary break-all">{r.url}</span>
+                    </div>
+                  ))}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )}
           {state.completedAt && (
             <span className="inline-flex items-center gap-1">
               <Clock className="h-3 w-3" />

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -289,7 +289,7 @@ function ReportContent() {
   )
   const repoUrls = useMemo<RepoUrl[]>(
     () => buildRepoUrls(result?.request_params),
-    [result?.request_params?.tests_repo_url, result?.request_params?.tests_repo_ref, result?.request_params?.additional_repos],
+    [result?.request_params],
   )
   const reviewedCount = allTestKeys.filter((k) => state.reviews[k]?.reviewed).length
 

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { api } from '@/lib/api'
 import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp, repoNameFromUrl } from '@/lib/utils'
+import { buildRepoUrls, type RepoUrl } from '@/lib/autoLink'
 import { groupFailures } from '@/lib/grouping'
 import { useExpandCollapseAll } from '@/lib/useExpandCollapseAll'
 import type { ResultResponse, CommentsAndReviews, AiConfig } from '@/types'
@@ -286,6 +287,10 @@ function ReportContent() {
     () => (result ? collectAllTestKeys(result.failures ?? [], result.child_job_analyses ?? []) : []),
     [result],
   )
+  const repoUrls = useMemo<RepoUrl[]>(
+    () => buildRepoUrls(result?.request_params),
+    [result?.request_params?.tests_repo_url, result?.request_params?.tests_repo_ref, result?.request_params?.additional_repos],
+  )
   const reviewedCount = allTestKeys.filter((k) => state.reviews[k]?.reviewed).length
 
   /** Format the AI provider/model label for display. */
@@ -473,6 +478,7 @@ function ReportContent() {
       <PeerAnalysisSummary
         failures={result.failures ?? []}
         childJobAnalyses={result.child_job_analyses ?? []}
+        repoUrls={repoUrls}
       />
 
       {/* ---- Top-level failures ---- */}

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -7,101 +7,9 @@ import { useReportState, useReportDispatch, useRefreshEnrichments } from './Repo
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { LinkedText } from '@/components/shared/LinkedText'
 import { Trash2, MessageSquare } from 'lucide-react'
 import type { Comment } from '@/types'
-
-/* ------------------------------------------------------------------ */
-/*  Auto-link: convert URLs in comment text to named clickable links   */
-/* ------------------------------------------------------------------ */
-
-const GITHUB_PR_RE = /https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\S*/g
-const GITHUB_ISSUE_RE = /https?:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)\S*/g
-const JIRA_BROWSE_RE = /https?:\/\/[^/]+\/browse\/([A-Z][A-Z0-9]+-\d+)\S*/g
-const GENERIC_URL_RE = /https?:\/\/\S+/g
-
-function trimTrailingPunctuation(url: string): string {
-  let result = url
-  while (result.length > 0) {
-    const last = result[result.length - 1]
-    if (last === '>') {
-      result = result.slice(0, -1)
-      continue
-    }
-    if (last === ')') {
-      const opens = (result.match(/\(/g) || []).length
-      const closes = (result.match(/\)/g) || []).length
-      if (closes > opens) {
-        result = result.slice(0, -1)
-        continue
-      }
-      break
-    }
-    if (/[.,;:!?]/.test(last)) {
-      result = result.slice(0, -1)
-      continue
-    }
-    break
-  }
-  return result
-}
-
-type LinkMatch = { start: number; end: number; text: string; href: string }
-
-interface LinkSegment {
-  type: 'text' | 'link'
-  text: string
-  href?: string
-}
-
-function collectMatches(
-  raw: string,
-  pattern: RegExp,
-  matches: LinkMatch[],
-  textFn: (m: RegExpMatchArray) => string,
-) {
-  for (const m of raw.matchAll(pattern)) {
-    const start = m.index!
-    const href = trimTrailingPunctuation(m[0])
-    const end = start + href.length
-    const text = textFn(m)
-    matches.push({ start, end, text, href })
-  }
-}
-
-/** Remove overlapping matches, preferring earlier entries (specific patterns added first). */
-function deduplicateMatches(matches: LinkMatch[]): LinkMatch[] {
-  const sorted = [...matches].sort((a, b) => a.start - b.start)
-  const result: typeof matches = []
-  for (const m of sorted) {
-    if (result.length > 0 && m.start < result[result.length - 1].end) continue
-    result.push(m)
-  }
-  return result
-}
-
-function autoLinkComment(raw: string): LinkSegment[] {
-  // Collect all link matches with their positions
-  const matches: LinkMatch[] = []
-
-  collectMatches(raw, GITHUB_PR_RE, matches, (m) => `${m[1]}#${m[2]}`)
-  collectMatches(raw, GITHUB_ISSUE_RE, matches, (m) => `${m[1]}#${m[2]}`)
-  collectMatches(raw, JIRA_BROWSE_RE, matches, (m) => m[1])
-  collectMatches(raw, GENERIC_URL_RE, matches, (m) => trimTrailingPunctuation(m[0]))
-
-  const deduplicated = deduplicateMatches(matches)
-
-  // Build segments
-  const segments: LinkSegment[] = []
-  let cursor = 0
-  for (const m of deduplicated) {
-    if (m.start > cursor) segments.push({ type: 'text', text: raw.slice(cursor, m.start) })
-    segments.push({ type: 'link', text: m.text, href: m.href })
-    cursor = m.end
-  }
-  if (cursor < raw.length) segments.push({ type: 'text', text: raw.slice(cursor) })
-
-  return segments.length > 0 ? segments : [{ type: 'text', text: raw }]
-}
 
 /* ------------------------------------------------------------------ */
 /*  Enrichment status badge colors                                     */
@@ -126,8 +34,6 @@ interface CommentsSectionProps {
 }
 
 export function CommentsSection({ jobId, testNames, childJobName, childBuildNumber }: CommentsSectionProps) {
-  const canPost = testNames.length === 1
-  const primaryTestName = canPost ? testNames[0] : null
   const scopedChildJobName = childJobName ?? ''
   const scopedChildBuildNumber = childBuildNumber ?? 0
 
@@ -137,6 +43,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
   const [text, setText] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [succeededTestNames, setSucceededTestNames] = useState<Set<string>>(new Set())
   const draftActiveRef = useRef(false)
   const username = getUsername()
 
@@ -154,8 +61,8 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
   // Sync draft-active state whenever text changes (including after submit clears it).
   // This replaces the previous side-effect inside the setText updater, keeping updaters pure.
   useEffect(() => {
-    syncDraftActive(canPost && text.trim().length > 0)
-  }, [canPost, text]) // eslint-disable-line react-hooks/exhaustive-deps -- syncDraftActive is stable via ref
+    syncDraftActive(text.trim().length > 0)
+  }, [text]) // eslint-disable-line react-hooks/exhaustive-deps -- syncDraftActive is stable via ref
 
   // Ensure the draft count is decremented if this editor unmounts while active.
   useEffect(() => {
@@ -166,40 +73,70 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
     }
   }, [dispatch])
 
+  // Reset retry tracking when scope changes
+  useEffect(() => {
+    setSucceededTestNames(new Set())
+  }, [jobId, testNames.join(','), scopedChildJobName, scopedChildBuildNumber]) // eslint-disable-line react-hooks/exhaustive-deps -- join produces a stable string key
+
   const testComments = comments.filter((c) => isCommentInScope(c, testNames, scopedChildJobName, scopedChildBuildNumber))
 
   async function handleSubmit() {
     if (submitting) return
-    if (!canPost || !primaryTestName) {
-      setSubmitError('Posting comments from grouped failures is not supported yet.')
-      return
-    }
     const submittedDraft = text
     const submittedText = submittedDraft.trim()
     if (!submittedText) return
+    let pendingTestNames = testNames.filter((t) => !succeededTestNames.has(t))
+    if (pendingTestNames.length === 0) {
+      setSucceededTestNames(new Set())
+      pendingTestNames = testNames
+    }
     setSubmitting(true)
     setSubmitError(null)
     try {
-      const res = await api.post<{ id: number }>(`/results/${jobId}/comments`, {
-        test_name: primaryTestName,
-        comment: submittedText,
-        child_job_name: scopedChildJobName,
-        child_build_number: scopedChildBuildNumber,
+      const results = await Promise.allSettled(
+        pendingTestNames.map((testName) =>
+          api.post<{ id: number }>(`/results/${jobId}/comments`, {
+            test_name: testName,
+            comment: submittedText,
+            child_job_name: scopedChildJobName,
+            child_build_number: scopedChildBuildNumber,
+          }).then((res) => ({ testName, id: res.id }))
+        )
+      )
+      const errors: string[] = []
+      let successCount = 0
+      results.forEach((result, i) => {
+        if (result.status === 'fulfilled') {
+          successCount++
+          const { testName, id } = result.value
+          setSucceededTestNames((prev) => new Set(prev).add(testName))
+          const fresh: Comment = {
+            id,
+            job_id: jobId,
+            test_name: testName,
+            child_job_name: scopedChildJobName,
+            child_build_number: scopedChildBuildNumber,
+            comment: submittedText,
+            username,
+            created_at: new Date().toISOString(),
+          }
+          dispatch({ type: 'ADD_COMMENT', payload: fresh })
+        } else {
+          const msg = result.reason instanceof Error ? result.reason.message : 'Failed to post comment'
+          errors.push(`${pendingTestNames[i]}: ${msg}`)
+        }
       })
-      const fresh: Comment = {
-        id: res.id,
-        job_id: jobId,
-        test_name: primaryTestName,
-        child_job_name: scopedChildJobName,
-        child_build_number: scopedChildBuildNumber,
-        comment: submittedText,
-        username,
-        created_at: new Date().toISOString(),
+      // Refresh enrichments once to pick up any tracker links in new comments
+      if (successCount > 0) refreshEnrichments(jobId)
+      if (errors.length > 0) {
+        const total = pendingTestNames.length
+        setSubmitError(`Posted ${successCount}/${total}. Failed: ${errors.join('; ')}`)
       }
-      dispatch({ type: 'ADD_COMMENT', payload: fresh })
-      // Refresh enrichments to pick up any tracker links in the new comment
-      refreshEnrichments(jobId)
-      setText((current) => (current === submittedDraft ? '' : current))
+      // Clear text only if ALL posts succeeded and the user hasn't changed it during submission
+      if (errors.length === 0) {
+        setSucceededTestNames(new Set())
+        setText((current) => (current === submittedDraft ? '' : current))
+      }
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Failed to post comment')
     } finally {
@@ -237,7 +174,6 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
       {testComments.length > 0 && (
         <div className="space-y-2">
           {testComments.map((c) => {
-            const segments = autoLinkComment(c.comment)
             const badges = enrichments[String(c.id)] ?? []
 
             return (
@@ -253,9 +189,10 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
                     </span>
                   </div>
                   <p className="mt-1 whitespace-pre-wrap text-text-secondary">
-                    {segments.map((seg, i) => {
-                      if (seg.type === 'link') {
-                        // Find matching enrichment for this link
+                    <LinkedText
+                      text={c.comment}
+                      repoUrls={[]}
+                      renderLink={(seg, i) => {
                         const match = badges.find((b) => seg.text === b.key || seg.href === b.key)
                         return (
                           <span key={i} className="inline-flex items-center gap-1">
@@ -269,9 +206,8 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
                             )}
                           </span>
                         )
-                      }
-                      return <span key={i}>{seg.text}</span>
-                    })}
+                      }}
+                    />
                   </p>
                 </div>
                 {username && c.username === username && (
@@ -293,32 +229,26 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
       )}
 
       <div className="space-y-1">
-        {canPost ? (
-          <div className="flex gap-2">
-            <Textarea
-              aria-label="Add a comment"
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="Add a comment..."
-              className="min-h-[36px] resize-none text-sm"
-              rows={1}
-              onKeyDown={(e) => {
-                if (e.nativeEvent.isComposing) return
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault()
-                  handleSubmit()
-                }
-              }}
-            />
-            <Button size="sm" onClick={handleSubmit} disabled={!text.trim() || submitting} className="shrink-0">
-              Post
-            </Button>
-          </div>
-        ) : (
-          <span className="text-xs text-text-tertiary">
-            Posting comments from grouped failures is not supported yet.
-          </span>
-        )}
+        <div className="flex gap-2">
+          <Textarea
+            aria-label="Add a comment"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Add a comment..."
+            className="min-h-[36px] resize-none text-sm"
+            rows={1}
+            onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing) return
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                handleSubmit()
+              }
+            }}
+          />
+          <Button size="sm" onClick={handleSubmit} disabled={!text.trim() || submitting} className="shrink-0">
+            Post
+          </Button>
+        </div>
         {submitError && (
           <span role="alert" className="text-signal-red text-xs">
             {submitError}

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -73,10 +73,10 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
     }
   }, [dispatch])
 
-  // Reset retry tracking when scope changes
+  // Reset retry tracking when scope or draft content changes
   useEffect(() => {
     setSucceededTestNames(new Set())
-  }, [jobId, testNames.join(','), scopedChildJobName, scopedChildBuildNumber]) // eslint-disable-line react-hooks/exhaustive-deps -- join produces a stable string key
+  }, [jobId, testNames.join(','), scopedChildJobName, scopedChildBuildNumber, text]) // eslint-disable-line react-hooks/exhaustive-deps -- join produces a stable string key
 
   const testComments = comments.filter((c) => isCommentInScope(c, testNames, scopedChildJobName, scopedChildBuildNumber))
 

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -71,7 +71,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
 
   const repoUrls = useMemo<RepoUrl[]>(
     () => buildRepoUrls(result?.request_params),
-    [result?.request_params?.tests_repo_url, result?.request_params?.tests_repo_ref, result?.request_params?.additional_repos],
+    [result?.request_params],
   )
 
   useEffect(() => {

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react'
 import type { GroupedFailure } from '@/types'
-import { buildFileUrl, buildRepoUrls, matchRepo, type RepoUrl } from '@/lib/autoLink'
+import { buildFileUrl, buildRepoUrls, isSafeHref, matchRepo, type RepoUrl } from '@/lib/autoLink'
 import { isCommentInScope } from '@/lib/grouping'
 import { api } from '@/lib/api'
 import { getUsername } from '@/lib/cookies'
@@ -313,11 +313,12 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     <p className="font-mono text-xs text-signal-green">
                       {repoUrls.length > 0 ? (() => {
                         const { repo, prefixMatched } = matchRepo(analysis.code_fix.file, repoUrls)
-                        const canLink = !!repo
                         const relPath = repo && prefixMatched ? analysis.code_fix.file.slice(repo.name.length + 1) : analysis.code_fix.file
+                        const href = repo ? buildFileUrl(repo.url, relPath, analysis.code_fix.line, repo.ref) : ''
+                        const canLink = !!repo && isSafeHref(href)
                         return canLink ? (
                           <a
-                            href={buildFileUrl(repo!.url, relPath, analysis.code_fix.line, repo!.ref)}
+                            href={href}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-signal-green hover:underline"

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect, type ReactNode } from 'react'
+import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react'
 import type { GroupedFailure } from '@/types'
+import { buildFileUrl, buildRepoUrls, matchRepo, type RepoUrl } from '@/lib/autoLink'
 import { isCommentInScope } from '@/lib/grouping'
 import { api } from '@/lib/api'
 import { getUsername } from '@/lib/cookies'
@@ -9,6 +10,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ClassificationBadge } from '@/components/shared/ClassificationBadge'
+import { LinkedText } from '@/components/shared/LinkedText'
 import { PeerDebateSection } from './PeerDebateSection'
 import { ReviewToggle } from './ReviewToggle'
 import { CommentsSection } from './CommentsSection'
@@ -66,6 +68,11 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const [includeLinks, setIncludeLinks] = useState(false)
   const [copiedSection, setCopiedSection] = useState<string | null>(null)
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  const repoUrls = useMemo<RepoUrl[]>(
+    () => buildRepoUrls(result?.request_params),
+    [result?.request_params?.tests_repo_url, result?.request_params?.tests_repo_ref, result?.request_params?.additional_repos],
+  )
 
   useEffect(() => {
     return () => {
@@ -274,7 +281,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     </Badge>
                   ) : undefined}
                 />
-                <div className="rounded-md bg-glow-blue p-3 text-sm text-text-secondary whitespace-pre-wrap">{analysis.details}</div>
+                <div className="rounded-md bg-glow-blue p-3 text-sm text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.details} repoUrls={repoUrls} /></div>
               </div>
             )}
 
@@ -282,9 +289,9 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
             {analysis.artifacts_evidence && (
               <div>
                 <CopyableSectionHeader title="Artifacts Evidence" content={analysis.artifacts_evidence} sectionId="artifacts_evidence" copiedSection={copiedSection} onCopy={copyToClipboard} />
-                <pre className="overflow-x-auto rounded-md bg-surface-elevated p-3 text-xs text-text-secondary font-mono whitespace-pre-wrap max-h-64 overflow-y-auto">
-                  {analysis.artifacts_evidence}
-                </pre>
+                <div className="overflow-x-auto rounded-md bg-surface-elevated p-3 text-xs text-text-secondary font-mono whitespace-pre-wrap max-h-64 overflow-y-auto">
+                  <LinkedText text={analysis.artifacts_evidence} repoUrls={repoUrls} />
+                </div>
               </div>
             )}
 
@@ -304,11 +311,25 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                 <div className="rounded-md bg-glow-green border border-signal-green/20 p-3 text-sm">
                   {analysis.code_fix.file && (
                     <p className="font-mono text-xs text-signal-green">
-                      {analysis.code_fix.file}
-                      {analysis.code_fix.line && `:${analysis.code_fix.line}`}
+                      {repoUrls.length > 0 ? (() => {
+                        const { repo, prefixMatched } = matchRepo(analysis.code_fix.file, repoUrls)
+                        const relPath = prefixMatched ? analysis.code_fix.file.slice(repo.name.length + 1) : analysis.code_fix.file
+                        return (
+                          <a
+                            href={buildFileUrl(repo.url, relPath, analysis.code_fix.line, repo.ref)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-signal-green hover:underline"
+                          >
+                            {analysis.code_fix.file}{analysis.code_fix.line && `:${analysis.code_fix.line}`}
+                          </a>
+                        )
+                      })() : (
+                        <>{analysis.code_fix.file}{analysis.code_fix.line && `:${analysis.code_fix.line}`}</>
+                      )}
                     </p>
                   )}
-                  {analysis.code_fix.change && <p className="mt-1 text-text-secondary whitespace-pre-wrap">{analysis.code_fix.change}</p>}
+                  {analysis.code_fix.change && <p className="mt-1 text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.code_fix.change} repoUrls={repoUrls} /></p>}
                 </div>
               </div>
             )}
@@ -320,7 +341,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                 <div className="rounded-md bg-glow-orange border border-signal-orange/20 p-3 text-sm space-y-2">
                   {analysis.product_bug_report.title && <p className="font-medium text-text-primary">{analysis.product_bug_report.title}</p>}
                   {analysis.product_bug_report.severity && <Badge variant="warning" className="text-[10px]">{analysis.product_bug_report.severity}</Badge>}
-                  {analysis.product_bug_report.description && <p className="text-text-secondary whitespace-pre-wrap">{analysis.product_bug_report.description}</p>}
+                  {analysis.product_bug_report.description && <p className="text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.product_bug_report.description} repoUrls={repoUrls} /></p>}
                   {analysis.product_bug_report?.jira_matches?.length > 0 && (
                     <div className="mt-2">
                       <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">Matching Jira Issues</p>
@@ -341,7 +362,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
             )}
 
             {/* Peer debate trail */}
-            {rep.peer_debate && <PeerDebateSection debate={rep.peer_debate} />}
+            {rep.peer_debate && <PeerDebateSection debate={rep.peer_debate} repoUrls={repoUrls} />}
 
             {/* Actions: classification + AI selector + bug creation */}
             <div className="flex flex-wrap items-center gap-3 pt-2 border-t border-border-muted">

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -313,11 +313,11 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     <p className="font-mono text-xs text-signal-green">
                       {repoUrls.length > 0 ? (() => {
                         const { repo, prefixMatched } = matchRepo(analysis.code_fix.file, repoUrls)
-                        const canLink = prefixMatched || repoUrls.length === 1
-                        const relPath = prefixMatched ? analysis.code_fix.file.slice(repo.name.length + 1) : analysis.code_fix.file
+                        const canLink = !!repo
+                        const relPath = repo && prefixMatched ? analysis.code_fix.file.slice(repo.name.length + 1) : analysis.code_fix.file
                         return canLink ? (
                           <a
-                            href={buildFileUrl(repo.url, relPath, analysis.code_fix.line, repo.ref)}
+                            href={buildFileUrl(repo!.url, relPath, analysis.code_fix.line, repo!.ref)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-signal-green hover:underline"

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -313,8 +313,9 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     <p className="font-mono text-xs text-signal-green">
                       {repoUrls.length > 0 ? (() => {
                         const { repo, prefixMatched } = matchRepo(analysis.code_fix.file, repoUrls)
+                        const canLink = prefixMatched || repoUrls.length === 1
                         const relPath = prefixMatched ? analysis.code_fix.file.slice(repo.name.length + 1) : analysis.code_fix.file
-                        return (
+                        return canLink ? (
                           <a
                             href={buildFileUrl(repo.url, relPath, analysis.code_fix.line, repo.ref)}
                             target="_blank"
@@ -323,6 +324,8 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                           >
                             {analysis.code_fix.file}{analysis.code_fix.line && `:${analysis.code_fix.line}`}
                           </a>
+                        ) : (
+                          <>{analysis.code_fix.file}{analysis.code_fix.line && `:${analysis.code_fix.line}`}</>
                         )
                       })() : (
                         <>{analysis.code_fix.file}{analysis.code_fix.line && `:${analysis.code_fix.line}`}</>

--- a/frontend/src/pages/report/PeerAnalysisSummary.tsx
+++ b/frontend/src/pages/report/PeerAnalysisSummary.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import type { FailureAnalysis, PeerDebate, ChildJobAnalysis } from '@/types'
+import type { RepoUrl } from '@/lib/autoLink'
 import { Badge } from '@/components/ui/badge'
 import { PeerRoundEntry } from '@/components/shared/PeerRoundEntry'
 import { groupPeerRounds } from '@/lib/peerDebate'
@@ -73,9 +74,10 @@ function getUniqueAiLabels(debates: FailureWithDebate[]): string[] {
 interface PeerAnalysisSummaryProps {
   failures: FailureAnalysis[]
   childJobAnalyses?: ChildJobAnalysis[]
+  repoUrls: RepoUrl[]
 }
 
-export function PeerAnalysisSummary({ failures, childJobAnalyses }: PeerAnalysisSummaryProps) {
+export function PeerAnalysisSummary({ failures, childJobAnalyses, repoUrls }: PeerAnalysisSummaryProps) {
   const [expanded, setExpanded] = useState(false)
 
   const debateFailures = useMemo(
@@ -139,7 +141,7 @@ export function PeerAnalysisSummary({ failures, childJobAnalyses }: PeerAnalysis
       {expanded && (
         <div className="border-t border-border-muted p-4 space-y-4">
           {debateFailures.map(({ id, testName, siblingTestNames, jobLabel, debate }) => (
-            <DebateEntry key={id} testName={testName} siblingTestNames={siblingTestNames} jobLabel={jobLabel} debate={debate} />
+            <DebateEntry key={id} testName={testName} siblingTestNames={siblingTestNames} jobLabel={jobLabel} debate={debate} repoUrls={repoUrls} />
           ))}
         </div>
       )}
@@ -148,7 +150,7 @@ export function PeerAnalysisSummary({ failures, childJobAnalyses }: PeerAnalysis
 }
 
 /** A single failure's debate entry within the summary. */
-function DebateEntry({ testName, siblingTestNames, jobLabel, debate }: { testName: string; siblingTestNames: string[]; jobLabel: string; debate: PeerDebate }) {
+function DebateEntry({ testName, siblingTestNames, jobLabel, debate, repoUrls }: { testName: string; siblingTestNames: string[]; jobLabel: string; debate: PeerDebate; repoUrls: RepoUrl[] }) {
   const [timelineOpen, setTimelineOpen] = useState(false)
   const groupedRounds = useMemo(() => groupPeerRounds(debate.rounds), [debate.rounds])
 
@@ -197,7 +199,7 @@ function DebateEntry({ testName, siblingTestNames, jobLabel, debate }: { testNam
               </p>
               <div className="space-y-2">
                 {entries.map((entry) => (
-                  <PeerRoundEntry key={`r${roundNum}-${entry.role}-${entry.ai_provider}-${entry.ai_model}`} entry={entry} compact />
+                  <PeerRoundEntry key={`r${roundNum}-${entry.role}-${entry.ai_provider}-${entry.ai_model}`} entry={entry} repoUrls={repoUrls} compact />
                 ))}
               </div>
             </div>

--- a/frontend/src/pages/report/PeerDebateSection.tsx
+++ b/frontend/src/pages/report/PeerDebateSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { PeerDebate } from '@/types'
+import type { RepoUrl } from '@/lib/autoLink'
 import { Badge } from '@/components/ui/badge'
 import { PeerRoundEntry } from '@/components/shared/PeerRoundEntry'
 import { groupPeerRounds } from '@/lib/peerDebate'
@@ -7,9 +8,10 @@ import { ChevronDown, ChevronRight } from 'lucide-react'
 
 interface PeerDebateSectionProps {
   debate: PeerDebate
+  repoUrls: RepoUrl[]
 }
 
-export function PeerDebateSection({ debate }: PeerDebateSectionProps) {
+export function PeerDebateSection({ debate, repoUrls }: PeerDebateSectionProps) {
   const [expanded, setExpanded] = useState(false)
 
   const groupedRounds = groupPeerRounds(debate.rounds)
@@ -47,7 +49,7 @@ export function PeerDebateSection({ debate }: PeerDebateSectionProps) {
               </p>
               <div className="space-y-2">
                 {entries.map((entry, i) => (
-                  <PeerRoundEntry key={`${entry.role}-${entry.ai_provider}-${i}`} entry={entry} />
+                  <PeerRoundEntry key={`${entry.role}-${entry.ai_provider}-${i}`} entry={entry} repoUrls={repoUrls} />
                 ))}
               </div>
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,7 +105,8 @@ export interface AnalysisResult {
     peer_ai_configs?: AiConfig[]
     peer_analysis_max_rounds?: number
     tests_repo_url?: string
-    additional_repos?: Array<{ name: string; url: string }>
+    tests_repo_ref?: string
+    additional_repos?: Array<{ name: string; url: string; ref?: string }>
     [key: string]: unknown
   }
 }

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -19,7 +19,7 @@ import jenkins
 from fastapi import HTTPException
 from simple_logger.logger import get_logger
 
-from jenkins_job_insight.config import Settings, parse_additional_repos
+from jenkins_job_insight.config import Settings, parse_additional_repos, parse_repo_ref
 from jenkins_job_insight.jenkins_artifacts import (
     ERROR_PATTERN,
     cleanup_extract_dir,
@@ -87,7 +87,11 @@ async def clone_additional_repos(
         target = repo_path / ar.name
         try:
             await asyncio.to_thread(
-                repo_manager.clone_into, str(ar.url), target, depth=1
+                repo_manager.clone_into,
+                str(ar.url),
+                target,
+                depth=1,
+                branch=ar.ref,
             )
             cloned[ar.name] = target
             logger.info(f"Cloned additional repo '{ar.name}' into {target}")
@@ -211,8 +215,8 @@ If CODE ISSUE:
 {
   "classification": "CODE ISSUE",
   "affected_tests": ["test_name_1", "test_name_2"],
-  "details": "Your detailed analysis of what caused this failure",
-  "artifacts_evidence": "VERBATIM lines from files under build-artifacts/ that support your analysis. Format each line as [file-path]: content. Example: [build-artifacts/logs/app.log]: 2026-03-16 INFO Service started successfully. Include evidence showing the product is healthy or that the test code caused the failure.",
+  "details": "Your detailed analysis of what caused this failure. Use paragraph breaks (double newlines) to separate sections: root cause identification, evidence from logs/code, and impact assessment. Do NOT write one continuous paragraph.",
+  "artifacts_evidence": "VERBATIM lines from files under build-artifacts/ that support your analysis. Format each line as [file-path]: content. Example: [build-artifacts/logs/app.log]: 2026-03-16 INFO Service started successfully. Include evidence showing the product is healthy or that the test code caused the failure. Separate distinct artifact entries with paragraph breaks (double newlines).",
   "code_fix": {
     "file": "exact/file/path.py",
     "line": "line number",
@@ -224,13 +228,13 @@ If PRODUCT BUG:
 {
   "classification": "PRODUCT BUG",
   "affected_tests": ["test_name_1", "test_name_2"],
-  "details": "Your detailed analysis of what caused this failure",
-  "artifacts_evidence": "VERBATIM lines from files under build-artifacts/ that prove the product defect. Format each line as [file-path]: content. Example: [build-artifacts/logs/error.log]: 2026-03-16 ERROR NullPointerException in AuthService. Include the specific log lines showing the product failure.",
+  "details": "Your detailed analysis of what caused this failure. Use paragraph breaks (double newlines) to separate sections: root cause identification, evidence from logs/code, and impact assessment. Do NOT write one continuous paragraph.",
+  "artifacts_evidence": "VERBATIM lines from files under build-artifacts/ that prove the product defect. Format each line as [file-path]: content. Example: [build-artifacts/logs/error.log]: 2026-03-16 ERROR NullPointerException in AuthService. Include the specific log lines showing the product failure. Separate distinct artifact entries with paragraph breaks (double newlines).",
   "product_bug_report": {
     "title": "concise bug title",
     "severity": "critical/high/medium/low",
     "component": "affected component",
-    "description": "what product behavior is broken",
+    "description": "what product behavior is broken. Use paragraph breaks between sections.",
     "evidence": "relevant log snippets",
     "jira_search_keywords": ["specific error symptom", "component + behavior", "error type"]
   }
@@ -1540,18 +1544,20 @@ async def analyze_job(
 
             if tests_repo_url:
                 try:
+                    clean_tests_url, tests_ref = parse_repo_ref(str(tests_repo_url))
                     repo_name = derive_test_repo_name(
-                        str(tests_repo_url), additional_repos_list
+                        clean_tests_url, additional_repos_list
                     )
-                    logger.info(f"Cloning test repository: {tests_repo_url}")
+                    logger.info(f"Cloning test repository: {clean_tests_url}")
                     await asyncio.to_thread(
                         repo_manager.clone_into,
-                        str(tests_repo_url),
+                        clean_tests_url,
                         repo_path / repo_name,
                         depth=50,
+                        branch=tests_ref,
                     )
                     cloned_repos[repo_name] = repo_path / repo_name
-                    repo_context = f"\nTest repository cloned from: {tests_repo_url} (at {repo_name}/)"
+                    repo_context = f"\nTest repository cloned from: {clean_tests_url} (at {repo_name}/)"
                 except Exception as e:
                     logger.warning(f"Failed to clone repository: {e}")
                     repo_context = f"\nFailed to clone repo: {e}"

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -2,6 +2,7 @@
 
 import os
 from functools import lru_cache
+from urllib.parse import urlsplit, urlunsplit
 
 from ai_cli_runner import VALID_AI_PROVIDERS
 from pydantic import Field, SecretStr, model_validator
@@ -82,9 +83,10 @@ def parse_additional_repos(raw: str) -> list[dict]:
 def parse_repo_ref(raw: str) -> tuple[str, str]:
     """Extract git ref from a URL string.
 
-    Format: 'url:ref' where ref is in the last path segment.
+    Format: 'url:ref' where ref is appended after the repo path with a colon.
     Examples:
         'https://github.com/org/repo:develop' -> ('https://github.com/org/repo', 'develop')
+        'https://github.com/org/repo:feature/foo' -> ('https://github.com/org/repo', 'feature/foo')
         'https://github.com/org/repo' -> ('https://github.com/org/repo', '')
         'https://gitlab.internal:8443/org/repo:v1.0.0' -> ('https://gitlab.internal:8443/org/repo', 'v1.0.0')
         '' -> ('', '')
@@ -92,15 +94,15 @@ def parse_repo_ref(raw: str) -> tuple[str, str]:
     if not raw or not raw.strip():
         return ("", "")
     raw = raw.strip()
-    last_slash = raw.rfind("/")
-    if last_slash == -1:
-        return (raw, "")
-    last_segment = raw[last_slash + 1 :]
-    if ":" in last_segment:
-        colon_idx = last_segment.index(":")
-        ref = last_segment[colon_idx + 1 :]
-        url = raw[: last_slash + 1] + last_segment[:colon_idx]
-        return (url, ref)
+
+    parts = urlsplit(raw)
+    path = parts.path or ""
+    if ":" in path:
+        repo_path, ref = path.split(":", 1)
+        clean_url = urlunsplit(
+            (parts.scheme, parts.netloc, repo_path, parts.query, parts.fragment)
+        )
+        return (clean_url, ref)
     return (raw, "")
 
 

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -59,13 +59,15 @@ def parse_additional_repos(raw: str) -> list[dict]:
             raise ValueError(
                 f"Invalid additional repo at position {i + 1}: '{entry}' (expected 'name:url')"
             )
-        name, url = entry.split(":", 1)
-        name, url = name.strip(), url.strip()
+        name, url_raw = entry.split(":", 1)
+        name = name.strip()
+        url_raw = url_raw.strip()
         if not name:
             raise ValueError(f"Empty name at position {i + 1}: '{entry}'")
-        if not url:
+        if not url_raw:
             raise ValueError(f"Empty URL at position {i + 1}: '{entry}'")
-        result.append({"name": name, "url": url})
+        url, ref = parse_repo_ref(url_raw)
+        result.append({"name": name, "url": url, "ref": ref})
 
     names = [r["name"] for r in result]
     dupes = [n for n in names if names.count(n) > 1]
@@ -75,6 +77,31 @@ def parse_additional_repos(raw: str) -> list[dict]:
         )
 
     return result
+
+
+def parse_repo_ref(raw: str) -> tuple[str, str]:
+    """Extract git ref from a URL string.
+
+    Format: 'url:ref' where ref is in the last path segment.
+    Examples:
+        'https://github.com/org/repo:develop' -> ('https://github.com/org/repo', 'develop')
+        'https://github.com/org/repo' -> ('https://github.com/org/repo', '')
+        'https://gitlab.internal:8443/org/repo:v1.0.0' -> ('https://gitlab.internal:8443/org/repo', 'v1.0.0')
+        '' -> ('', '')
+    """
+    if not raw or not raw.strip():
+        return ("", "")
+    raw = raw.strip()
+    last_slash = raw.rfind("/")
+    if last_slash == -1:
+        return (raw, "")
+    last_segment = raw[last_slash + 1 :]
+    if ":" in last_segment:
+        colon_idx = last_segment.index(":")
+        ref = last_segment[colon_idx + 1 :]
+        url = raw[: last_slash + 1] + last_segment[:colon_idx]
+        return (url, ref)
+    return (raw, "")
 
 
 class Settings(BaseSettings):

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -211,6 +211,13 @@ def _attach_result_links(payload: dict, base_url: str, job_id: str) -> dict:
     return payload
 
 
+def _recompose_repo_spec(url: str, ref: str) -> str:
+    """Recompose 'url:ref' from stored components. Returns url alone when ref is empty."""
+    if not url:
+        return ""
+    return f"{url}:{ref}" if ref else url
+
+
 def _reconstruct_from_params(
     result_data: dict,
 ) -> tuple[AnalyzeRequest, Settings]:
@@ -241,7 +248,10 @@ def _reconstruct_from_params(
         max_wait_minutes=params.get("max_wait_minutes", 0),
         enable_jira=params.get("enable_jira"),
         raw_prompt=params.get("raw_prompt") or None,
-        tests_repo_url=params.get("tests_repo_url") or None,
+        tests_repo_url=_recompose_repo_spec(
+            params.get("tests_repo_url", ""), params.get("tests_repo_ref", "")
+        )
+        or None,
         peer_ai_configs=(
             params["peer_ai_configs"] if "peer_ai_configs" in params else []
         ),
@@ -277,8 +287,11 @@ def _reconstruct_from_params(
             overrides[field] = params[field]
 
     # Tests repo URL
-    if params.get("tests_repo_url"):
-        overrides["tests_repo_url"] = params["tests_repo_url"]
+    recomposed = _recompose_repo_spec(
+        params.get("tests_repo_url", ""), params.get("tests_repo_ref", "")
+    )
+    if recomposed:
+        overrides["tests_repo_url"] = recomposed
 
     # SecretStr fields
     if params.get("jira_api_token"):

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -28,7 +28,12 @@ from jenkins_job_insight.analyzer import (
     format_exception_with_type,
     get_failure_signature,
 )
-from jenkins_job_insight.config import Settings, get_settings, parse_peer_configs
+from jenkins_job_insight.config import (
+    Settings,
+    get_settings,
+    parse_peer_configs,
+    parse_repo_ref,
+)
 from jenkins_job_insight.encryption import (
     SENSITIVE_KEYS,
     decrypt_sensitive_fields,
@@ -949,6 +954,7 @@ def _build_base_request_params(
     peer_ai_configs_resolved: list | None = None,
     *,
     tests_repo_url: str = "",
+    tests_repo_ref: str = "",
     additional_repos: list | None = None,
 ) -> dict:
     """Serialize the common request parameters shared by all analysis endpoints.
@@ -982,6 +988,7 @@ def _build_base_request_params(
         if additional_repos is not None
         else None,
         "tests_repo_url": tests_repo_url,
+        "tests_repo_ref": tests_repo_ref,
     }
 
 
@@ -1013,12 +1020,14 @@ def _build_request_params(
         if merged.tests_repo_url
         else ""
     )
+    resolved_tests_repo, tests_repo_ref = parse_repo_ref(resolved_tests_repo)
     resolved_additional = resolve_additional_repos(body, merged)
     params = _build_base_request_params(
         ai_provider,
         ai_model,
         peer_ai_configs_resolved,
         tests_repo_url=resolved_tests_repo,
+        tests_repo_ref=tests_repo_ref,
         additional_repos=resolved_additional,
     )
     params.update(
@@ -1169,7 +1178,8 @@ async def analyze_failures(
 
     # Resolve repos early so _build_base_request_params captures effective values
     # (including env-var / config-file defaults, not just request-body values).
-    tests_repo_url = body.tests_repo_url or merged.tests_repo_url
+    tests_repo_url_raw = str(body.tests_repo_url or merged.tests_repo_url or "")
+    tests_repo_url, tests_repo_ref = parse_repo_ref(tests_repo_url_raw)
     additional_repos_list = resolve_additional_repos(body, merged)
 
     job_id = str(uuid.uuid4())
@@ -1184,7 +1194,8 @@ async def analyze_failures(
             ai_provider,
             ai_model,
             peer_ai_configs,
-            tests_repo_url=str(tests_repo_url) if tests_repo_url else "",
+            tests_repo_url=tests_repo_url,
+            tests_repo_ref=tests_repo_ref,
             additional_repos=additional_repos_list or None,
         ),
     }
@@ -1220,6 +1231,7 @@ async def analyze_failures(
                     str(tests_repo_url),
                     repo_path / repo_name,
                     depth=50,
+                    branch=tests_repo_ref,
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
             except Exception as e:

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -39,6 +39,15 @@ class AdditionalRepo(BaseModel):
         min_length=1, description="Descriptive name (used as cloned directory name)"
     )
     url: HttpUrl = Field(description="Repository URL to clone")
+    ref: str = Field(
+        default="",
+        description="Git ref (branch/tag) for clone checkout and UI file links; empty = remote default branch",
+    )
+
+    @field_validator("ref")
+    @classmethod
+    def ref_strip(cls, v: str) -> str:
+        return v.strip()
 
     @field_validator("name")
     @classmethod
@@ -60,7 +69,7 @@ class AdditionalRepo(BaseModel):
 class BaseAnalysisRequest(BaseModel):
     """Shared fields for all analysis request types."""
 
-    tests_repo_url: HttpUrl | None = Field(
+    tests_repo_url: str | None = Field(
         default=None,
         description="URL of the tests repository (overrides env var default)",
     )

--- a/src/jenkins_job_insight/repository.py
+++ b/src/jenkins_job_insight/repository.py
@@ -107,10 +107,22 @@ def _validate_repo_url(repo_url: str | HttpUrl) -> None:
         )
 
 
-def _clone_with_ssl_retry(repo_url: str, clone_dir: Path, depth: int) -> None:
-    """Clone a repo, retrying without SSL verification on cert errors."""
+def _clone_with_ssl_retry(
+    repo_url: str, clone_dir: Path, depth: int, branch: str = ""
+) -> None:
+    """Clone a repo, retrying without SSL verification on cert errors.
+
+    Args:
+        repo_url: Repository URL to clone.
+        clone_dir: Target directory for the clone.
+        depth: Number of commits to fetch.
+        branch: Git ref (branch/tag) to check out. Empty string means default branch.
+    """
+    kwargs: dict[str, object] = {"depth": depth}
+    if branch:
+        kwargs["branch"] = branch
     try:
-        Repo.clone_from(repo_url, clone_dir, depth=depth)
+        Repo.clone_from(repo_url, clone_dir, **kwargs)
     except GitCommandError as exc:
         stderr = str(exc)
         if (
@@ -129,7 +141,7 @@ def _clone_with_ssl_retry(repo_url: str, clone_dir: Path, depth: int) -> None:
             Repo.clone_from(
                 repo_url,
                 clone_dir,
-                depth=depth,
+                **kwargs,
                 env={"GIT_SSL_NO_VERIFY": "1"},
             )
         else:
@@ -145,7 +157,7 @@ class RepositoryManager:
         self.base_path.mkdir(parents=True, exist_ok=True)
         self.temp_dirs: list[Path] = []
 
-    def clone(self, repo_url: str | HttpUrl, depth: int = 50) -> Path:
+    def clone(self, repo_url: str | HttpUrl, depth: int = 50, branch: str = "") -> Path:
         """Clone repository to a unique temporary directory.
 
         Each clone gets a UUID-based directory to support parallel webhook calls.
@@ -153,6 +165,7 @@ class RepositoryManager:
         Args:
             repo_url: URL of the git repository to clone (string or HttpUrl).
             depth: Number of commits to fetch for git history context.
+            branch: Git ref (branch/tag) to check out. Empty string means default branch.
 
         Returns:
             Path to the cloned repository.
@@ -167,11 +180,15 @@ class RepositoryManager:
         clone_dir.mkdir(parents=True, exist_ok=True)
         self.temp_dirs.append(clone_dir)
         logger.info(f"Cloning repository to {clone_dir}")
-        _clone_with_ssl_retry(str(repo_url), clone_dir, depth)
+        _clone_with_ssl_retry(str(repo_url), clone_dir, depth, branch=branch)
         return clone_dir
 
     def clone_into(
-        self, repo_url: str | HttpUrl, target_dir: Path, depth: int = 1
+        self,
+        repo_url: str | HttpUrl,
+        target_dir: Path,
+        depth: int = 1,
+        branch: str = "",
     ) -> Path:
         """Clone repository into a specific target directory.
 
@@ -184,6 +201,7 @@ class RepositoryManager:
             repo_url: URL of the git repository to clone.
             target_dir: Exact directory to clone into.
             depth: Number of commits to fetch (default 1 for shallow).
+            branch: Git ref (branch/tag) to check out. Empty string means default branch.
 
         Returns:
             Path to the cloned repository (same as target_dir).
@@ -194,7 +212,7 @@ class RepositoryManager:
         _validate_repo_url(repo_url)
         target_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Cloning repository into {target_dir}")
-        _clone_with_ssl_retry(str(repo_url), target_dir, depth)
+        _clone_with_ssl_retry(str(repo_url), target_dir, depth, branch=branch)
         return target_dir
 
     def create_workspace(self) -> Path:

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException
 
 from jenkins_job_insight.analyzer import (
+    _JSON_RESPONSE_SCHEMA,
     _build_resources_section,
     _call_ai_cli_with_retry,
     handle_jenkins_exception,
@@ -1127,7 +1128,7 @@ class TestCloneAdditionalRepos:
 
         manager = MagicMock(spec=RepositoryManager)
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             return target
 
@@ -1169,7 +1170,7 @@ class TestCloneAdditionalRepos:
 
         manager = MagicMock(spec=RepositoryManager)
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             return target
 
@@ -1211,7 +1212,7 @@ class TestCloneAdditionalRepos:
 
         manager = MagicMock(spec=RepositoryManager)
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             return target
 
@@ -1255,7 +1256,7 @@ class TestCloneAdditionalRepos:
             ),
         ]
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             if "bad" in str(url):
                 raise RuntimeError("Clone failed")
             target.mkdir(parents=True, exist_ok=True)
@@ -1303,7 +1304,7 @@ class TestCloneAdditionalRepos:
 
         manager = MagicMock(spec=RepositoryManager)
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             return target
 
@@ -1352,7 +1353,7 @@ class TestCloneAdditionalRepos:
 
         manager = MagicMock(spec=RepositoryManager)
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             return target
 
@@ -1557,7 +1558,7 @@ class TestAnalyzeJobWorkspacePattern:
         mock_repo_manager = MagicMock()
         mock_repo_manager.create_workspace.return_value = workspace_dir
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             clone_into_calls.append({"url": url, "target": target, "depth": depth})
             target.mkdir(parents=True, exist_ok=True)
             # Create .git to simulate a real clone
@@ -1654,7 +1655,7 @@ class TestAnalyzeJobWorkspacePattern:
         mock_repo_manager = MagicMock()
         mock_repo_manager.create_workspace.return_value = workspace_dir
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             clone_into_calls.append({"url": url, "target": target, "depth": depth})
             target.mkdir(parents=True, exist_ok=True)
             (target / ".git").mkdir(exist_ok=True)
@@ -1744,7 +1745,7 @@ class TestAnalyzeJobWorkspacePattern:
         mock_repo_manager = MagicMock()
         mock_repo_manager.create_workspace.return_value = workspace_dir
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             (target / ".git").mkdir(exist_ok=True)
             return target
@@ -1847,7 +1848,7 @@ class TestAnalyzeJobWorkspacePattern:
         mock_repo_manager = MagicMock()
         mock_repo_manager.create_workspace.return_value = workspace_dir
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             clone_into_calls.append({"url": url, "target": target, "depth": depth})
             target.mkdir(parents=True, exist_ok=True)
             (target / ".git").mkdir(exist_ok=True)
@@ -1964,7 +1965,7 @@ class TestAnalyzeJobWorkspacePattern:
         mock_repo_manager = MagicMock()
         mock_repo_manager.create_workspace.return_value = workspace_dir
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             target.mkdir(parents=True, exist_ok=True)
             (target / ".git").mkdir(exist_ok=True)
             return target
@@ -2044,7 +2045,7 @@ class TestAnalyzeFailuresWorkspacePattern:
         mock_repo_manager.create_workspace.return_value = workspace_dir
         mock_repo_manager.cleanup.return_value = None
 
-        def fake_clone_into(url, target, depth=1):
+        def fake_clone_into(url, target, depth=1, branch=""):
             clone_into_calls.append({"url": url, "target": target, "depth": depth})
             target.mkdir(parents=True, exist_ok=True)
             (target / ".git").mkdir(exist_ok=True)
@@ -2331,3 +2332,305 @@ class TestWorkspaceAlwaysCreated:
         # The annotation should be Path, not Path | None
         assert repo_path_param.annotation is not inspect.Parameter.empty
         assert "None" not in str(repo_path_param.annotation)
+
+
+class TestCloneAdditionalReposPassesRef:
+    """Tests that clone_additional_repos passes ar.ref as branch to clone_into."""
+
+    @pytest.mark.asyncio
+    async def test_ref_passed_as_branch(self, tmp_path) -> None:
+        """AdditionalRepo.ref is forwarded as branch parameter to clone_into."""
+        from jenkins_job_insight.analyzer import clone_additional_repos
+        from jenkins_job_insight.models import AdditionalRepo
+        from jenkins_job_insight.repository import RepositoryManager
+
+        repo_path = tmp_path / "workspace"
+        repo_path.mkdir()
+
+        repos = [
+            AdditionalRepo.model_validate(
+                {
+                    "name": "infra",
+                    "url": "https://github.com/org/infra",
+                    "ref": "develop",
+                }
+            ),
+            AdditionalRepo.model_validate(
+                {"name": "product", "url": "https://github.com/org/product", "ref": ""}
+            ),
+        ]
+
+        manager = MagicMock(spec=RepositoryManager)
+
+        def fake_clone_into(url, target, depth=1, branch=""):
+            target.mkdir(parents=True, exist_ok=True)
+            return target
+
+        manager.clone_into = MagicMock(side_effect=fake_clone_into)
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            side_effect=fake_to_thread,
+        ):
+            cloned, _ = await clone_additional_repos(manager, repos, repo_path)
+
+        assert len(cloned) == 2
+        # Check calls: infra should have branch="develop", product should have branch=""
+        calls = manager.clone_into.call_args_list
+        assert len(calls) == 2
+
+        # Find the call for each repo (order may vary due to asyncio.gather)
+        call_args_by_url = {}
+        for call in calls:
+            url = call[0][0] if call[0] else call[1].get("url", "")
+            call_args_by_url[url] = call
+
+        infra_call = call_args_by_url.get("https://github.com/org/infra")
+        assert infra_call is not None
+        # branch should be "develop"
+        assert infra_call[1].get("branch") == "develop" or (
+            len(infra_call[0]) > 3 and infra_call[0][3] == "develop"
+        )
+
+        product_call = call_args_by_url.get("https://github.com/org/product")
+        assert product_call is not None
+        # branch should be "" (empty)
+        assert product_call[1].get("branch", "") == ""
+
+
+class TestAnalyzeJobParsesRepoRef:
+    """Tests that analyze_job parses ref from tests_repo_url before cloning."""
+
+    @pytest.mark.asyncio
+    async def test_tests_repo_url_with_ref_passes_branch_to_clone(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """When tests_repo_url has ':ref', parse it and pass branch to clone_into."""
+        from jenkins_job_insight.analyzer import analyze_job
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest.model_validate(
+            {
+                "job_name": "my-job",
+                "build_number": 123,
+                "tests_repo_url": "https://github.com/org/my-tests:develop",
+            }
+        )
+        settings = Settings()
+        settings_data = settings.model_dump(mode="python")
+        settings_data["jenkins_url"] = "https://jenkins.example.com"
+        settings_data["jenkins_user"] = "user"
+        settings_data["jenkins_password"] = _FAKE_JENKINS_PASSWORD
+        merged = Settings.model_validate(settings_data)
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+
+        mock_client = MagicMock()
+        mock_client.get_build_info_safe.return_value = {
+            "result": "FAILURE",
+            "building": False,
+        }
+        mock_client.get_build_console.return_value = "Build failed"
+        mock_client.get_test_report.return_value = None
+        mock_client.session = MagicMock()
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.JenkinsClient",
+            lambda **kwargs: mock_client,
+        )
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            fake_to_thread,
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.check_ai_cli_available",
+            AsyncMock(return_value=(True, "")),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
+            AsyncMock(
+                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+            ),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.update_progress_phase",
+            AsyncMock(),
+        )
+
+        clone_into_calls = []
+        mock_repo_manager = MagicMock()
+        mock_repo_manager.create_workspace.return_value = workspace_dir
+
+        def fake_clone_into(url, target, depth=1, branch=""):
+            clone_into_calls.append(
+                {"url": url, "target": target, "depth": depth, "branch": branch}
+            )
+            target.mkdir(parents=True, exist_ok=True)
+            (target / ".git").mkdir(exist_ok=True)
+            return target
+
+        mock_repo_manager.clone_into = MagicMock(side_effect=fake_clone_into)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.RepositoryManager",
+            lambda: mock_repo_manager,
+        )
+
+        await analyze_job(
+            body,
+            merged,
+            ai_provider="claude",
+            ai_model="test-model",
+            job_id="test-job-id",
+        )
+
+        assert len(clone_into_calls) == 1
+        call = clone_into_calls[0]
+        # URL should be clean (no :develop suffix)
+        assert call["url"] == "https://github.com/org/my-tests"
+        # Branch should be "develop"
+        assert call["branch"] == "develop"
+        # Target should use the clean repo name
+        assert call["target"] == workspace_dir / "my-tests"
+
+    @pytest.mark.asyncio
+    async def test_tests_repo_url_without_ref_no_branch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """When tests_repo_url has no ':ref', branch is empty string."""
+        from jenkins_job_insight.analyzer import analyze_job
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest.model_validate(
+            {
+                "job_name": "my-job",
+                "build_number": 123,
+                "tests_repo_url": "https://github.com/org/my-tests",
+            }
+        )
+        settings = Settings()
+        settings_data = settings.model_dump(mode="python")
+        settings_data["jenkins_url"] = "https://jenkins.example.com"
+        settings_data["jenkins_user"] = "user"
+        settings_data["jenkins_password"] = _FAKE_JENKINS_PASSWORD
+        merged = Settings.model_validate(settings_data)
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+
+        mock_client = MagicMock()
+        mock_client.get_build_info_safe.return_value = {
+            "result": "FAILURE",
+            "building": False,
+        }
+        mock_client.get_build_console.return_value = "Build failed"
+        mock_client.get_test_report.return_value = None
+        mock_client.session = MagicMock()
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.JenkinsClient",
+            lambda **kwargs: mock_client,
+        )
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            fake_to_thread,
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.check_ai_cli_available",
+            AsyncMock(return_value=(True, "")),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
+            AsyncMock(
+                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+            ),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.update_progress_phase",
+            AsyncMock(),
+        )
+
+        clone_into_calls = []
+        mock_repo_manager = MagicMock()
+        mock_repo_manager.create_workspace.return_value = workspace_dir
+
+        def fake_clone_into(url, target, depth=1, branch=""):
+            clone_into_calls.append(
+                {"url": url, "target": target, "depth": depth, "branch": branch}
+            )
+            target.mkdir(parents=True, exist_ok=True)
+            (target / ".git").mkdir(exist_ok=True)
+            return target
+
+        mock_repo_manager.clone_into = MagicMock(side_effect=fake_clone_into)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.RepositoryManager",
+            lambda: mock_repo_manager,
+        )
+
+        await analyze_job(
+            body,
+            merged,
+            ai_provider="claude",
+            ai_model="test-model",
+            job_id="test-job-id",
+        )
+
+        assert len(clone_into_calls) == 1
+        call = clone_into_calls[0]
+        assert call["url"] == "https://github.com/org/my-tests"
+        assert call["branch"] == ""
+
+
+class TestJsonResponseSchemaParagraphBreaks:
+    """Tests that _JSON_RESPONSE_SCHEMA instructs the AI to use paragraph breaks."""
+
+    def test_code_issue_details_has_paragraph_break_instruction(self) -> None:
+        """CODE ISSUE details field instructs AI to use paragraph breaks."""
+        assert "paragraph breaks" in _JSON_RESPONSE_SCHEMA
+        assert "root cause identification" in _JSON_RESPONSE_SCHEMA
+        assert "Do NOT write one continuous paragraph" in _JSON_RESPONSE_SCHEMA
+
+    def test_product_bug_details_has_paragraph_break_instruction(self) -> None:
+        """PRODUCT BUG details field instructs AI to use paragraph breaks."""
+        assert "If PRODUCT BUG:" in _JSON_RESPONSE_SCHEMA
+        assert "Do NOT write one continuous paragraph" in _JSON_RESPONSE_SCHEMA
+
+    def test_code_issue_artifacts_evidence_has_paragraph_break_instruction(
+        self,
+    ) -> None:
+        """CODE ISSUE artifacts_evidence field instructs AI to separate entries with paragraph breaks."""
+        assert "artifacts_evidence" in _JSON_RESPONSE_SCHEMA
+        assert (
+            "Separate distinct artifact entries with paragraph breaks"
+            in _JSON_RESPONSE_SCHEMA
+        )
+
+    def test_product_bug_artifacts_evidence_has_paragraph_break_instruction(
+        self,
+    ) -> None:
+        """PRODUCT BUG artifacts_evidence field instructs AI to separate entries with paragraph breaks."""
+        assert "artifacts_evidence" in _JSON_RESPONSE_SCHEMA
+        assert (
+            "Separate distinct artifact entries with paragraph breaks"
+            in _JSON_RESPONSE_SCHEMA
+        )
+
+    def test_product_bug_report_description_has_paragraph_break_instruction(
+        self,
+    ) -> None:
+        """product_bug_report description field instructs AI to use paragraph breaks."""
+        assert "paragraph breaks between sections" in _JSON_RESPONSE_SCHEMA

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1890,8 +1890,8 @@ class TestAnalyzeAdditionalReposFlags:
         assert result.exit_code == 0
         kwargs = mock_client.analyze.call_args[1]
         assert kwargs["additional_repos"] == [
-            {"name": "infra", "url": "https://github.com/org/infra"},
-            {"name": "product", "url": "https://github.com/org/product"},
+            {"name": "infra", "url": "https://github.com/org/infra", "ref": ""},
+            {"name": "product", "url": "https://github.com/org/product", "ref": ""},
         ]
 
     def test_additional_repos_flag_invalid_format_exits(self, mock_client):
@@ -1948,7 +1948,7 @@ class TestAnalyzeAdditionalReposFlags:
             assert result.exit_code == 0
             kwargs = client.analyze.call_args[1]
             assert kwargs["additional_repos"] == [
-                {"name": "infra", "url": "https://github.com/org/infra"},
+                {"name": "infra", "url": "https://github.com/org/infra", "ref": ""},
             ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -480,6 +480,12 @@ class TestParseRepoRef:
         assert url == "https://github.com/org/repo"
         assert ref == ""
 
+    def test_ref_with_slash(self) -> None:
+        """Ref containing slashes (branch names like feature/foo)."""
+        url, ref = parse_repo_ref("https://github.com/org/repo:feature/foo")
+        assert url == "https://github.com/org/repo"
+        assert ref == "feature/foo"
+
 
 class TestPeerSettingsFields:
     """Tests for peer_ai_configs and peer_analysis_max_rounds Settings fields."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from jenkins_job_insight.config import (
     get_settings,
     parse_additional_repos,
     parse_peer_configs,
+    parse_repo_ref,
 )
 
 
@@ -342,19 +343,45 @@ class TestParseAdditionalRepos:
 
     def test_single_repo(self) -> None:
         result = parse_additional_repos("infra:https://github.com/org/infra")
-        assert result == [{"name": "infra", "url": "https://github.com/org/infra"}]
+        assert result == [
+            {"name": "infra", "url": "https://github.com/org/infra", "ref": ""}
+        ]
 
     def test_multiple_repos(self) -> None:
         result = parse_additional_repos(
             "infra:https://github.com/org/infra,product:https://github.com/org/product"
         )
         assert len(result) == 2
-        assert result[0] == {"name": "infra", "url": "https://github.com/org/infra"}
-        assert result[1] == {"name": "product", "url": "https://github.com/org/product"}
+        assert result[0] == {
+            "name": "infra",
+            "url": "https://github.com/org/infra",
+            "ref": "",
+        }
+        assert result[1] == {
+            "name": "product",
+            "url": "https://github.com/org/product",
+            "ref": "",
+        }
 
     def test_whitespace_trimmed(self) -> None:
         result = parse_additional_repos("  infra : https://github.com/org/infra  ")
-        assert result == [{"name": "infra", "url": "https://github.com/org/infra"}]
+        assert result == [
+            {"name": "infra", "url": "https://github.com/org/infra", "ref": ""}
+        ]
+
+    def test_repo_with_branch_ref(self) -> None:
+        """Repo URL with ':branch' extracts ref into result dict."""
+        result = parse_additional_repos("infra:https://github.com/org/infra:develop")
+        assert result == [
+            {"name": "infra", "url": "https://github.com/org/infra", "ref": "develop"}
+        ]
+
+    def test_repo_with_port_and_ref(self) -> None:
+        """Repo URL with port AND ref correctly extracts both."""
+        result = parse_additional_repos("infra:https://gitlab:8443/org/infra:main")
+        assert result == [
+            {"name": "infra", "url": "https://gitlab:8443/org/infra", "ref": "main"}
+        ]
 
     def test_empty_entry_raises(self) -> None:
         with pytest.raises(ValueError, match="Empty entry"):
@@ -389,6 +416,69 @@ class TestParseAdditionalRepos:
         ):
             settings = Settings(_env_file=None)
             assert settings.additional_repos == "infra:https://github.com/org/infra"
+
+
+class TestParseRepoRef:
+    """Tests for parse_repo_ref function."""
+
+    def test_url_without_ref(self) -> None:
+        """URL without ref returns empty ref string."""
+        url, ref = parse_repo_ref("https://github.com/org/repo")
+        assert url == "https://github.com/org/repo"
+        assert ref == ""
+
+    def test_url_with_branch_ref(self) -> None:
+        """URL with ':develop' returns URL and branch ref."""
+        url, ref = parse_repo_ref("https://github.com/org/repo:develop")
+        assert url == "https://github.com/org/repo"
+        assert ref == "develop"
+
+    def test_url_with_tag_ref(self) -> None:
+        """URL with ':v1.0.0' returns URL and tag ref."""
+        url, ref = parse_repo_ref("https://github.com/org/repo:v1.0.0")
+        assert url == "https://github.com/org/repo"
+        assert ref == "v1.0.0"
+
+    def test_url_with_port_and_ref(self) -> None:
+        """URL with port AND ref correctly splits on last segment's colon."""
+        url, ref = parse_repo_ref("https://gitlab.internal:8443/org/repo:main")
+        assert url == "https://gitlab.internal:8443/org/repo"
+        assert ref == "main"
+
+    def test_url_ending_with_git_and_ref(self) -> None:
+        """URL ending with '.git:ref' extracts ref from .git segment."""
+        url, ref = parse_repo_ref("https://github.com/org/repo.git:feature-x")
+        assert url == "https://github.com/org/repo.git"
+        assert ref == "feature-x"
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty tuple."""
+        url, ref = parse_repo_ref("")
+        assert url == ""
+        assert ref == ""
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only string returns empty tuple."""
+        url, ref = parse_repo_ref("   ")
+        assert url == ""
+        assert ref == ""
+
+    def test_url_with_trailing_slash(self) -> None:
+        """URL with trailing slash has no ref (last segment is empty)."""
+        url, ref = parse_repo_ref("https://github.com/org/repo/")
+        assert url == "https://github.com/org/repo/"
+        assert ref == ""
+
+    def test_whitespace_stripped(self) -> None:
+        """Leading/trailing whitespace is stripped before parsing."""
+        url, ref = parse_repo_ref("  https://github.com/org/repo:develop  ")
+        assert url == "https://github.com/org/repo"
+        assert ref == "develop"
+
+    def test_trailing_colon_returns_empty_ref(self) -> None:
+        url, ref = parse_repo_ref("https://github.com/org/repo:")
+        assert url == "https://github.com/org/repo"
+        assert ref == ""
 
 
 class TestPeerSettingsFields:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,6 +168,7 @@ class TestAnalyzeEndpoint:
         )
         # 400 from missing AI config, not 422 from URL validation
         assert response.status_code == 400
+        assert "AI provider" in response.json()["detail"]
 
     def test_analyze_missing_required_field(self, test_client) -> None:
         """Test that missing required field returns 422."""
@@ -2696,6 +2697,26 @@ class TestReconstructFromParams:
         body, merged = _reconstruct_from_params(result_data)
         assert body.job_name == "j"
         assert merged.jenkins_url  # Falls back to env default
+
+    def test_reconstruct_rehydrates_tests_repo_ref(self, mock_settings) -> None:
+        """tests_repo_ref is recomposed with tests_repo_url during reconstruction."""
+        from jenkins_job_insight.main import _reconstruct_from_params
+
+        result_data = {
+            "job_name": "j",
+            "build_number": 1,
+            "request_params": {
+                "ai_provider": "claude",
+                "ai_model": "m",
+                "tests_repo_url": "https://github.com/org/repo",
+                "tests_repo_ref": "feature/bar",
+            },
+        }
+        body, merged = _reconstruct_from_params(result_data)
+        # Body should have the recomposed url:ref format
+        assert body.tests_repo_url == "https://github.com/org/repo:feature/bar"
+        # Settings should also have the recomposed format
+        assert merged.tests_repo_url == "https://github.com/org/repo:feature/bar"
 
 
 class TestResumeWaitingJobs:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -156,17 +156,18 @@ class TestAnalyzeEndpoint:
         )
         assert response.status_code == 422
 
-    def test_analyze_invalid_tests_repo_url(self, test_client) -> None:
-        """Test that invalid repo URL returns 422."""
+    def test_analyze_accepts_tests_repo_url_with_ref(self, test_client) -> None:
+        """Test that tests_repo_url with ':ref' suffix is accepted (no URL validation)."""
         response = test_client.post(
             "/analyze",
             json={
                 "job_name": "test",
                 "build_number": 123,
-                "tests_repo_url": "not-a-valid-url",
+                "tests_repo_url": "https://github.com/org/repo:develop",
             },
         )
-        assert response.status_code == 422
+        # 400 from missing AI config, not 422 from URL validation
+        assert response.status_code == 400
 
     def test_analyze_missing_required_field(self, test_client) -> None:
         """Test that missing required field returns 422."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,6 +60,14 @@ class TestAnalyzeRequest:
         )
         assert request.tests_repo_url == "https://github.com/org/repo:develop"
 
+        # Also verify a non-URL string is accepted
+        request2 = AnalyzeRequest(
+            job_name="test",
+            build_number=123,
+            tests_repo_url="not-a-valid-url",
+        )
+        assert request2.tests_repo_url == "not-a-valid-url"
+
     def test_wait_for_completion_defaults(self) -> None:
         """Test wait_for_completion fields have correct defaults."""
         request = AnalyzeRequest(job_name="test", build_number=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -39,7 +39,7 @@ class TestAnalyzeRequest:
         )
         assert request.job_name == "test"
         assert request.build_number == 123
-        assert str(request.tests_repo_url) == "https://github.com/example/repo"
+        assert request.tests_repo_url == "https://github.com/example/repo"
 
     def test_analyze_request_without_tests_repo_url(self) -> None:
         """Test creating AnalyzeRequest without tests_repo_url (now optional)."""
@@ -51,14 +51,14 @@ class TestAnalyzeRequest:
         assert request.build_number == 123
         assert request.tests_repo_url is None
 
-    def test_analyze_request_invalid_tests_repo_url(self) -> None:
-        """Test that invalid repo URL raises ValidationError."""
-        with pytest.raises(ValidationError):
-            AnalyzeRequest(
-                job_name="test",
-                build_number=123,
-                tests_repo_url="not-a-valid-url",
-            )
+    def test_analyze_request_accepts_any_tests_repo_url_string(self) -> None:
+        """Test that tests_repo_url accepts any string (no URL validation)."""
+        request = AnalyzeRequest(
+            job_name="test",
+            build_number=123,
+            tests_repo_url="https://github.com/org/repo:develop",
+        )
+        assert request.tests_repo_url == "https://github.com/org/repo:develop"
 
     def test_wait_for_completion_defaults(self) -> None:
         """Test wait_for_completion fields have correct defaults."""
@@ -878,6 +878,20 @@ class TestAdditionalRepo:
         """Reserved name 'build-artifacts' must be rejected."""
         with pytest.raises(ValidationError):
             AdditionalRepo(name="build-artifacts", url="https://github.com/org/repo")
+
+    def test_ref_whitespace_stripped(self) -> None:
+        """Leading/trailing whitespace in ref is stripped."""
+        repo = AdditionalRepo(
+            name="infra", url="https://github.com/org/infra", ref="  main  "
+        )
+        assert repo.ref == "main"
+
+    def test_ref_whitespace_only_becomes_empty(self) -> None:
+        """Whitespace-only ref is stripped to empty string."""
+        repo = AdditionalRepo(
+            name="infra", url="https://github.com/org/infra", ref="   "
+        )
+        assert repo.ref == ""
 
 
 class TestAdditionalReposDuplicateNames:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -549,3 +549,123 @@ class TestRedactUrl:
         from jenkins_job_insight.repository import _redact_url
 
         assert _redact_url("git://github.com/org/repo") == "git://github.com/org/repo"
+
+
+class TestCloneBranchParameter:
+    """Tests for passing branch parameter through clone functions."""
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_with_ssl_retry_passes_branch(
+        self, mock_repo: MagicMock, tmp_path
+    ) -> None:
+        """_clone_with_ssl_retry passes branch to Repo.clone_from when non-empty."""
+        from jenkins_job_insight.repository import _clone_with_ssl_retry
+
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        _clone_with_ssl_retry(
+            "https://example.com/repo", clone_dir, depth=1, branch="develop"
+        )
+        mock_repo.clone_from.assert_called_once_with(
+            "https://example.com/repo", clone_dir, depth=1, branch="develop"
+        )
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_with_ssl_retry_no_branch_when_empty(
+        self, mock_repo: MagicMock, tmp_path
+    ) -> None:
+        """_clone_with_ssl_retry does NOT pass branch when empty string."""
+        from jenkins_job_insight.repository import _clone_with_ssl_retry
+
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        _clone_with_ssl_retry("https://example.com/repo", clone_dir, depth=1, branch="")
+        mock_repo.clone_from.assert_called_once_with(
+            "https://example.com/repo", clone_dir, depth=1
+        )
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_with_ssl_retry_default_no_branch(
+        self, mock_repo: MagicMock, tmp_path
+    ) -> None:
+        """_clone_with_ssl_retry without branch arg does not pass branch."""
+        from jenkins_job_insight.repository import _clone_with_ssl_retry
+
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        _clone_with_ssl_retry("https://example.com/repo", clone_dir, depth=1)
+        mock_repo.clone_from.assert_called_once_with(
+            "https://example.com/repo", clone_dir, depth=1
+        )
+
+    def test_clone_with_ssl_retry_passes_branch_on_ssl_retry(self, tmp_path) -> None:
+        """branch is passed in BOTH the initial and SSL retry Repo.clone_from calls."""
+        from jenkins_job_insight.repository import _clone_with_ssl_retry
+
+        with patch("jenkins_job_insight.repository.Repo.clone_from") as mock_clone:
+            mock_clone.side_effect = [
+                GitCommandError(
+                    "git clone",
+                    128,
+                    stderr="SSL certificate problem",
+                ),
+                MagicMock(),
+            ]
+            target = tmp_path / "repo"
+            target.mkdir()
+            _clone_with_ssl_retry(
+                "https://example.com/repo", target, depth=1, branch="main"
+            )
+
+            assert mock_clone.call_count == 2
+            # First call should have branch
+            first_call = mock_clone.call_args_list[0]
+            assert first_call[1].get("branch") == "main"
+            # Second (retry) call should also have branch
+            second_call = mock_clone.call_args_list[1]
+            assert second_call[1].get("branch") == "main"
+            assert second_call[1].get("env", {}).get("GIT_SSL_NO_VERIFY") == "1"
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_into_passes_branch(self, mock_repo: MagicMock, tmp_path) -> None:
+        """clone_into forwards branch to _clone_with_ssl_retry."""
+        manager = RepositoryManager()
+        target = tmp_path / "my-repo"
+        manager.clone_into(
+            "https://github.com/org/repo", target, depth=1, branch="feature-x"
+        )
+        mock_repo.clone_from.assert_called_once_with(
+            "https://github.com/org/repo", target, depth=1, branch="feature-x"
+        )
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_into_no_branch_when_empty(
+        self, mock_repo: MagicMock, tmp_path
+    ) -> None:
+        """clone_into does not pass branch when empty string."""
+        manager = RepositoryManager()
+        target = tmp_path / "my-repo"
+        manager.clone_into("https://github.com/org/repo", target, depth=1, branch="")
+        mock_repo.clone_from.assert_called_once_with(
+            "https://github.com/org/repo", target, depth=1
+        )
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_passes_branch(self, mock_repo: MagicMock) -> None:
+        """clone forwards branch to _clone_with_ssl_retry."""
+        manager = RepositoryManager()
+        manager.clone("https://github.com/org/repo", depth=50, branch="release-1.0")
+        mock_repo.clone_from.assert_called_once()
+        call_kwargs = mock_repo.clone_from.call_args[1]
+        assert call_kwargs["branch"] == "release-1.0"
+        manager.cleanup()
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_no_branch_when_empty(self, mock_repo: MagicMock) -> None:
+        """clone does not pass branch when empty string."""
+        manager = RepositoryManager()
+        manager.clone("https://github.com/org/repo", depth=50, branch="")
+        mock_repo.clone_from.assert_called_once()
+        call_kwargs = mock_repo.clone_from.call_args[1]
+        assert "branch" not in call_kwargs
+        manager.cleanup()


### PR DESCRIPTION
## Summary

- Support posting comments from grouped failures (one comment per test in parallel via Promise.allSettled, with retry dedup for partial failures)
- Auto-link file paths in analysis text to source repo (Analysis, Artifacts Evidence, Suggested Fix, Bug Report, Peer Debate sections)
- Support branch/tag refs in repo URLs (`url:ref` format like `provider:model`)
- Pass ref to git clone so AI analyzes the correct branch
- Extract shared auto-link utilities (autoLink.ts, LinkedText component)
- Add paragraph break instructions to AI prompt for formatted output
- Use HEAD as default ref for blob URLs (resolves to actual default branch)

## Changes

### Backend (Python)
- `config.py`: New `parse_repo_ref()` function, updated `parse_additional_repos()` to extract refs
- `models.py`: `tests_repo_url` changed from HttpUrl to str (supports `url:ref`), `AdditionalRepo` got `ref` field with whitespace validator
- `main.py`: Plumbing for `tests_repo_ref` through `_build_base_request_params`
- `repository.py`: `branch` parameter threaded through `clone_into()` → `Repo.clone_from()`
- `analyzer.py`: Passes ref to clone for both tests repo and additional repos

### Frontend (TypeScript/React)
- `autoLink.ts`: Shared auto-link utilities with `RepoUrl.ref`, `buildFileUrl` (ref + line-0 fix), `matchRepo` (multi-repo prefix matching + path stripping), `buildRepoUrls` (shared helper), fresh regex instances, directory dots fix in `FILE_PATH_RE`
- `LinkedText.tsx`: Reusable component with `renderLink` callback for custom link rendering
- `CommentsSection.tsx`: Uses LinkedText, grouped comment posting via Promise.allSettled, retry dedup with `succeededTestNames`
- `FailureCard.tsx`: LinkedText for all analysis text fields, `matchRepo` for code_fix links
- `PeerRoundEntry.tsx` + `PeerDebateSection.tsx`: LinkedText integration for peer debate text
- `ReportPage.tsx`: Shared `buildRepoUrls` with aligned useMemo deps

### Tests
- 990 total tests (929 backend + 61 frontend)
- New tests for `parse_repo_ref`, clone branch parameter, `matchRepo`, `buildFileUrl`, `LinkedText` render

## Test plan
- [ ] Run `uvx --with tox-uv tox` — all 990 tests pass
- [ ] Submit analysis with `--tests-repo-url https://repo:branch` — verify clone uses correct branch
- [ ] Verify file paths in analysis text are clickable links pointing to correct repo/branch
- [ ] Verify grouped comment posting works (post to multiple tests, partial failure retry)
- [ ] Verify paragraph breaks in AI analysis output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-linking: URLs and repository file paths in details, comments, peer discussions, failure cards, and suggested fixes become clickable and open externally.
  * Repository ref support: specify branch/tag for test and additional repositories so clones and file links use the selected ref.

* **Behavior Changes**
  * Comment posting now posts to multiple tests concurrently, tracks per-test success/retries, and always shows the input + Post button.

* **Tests**
  * Expanded coverage for auto-linking, repo-ref parsing, and clone/branch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->