### PR TITLE
feat: Re-Analyze button with settings dialog on report page (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ htmlcov/
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+
+# Local config
+.envrc
+.claude/

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -85,8 +85,6 @@ function ReportContent() {
   const dispatch = useReportDispatch()
   const refreshEnrichments = useRefreshEnrichments()
 
-  const [reAnalyzeOpen, setReAnalyzeOpen] = useState(false)
-
   // Capture hash fragment on mount and listen for changes (child-job deep linking)
   const [activeHash, setActiveHash] = useState(() => window.location.hash.replace(/^#/, ''))
 
@@ -395,7 +393,7 @@ function ReportContent() {
                 variant="outline"
                 size="sm"
                 className="gap-1.5 text-xs"
-                onClick={() => setReAnalyzeOpen(true)}
+                onClick={() => dispatch({ type: 'SET_RE_ANALYZE_OPEN', payload: true })}
                 disabled={result.status === 'running' || result.status === 'pending' || result.status === 'waiting'}
               >
                 <RotateCw className="h-3.5 w-3.5" />
@@ -538,8 +536,8 @@ function ReportContent() {
     </div>
       {result.request_params && (
         <ReAnalyzeDialog
-          open={reAnalyzeOpen}
-          onOpenChange={setReAnalyzeOpen}
+          open={state.reAnalyzeOpen}
+          onOpenChange={(v) => dispatch({ type: 'SET_RE_ANALYZE_OPEN', payload: v })}
           result={result}
           jobId={jobId!}
         />

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -16,7 +16,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Skeleton } from '@/components/ui/skeleton'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { ExpandCollapseButtons } from '@/components/shared/ExpandCollapseButtons'
-import { ExternalLink, CheckCircle2, Clock, Calendar, Cpu, Timer, FolderGit2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ExternalLink, CheckCircle2, Clock, Calendar, Cpu, Timer, FolderGit2, RotateCw } from 'lucide-react'
+import { ReAnalyzeDialog } from './report/ReAnalyzeDialog'
 import { reviewKey } from './report/ReportContext'
 import type { ChildJobAnalysis } from '@/types'
 
@@ -82,6 +84,8 @@ function ReportContent() {
   const state = useReportState()
   const dispatch = useReportDispatch()
   const refreshEnrichments = useRefreshEnrichments()
+
+  const [reAnalyzeOpen, setReAnalyzeOpen] = useState(false)
 
   // Capture hash fragment on mount and listen for changes (child-job deep linking)
   const [activeHash, setActiveHash] = useState(() => window.location.hash.replace(/^#/, ''))
@@ -385,16 +389,30 @@ function ReportContent() {
               {formatAiLabel(result.ai_provider, result.ai_model)}
             </Badge>
           )}
-          {result.jenkins_url && (
-            <a
-              href={String(result.jenkins_url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-auto flex items-center gap-1 text-xs text-text-link hover:underline"
-            >
-              Jenkins <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
+          <div className="ml-auto flex items-center gap-3">
+            {result.request_params && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 text-xs"
+                onClick={() => setReAnalyzeOpen(true)}
+                disabled={result.status === 'running' || result.status === 'pending' || result.status === 'waiting'}
+              >
+                <RotateCw className="h-3.5 w-3.5" />
+                Re-Analyze
+              </Button>
+            )}
+            {result.jenkins_url && (
+              <a
+                href={String(result.jenkins_url)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-xs text-text-link hover:underline"
+              >
+                Jenkins <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
         </div>
       </div>
 
@@ -518,6 +536,14 @@ function ReportContent() {
         )}
       </footer>
     </div>
+      {result.request_params && (
+        <ReAnalyzeDialog
+          open={reAnalyzeOpen}
+          onOpenChange={setReAnalyzeOpen}
+          result={result}
+          jobId={jobId!}
+        />
+      )}
     </TooltipProvider>
   )
 }

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -1,0 +1,525 @@
+import { useState, useCallback, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select'
+import { api } from '@/lib/api'
+import type { AnalysisResult, AiConfig } from '@/types'
+import { ChevronRight, Plus, Trash2, RotateCw } from 'lucide-react'
+
+interface ReAnalyzeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  result: AnalysisResult
+  jobId: string
+}
+
+function Section({
+  title,
+  dotColor,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  dotColor: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-2 py-2 text-left group"
+      >
+        <ChevronRight
+          className={`h-3 w-3 text-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
+        />
+        <span className={`w-1.5 h-1.5 rounded-full ${dotColor} flex-shrink-0`} />
+        <span className="font-display text-[11px] font-semibold tracking-widest text-text-secondary uppercase">
+          {title}
+        </span>
+      </button>
+      {open && <div className="pl-5 space-y-4 pb-4">{children}</div>}
+    </div>
+  )
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      className={`relative w-11 h-6 rounded-full transition-colors ${
+        checked ? 'bg-signal-blue' : 'bg-surface-hover'
+      }`}
+    >
+      <span
+        className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-5' : ''
+        }`}
+      />
+    </button>
+  )
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <label className="text-xs text-text-tertiary">{children}</label>
+}
+
+export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyzeDialogProps) {
+  const navigate = useNavigate()
+  const params = result.request_params
+
+  const [aiProvider, setAiProvider] = useState(params?.ai_provider || 'claude')
+  const [aiModel, setAiModel] = useState(params?.ai_model || '')
+  const [aiCliTimeout, setAiCliTimeout] = useState<number>(
+    (params?.ai_cli_timeout as number) || 10,
+  )
+  const [rawPrompt, setRawPrompt] = useState((params?.raw_prompt as string) || '')
+
+  const [enablePeers, setEnablePeers] = useState(!!(params?.peer_ai_configs?.length))
+  const [peerConfigs, setPeerConfigs] = useState<AiConfig[]>(params?.peer_ai_configs || [])
+  const [maxRounds, setMaxRounds] = useState(params?.peer_analysis_max_rounds || 3)
+
+  const [testsRepoUrl, setTestsRepoUrl] = useState(params?.tests_repo_url || '')
+  const [testsRepoRef, setTestsRepoRef] = useState(params?.tests_repo_ref || '')
+  const [additionalRepos, setAdditionalRepos] = useState<
+    Array<{ name: string; url: string; ref: string }>
+  >(
+    (params?.additional_repos || []).map((r) => ({
+      name: r.name,
+      url: r.url,
+      ref: r.ref || '',
+    })),
+  )
+
+  const [enableJira, setEnableJira] = useState((params?.enable_jira as boolean) !== false)
+  const [jiraUrl, setJiraUrl] = useState((params?.jira_url as string) || '')
+  const [jiraProjectKey, setJiraProjectKey] = useState(
+    (params?.jira_project_key as string) || '',
+  )
+
+  const [getArtifacts, setGetArtifacts] = useState(
+    (params?.get_job_artifacts as boolean) !== false,
+  )
+  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number>(
+    (params?.jenkins_artifacts_max_size_mb as number) || 50,
+  )
+  const [contextLines, setContextLines] = useState<number>(
+    (params?.jenkins_artifacts_context_lines as number) || 100,
+  )
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  // Reset form state when dialog opens
+  useEffect(() => {
+    if (!open) return
+    const p = result.request_params
+    setAiProvider(p?.ai_provider || 'claude')
+    setAiModel(p?.ai_model || '')
+    setAiCliTimeout((p?.ai_cli_timeout as number) || 10)
+    setRawPrompt((p?.raw_prompt as string) || '')
+    setEnablePeers(!!(p?.peer_ai_configs?.length))
+    setPeerConfigs(p?.peer_ai_configs || [])
+    setMaxRounds(p?.peer_analysis_max_rounds || 3)
+    setTestsRepoUrl(p?.tests_repo_url || '')
+    setTestsRepoRef(p?.tests_repo_ref || '')
+    setAdditionalRepos(
+      (p?.additional_repos || []).map((r) => ({
+        name: r.name,
+        url: r.url,
+        ref: r.ref || '',
+      })),
+    )
+    setEnableJira((p?.enable_jira as boolean) !== false)
+    setJiraUrl((p?.jira_url as string) || '')
+    setJiraProjectKey((p?.jira_project_key as string) || '')
+    setGetArtifacts((p?.get_job_artifacts as boolean) !== false)
+    setMaxArtifactsSize((p?.jenkins_artifacts_max_size_mb as number) || 50)
+    setContextLines((p?.jenkins_artifacts_context_lines as number) || 100)
+    setSubmitting(false)
+    setError('')
+  }, [open, result.request_params])
+
+  const handleSubmit = useCallback(async () => {
+    setSubmitting(true)
+    setError('')
+    try {
+      const overrides: Record<string, unknown> = {
+        ai_provider: aiProvider,
+        ai_model: aiModel,
+        ai_cli_timeout: aiCliTimeout,
+        enable_jira: enableJira,
+        jira_url: jiraUrl || undefined,
+        jira_project_key: jiraProjectKey || undefined,
+        get_job_artifacts: getArtifacts,
+        jenkins_artifacts_max_size_mb: maxArtifactsSize,
+        jenkins_artifacts_context_lines: contextLines,
+        raw_prompt: rawPrompt || undefined,
+        tests_repo_url: testsRepoUrl || undefined,
+        tests_repo_ref: testsRepoRef || undefined,
+        peer_ai_configs: enablePeers ? peerConfigs : [],
+        peer_analysis_max_rounds: maxRounds,
+        additional_repos: additionalRepos
+          .filter((r) => r.name && r.url)
+          .map((r) => ({
+            name: r.name,
+            url: r.url,
+            ref: r.ref || undefined,
+          })),
+      }
+      const body = Object.fromEntries(
+        Object.entries(overrides).filter(([, v]) => v !== undefined),
+      )
+      const data = await api.post<{ job_id: string }>(`/re-analyze/${jobId}`, body)
+      onOpenChange(false)
+      navigate(`/results/${data.job_id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit re-analysis')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [
+    aiProvider,
+    aiModel,
+    aiCliTimeout,
+    rawPrompt,
+    enablePeers,
+    peerConfigs,
+    maxRounds,
+    testsRepoUrl,
+    testsRepoRef,
+    additionalRepos,
+    enableJira,
+    jiraUrl,
+    jiraProjectKey,
+    getArtifacts,
+    maxArtifactsSize,
+    contextLines,
+    jobId,
+    onOpenChange,
+    navigate,
+  ])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px] max-h-[85vh] flex flex-col bg-surface-card border-border-default p-0">
+        <DialogHeader className="px-6 pt-5 pb-4 border-b border-border-default flex-shrink-0">
+          <DialogTitle>🔄 Re-Analyze Job</DialogTitle>
+          <DialogDescription>
+            Adjust settings and re-run analysis. A new analysis will be created.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-y-auto flex-1 px-6 py-5 space-y-1">
+          {/* AI Configuration */}
+          <Section title="AI Configuration" dotColor="bg-signal-blue" defaultOpen>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <FieldLabel>AI Provider</FieldLabel>
+                <Select value={aiProvider} onValueChange={setAiProvider}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="claude">Claude</SelectItem>
+                    <SelectItem value="gemini">Gemini</SelectItem>
+                    <SelectItem value="cursor">Cursor</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>AI CLI Timeout</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  value={aiCliTimeout}
+                  onChange={(e) => setAiCliTimeout(Number(e.target.value) || 1)}
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>AI Model</FieldLabel>
+              <Input
+                placeholder="Default model"
+                value={aiModel}
+                onChange={(e) => setAiModel(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Raw Prompt</FieldLabel>
+              <textarea
+                className="flex w-full rounded-md border border-border-default bg-surface-elevated px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-accent min-h-[80px] resize-y"
+                placeholder="Custom prompt to send to AI..."
+                value={rawPrompt}
+                onChange={(e) => setRawPrompt(e.target.value)}
+              />
+            </div>
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Peer Analysis */}
+          <Section
+            title="Peer Analysis"
+            dotColor="bg-signal-purple"
+            defaultOpen={enablePeers}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Enable peer review</span>
+              <Toggle checked={enablePeers} onChange={setEnablePeers} />
+            </div>
+            {enablePeers && (
+              <>
+                <div className="space-y-2">
+                  {peerConfigs.map((peer, i) => (
+                    <div
+                      key={i}
+                      className="bg-surface-elevated border border-border-default rounded-lg p-2.5 flex items-center gap-2"
+                    >
+                      <Select
+                        value={peer.ai_provider}
+                        onValueChange={(v) => {
+                          const next = [...peerConfigs]
+                          next[i] = { ...next[i], ai_provider: v }
+                          setPeerConfigs(next)
+                        }}
+                      >
+                        <SelectTrigger className="w-[120px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="claude">Claude</SelectItem>
+                          <SelectItem value="gemini">Gemini</SelectItem>
+                          <SelectItem value="cursor">Cursor</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        className="flex-1"
+                        placeholder="Model"
+                        value={peer.ai_model}
+                        onChange={(e) => {
+                          const next = [...peerConfigs]
+                          next[i] = { ...next[i], ai_model: e.target.value }
+                          setPeerConfigs(next)
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
+                        onClick={() => setPeerConfigs(peerConfigs.filter((_, j) => j !== i))}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
+                  onClick={() =>
+                    setPeerConfigs([...peerConfigs, { ai_provider: 'claude', ai_model: '' }])
+                  }
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add Peer
+                </button>
+                <div className="space-y-1.5">
+                  <FieldLabel>Max Rounds</FieldLabel>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={maxRounds}
+                    onChange={(e) => setMaxRounds(Number(e.target.value) || 1)}
+                    className="w-24"
+                  />
+                </div>
+              </>
+            )}
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Source Repositories */}
+          <Section title="Source Repositories" dotColor="bg-signal-green">
+            <div className="grid grid-cols-3 gap-3">
+              <div className="col-span-2 space-y-1.5">
+                <FieldLabel>Tests Repo URL</FieldLabel>
+                <Input
+                  placeholder="https://github.com/org/repo"
+                  value={testsRepoUrl}
+                  onChange={(e) => setTestsRepoUrl(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>Ref / Branch</FieldLabel>
+                <Input
+                  placeholder="main"
+                  value={testsRepoRef}
+                  onChange={(e) => setTestsRepoRef(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <FieldLabel>Additional Repositories</FieldLabel>
+              {additionalRepos.map((repo, i) => (
+                <div
+                  key={i}
+                  className="bg-surface-elevated border border-border-default rounded-lg p-2.5 space-y-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Input
+                      className="w-32"
+                      placeholder="Name"
+                      value={repo.name}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], name: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <Input
+                      className="flex-1"
+                      placeholder="URL"
+                      value={repo.url}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], url: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <Input
+                      className="w-24"
+                      placeholder="Ref"
+                      value={repo.ref}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], ref: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
+                      onClick={() =>
+                        setAdditionalRepos(additionalRepos.filter((_, j) => j !== i))
+                      }
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
+                onClick={() =>
+                  setAdditionalRepos([...additionalRepos, { name: '', url: '', ref: '' }])
+                }
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add Repository
+              </button>
+            </div>
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Jira Integration */}
+          <Section title="Jira Integration" dotColor="bg-signal-orange">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Enable Jira search</span>
+              <Toggle checked={enableJira} onChange={setEnableJira} />
+            </div>
+            {enableJira && (
+              <>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <FieldLabel>Jira URL</FieldLabel>
+                    <Input
+                      placeholder="https://jira.example.com"
+                      value={jiraUrl}
+                      onChange={(e) => setJiraUrl(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <FieldLabel>Project Key</FieldLabel>
+                    <Input
+                      placeholder="PROJ"
+                      value={jiraProjectKey}
+                      onChange={(e) => setJiraProjectKey(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <p className="text-[11px] text-text-tertiary">
+                  🔒 Credentials from original analysis will be reused securely.
+                </p>
+              </>
+            )}
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Jenkins Artifacts */}
+          <Section title="Jenkins Artifacts" dotColor="bg-[#58a6ff]">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Fetch build artifacts</span>
+              <Toggle checked={getArtifacts} onChange={setGetArtifacts} />
+            </div>
+            {getArtifacts && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <FieldLabel>Max Size (MB)</FieldLabel>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={maxArtifactsSize}
+                    onChange={(e) => setMaxArtifactsSize(Number(e.target.value) || 1)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <FieldLabel>Context Lines</FieldLabel>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={contextLines}
+                    onChange={(e) => setContextLines(Number(e.target.value) || 1)}
+                  />
+                </div>
+              </div>
+            )}
+          </Section>
+        </div>
+
+        <DialogFooter className="px-6 py-4 border-t border-border-default flex-shrink-0">
+          {error && <p className="text-signal-red text-xs mr-auto">{error}</p>}
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting} className="gap-1.5">
+            <RotateCw className={`h-3.5 w-3.5 ${submitting ? 'animate-spin' : ''}`} />
+            Re-Analyze
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -60,10 +60,13 @@ function Section({
   )
 }
 
-function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label: string }) {
   return (
     <button
       type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
       onClick={() => onChange(!checked)}
       className={`relative w-11 h-6 rounded-full transition-colors ${
         checked ? 'bg-signal-blue' : 'bg-surface-hover'
@@ -82,48 +85,58 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   return <label className="text-xs text-text-tertiary">{children}</label>
 }
 
-export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyzeDialogProps) {
-  const navigate = useNavigate()
-  const params = result.request_params
-
-  const [aiProvider, setAiProvider] = useState(params?.ai_provider || 'claude')
-  const [aiModel, setAiModel] = useState(params?.ai_model || '')
-  const [aiCliTimeout, setAiCliTimeout] = useState<number>(
-    (params?.ai_cli_timeout as number) || 10,
-  )
-  const [rawPrompt, setRawPrompt] = useState((params?.raw_prompt as string) || '')
-
-  const [enablePeers, setEnablePeers] = useState(!!(params?.peer_ai_configs?.length))
-  const [peerConfigs, setPeerConfigs] = useState<AiConfig[]>(params?.peer_ai_configs || [])
-  const [maxRounds, setMaxRounds] = useState(params?.peer_analysis_max_rounds || 3)
-
-  const [testsRepoUrl, setTestsRepoUrl] = useState(params?.tests_repo_url || '')
-  const [testsRepoRef, setTestsRepoRef] = useState(params?.tests_repo_ref || '')
-  const [additionalRepos, setAdditionalRepos] = useState<
-    Array<{ name: string; url: string; ref: string }>
-  >(
-    (params?.additional_repos || []).map((r) => ({
+function initFormState(p: AnalysisResult['request_params']) {
+  return {
+    aiProvider: p?.ai_provider || 'claude',
+    aiModel: p?.ai_model || '',
+    aiCliTimeout: (p?.ai_cli_timeout as number) || 10,
+    rawPrompt: (p?.raw_prompt as string) || '',
+    enablePeers: !!(p?.peer_ai_configs?.length),
+    peerConfigs: p?.peer_ai_configs || [],
+    maxRounds: p?.peer_analysis_max_rounds || 3,
+    testsRepoUrl: p?.tests_repo_url || '',
+    testsRepoRef: p?.tests_repo_ref || '',
+    additionalRepos: (p?.additional_repos || []).map((r) => ({
       name: r.name,
       url: r.url,
       ref: r.ref || '',
     })),
-  )
+    enableJira: (p?.enable_jira as boolean) !== false,
+    jiraUrl: (p?.jira_url as string) || '',
+    jiraProjectKey: (p?.jira_project_key as string) || '',
+    getArtifacts: (p?.get_job_artifacts as boolean) !== false,
+    maxArtifactsSize: (p?.jenkins_artifacts_max_size_mb as number) || 50,
+    contextLines: (p?.jenkins_artifacts_context_lines as number) || 100,
+  }
+}
 
-  const [enableJira, setEnableJira] = useState((params?.enable_jira as boolean) !== false)
-  const [jiraUrl, setJiraUrl] = useState((params?.jira_url as string) || '')
-  const [jiraProjectKey, setJiraProjectKey] = useState(
-    (params?.jira_project_key as string) || '',
-  )
+export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyzeDialogProps) {
+  const navigate = useNavigate()
+  const params = result.request_params
 
-  const [getArtifacts, setGetArtifacts] = useState(
-    (params?.get_job_artifacts as boolean) !== false,
-  )
-  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number>(
-    (params?.jenkins_artifacts_max_size_mb as number) || 50,
-  )
-  const [contextLines, setContextLines] = useState<number>(
-    (params?.jenkins_artifacts_context_lines as number) || 100,
-  )
+  const init = initFormState(params)
+  const [aiProvider, setAiProvider] = useState(init.aiProvider)
+  const [aiModel, setAiModel] = useState(init.aiModel)
+  const [aiCliTimeout, setAiCliTimeout] = useState<number>(init.aiCliTimeout)
+  const [rawPrompt, setRawPrompt] = useState(init.rawPrompt)
+
+  const [enablePeers, setEnablePeers] = useState(init.enablePeers)
+  const [peerConfigs, setPeerConfigs] = useState<AiConfig[]>(init.peerConfigs)
+  const [maxRounds, setMaxRounds] = useState(init.maxRounds)
+
+  const [testsRepoUrl, setTestsRepoUrl] = useState(init.testsRepoUrl)
+  const [testsRepoRef, setTestsRepoRef] = useState(init.testsRepoRef)
+  const [additionalRepos, setAdditionalRepos] = useState<
+    Array<{ name: string; url: string; ref: string }>
+  >(init.additionalRepos)
+
+  const [enableJira, setEnableJira] = useState(init.enableJira)
+  const [jiraUrl, setJiraUrl] = useState(init.jiraUrl)
+  const [jiraProjectKey, setJiraProjectKey] = useState(init.jiraProjectKey)
+
+  const [getArtifacts, setGetArtifacts] = useState(init.getArtifacts)
+  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number>(init.maxArtifactsSize)
+  const [contextLines, setContextLines] = useState<number>(init.contextLines)
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -131,29 +144,23 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
   // Reset form state when dialog opens
   useEffect(() => {
     if (!open) return
-    const p = result.request_params
-    setAiProvider(p?.ai_provider || 'claude')
-    setAiModel(p?.ai_model || '')
-    setAiCliTimeout((p?.ai_cli_timeout as number) || 10)
-    setRawPrompt((p?.raw_prompt as string) || '')
-    setEnablePeers(!!(p?.peer_ai_configs?.length))
-    setPeerConfigs(p?.peer_ai_configs || [])
-    setMaxRounds(p?.peer_analysis_max_rounds || 3)
-    setTestsRepoUrl(p?.tests_repo_url || '')
-    setTestsRepoRef(p?.tests_repo_ref || '')
-    setAdditionalRepos(
-      (p?.additional_repos || []).map((r) => ({
-        name: r.name,
-        url: r.url,
-        ref: r.ref || '',
-      })),
-    )
-    setEnableJira((p?.enable_jira as boolean) !== false)
-    setJiraUrl((p?.jira_url as string) || '')
-    setJiraProjectKey((p?.jira_project_key as string) || '')
-    setGetArtifacts((p?.get_job_artifacts as boolean) !== false)
-    setMaxArtifactsSize((p?.jenkins_artifacts_max_size_mb as number) || 50)
-    setContextLines((p?.jenkins_artifacts_context_lines as number) || 100)
+    const s = initFormState(result.request_params)
+    setAiProvider(s.aiProvider)
+    setAiModel(s.aiModel)
+    setAiCliTimeout(s.aiCliTimeout)
+    setRawPrompt(s.rawPrompt)
+    setEnablePeers(s.enablePeers)
+    setPeerConfigs(s.peerConfigs)
+    setMaxRounds(s.maxRounds)
+    setTestsRepoUrl(s.testsRepoUrl)
+    setTestsRepoRef(s.testsRepoRef)
+    setAdditionalRepos(s.additionalRepos)
+    setEnableJira(s.enableJira)
+    setJiraUrl(s.jiraUrl)
+    setJiraProjectKey(s.jiraProjectKey)
+    setGetArtifacts(s.getArtifacts)
+    setMaxArtifactsSize(s.maxArtifactsSize)
+    setContextLines(s.contextLines)
     setSubmitting(false)
     setError('')
   }, [open, result.request_params])
@@ -173,8 +180,9 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
         jenkins_artifacts_max_size_mb: maxArtifactsSize,
         jenkins_artifacts_context_lines: contextLines,
         raw_prompt: rawPrompt || undefined,
-        tests_repo_url: testsRepoUrl || undefined,
-        tests_repo_ref: testsRepoRef || undefined,
+        tests_repo_url: testsRepoUrl
+          ? (testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl)
+          : undefined,
         peer_ai_configs: enablePeers ? peerConfigs : [],
         peer_analysis_max_rounds: maxRounds,
         additional_repos: additionalRepos
@@ -284,7 +292,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           >
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Enable peer review</span>
-              <Toggle checked={enablePeers} onChange={setEnablePeers} />
+              <Toggle checked={enablePeers} onChange={setEnablePeers} label="Enable peer review" />
             </div>
             {enablePeers && (
               <>
@@ -447,7 +455,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           <Section title="Jira Integration" dotColor="bg-signal-orange">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Enable Jira search</span>
-              <Toggle checked={enableJira} onChange={setEnableJira} />
+              <Toggle checked={enableJira} onChange={setEnableJira} label="Enable Jira search" />
             </div>
             {enableJira && (
               <>
@@ -482,7 +490,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           <Section title="Jenkins Artifacts" dotColor="bg-[#58a6ff]">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Fetch build artifacts</span>
-              <Toggle checked={getArtifacts} onChange={setGetArtifacts} />
+              <Toggle checked={getArtifacts} onChange={setGetArtifacts} label="Fetch build artifacts" />
             </div>
             {getArtifacts && (
               <div className="grid grid-cols-2 gap-3">

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -89,7 +89,7 @@ function initFormState(p: AnalysisResult['request_params']) {
   return {
     aiProvider: p?.ai_provider || 'claude',
     aiModel: p?.ai_model || '',
-    aiCliTimeout: (p?.ai_cli_timeout as number) || 10,
+    aiCliTimeout: p?.ai_cli_timeout != null ? (p.ai_cli_timeout as number) : undefined,
     rawPrompt: (p?.raw_prompt as string) || '',
     enablePeers: !!(p?.peer_ai_configs?.length),
     peerConfigs: p?.peer_ai_configs || [],
@@ -101,12 +101,12 @@ function initFormState(p: AnalysisResult['request_params']) {
       url: r.url,
       ref: r.ref || '',
     })),
-    enableJira: (p?.enable_jira as boolean) !== false,
+    enableJira: p?.enable_jira != null ? (p.enable_jira as boolean) : undefined,
     jiraUrl: (p?.jira_url as string) || '',
     jiraProjectKey: (p?.jira_project_key as string) || '',
-    getArtifacts: (p?.get_job_artifacts as boolean) !== false,
-    maxArtifactsSize: (p?.jenkins_artifacts_max_size_mb as number) || 50,
-    contextLines: (p?.jenkins_artifacts_context_lines as number) || 100,
+    getArtifacts: p?.get_job_artifacts != null ? (p.get_job_artifacts as boolean) : undefined,
+    maxArtifactsSize: p?.jenkins_artifacts_max_size_mb != null ? (p.jenkins_artifacts_max_size_mb as number) : undefined,
+    contextLines: p?.jenkins_artifacts_context_lines != null ? (p.jenkins_artifacts_context_lines as number) : undefined,
   }
 }
 
@@ -117,7 +117,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
   const init = initFormState(params)
   const [aiProvider, setAiProvider] = useState(init.aiProvider)
   const [aiModel, setAiModel] = useState(init.aiModel)
-  const [aiCliTimeout, setAiCliTimeout] = useState<number>(init.aiCliTimeout)
+  const [aiCliTimeout, setAiCliTimeout] = useState<number | undefined>(init.aiCliTimeout)
   const [rawPrompt, setRawPrompt] = useState(init.rawPrompt)
 
   const [enablePeers, setEnablePeers] = useState(init.enablePeers)
@@ -130,13 +130,13 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
     Array<{ name: string; url: string; ref: string }>
   >(init.additionalRepos)
 
-  const [enableJira, setEnableJira] = useState(init.enableJira)
+  const [enableJira, setEnableJira] = useState<boolean | undefined>(init.enableJira)
   const [jiraUrl, setJiraUrl] = useState(init.jiraUrl)
   const [jiraProjectKey, setJiraProjectKey] = useState(init.jiraProjectKey)
 
-  const [getArtifacts, setGetArtifacts] = useState(init.getArtifacts)
-  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number>(init.maxArtifactsSize)
-  const [contextLines, setContextLines] = useState<number>(init.contextLines)
+  const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(init.getArtifacts)
+  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(init.maxArtifactsSize)
+  const [contextLines, setContextLines] = useState<number | undefined>(init.contextLines)
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -169,20 +169,18 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
     setSubmitting(true)
     setError('')
     try {
-      const overrides: Record<string, unknown> = {
+      const body: Record<string, unknown> = {
         ai_provider: aiProvider,
         ai_model: aiModel,
-        ai_cli_timeout: aiCliTimeout,
-        enable_jira: enableJira,
-        jira_url: jiraUrl || undefined,
-        jira_project_key: jiraProjectKey || undefined,
-        get_job_artifacts: getArtifacts,
-        jenkins_artifacts_max_size_mb: maxArtifactsSize,
-        jenkins_artifacts_context_lines: contextLines,
-        raw_prompt: rawPrompt || undefined,
-        tests_repo_url: testsRepoUrl
-          ? (testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl)
-          : undefined,
+        ...(aiCliTimeout !== undefined && { ai_cli_timeout: aiCliTimeout }),
+        ...(enableJira !== undefined && { enable_jira: enableJira }),
+        ...(jiraUrl && { jira_url: jiraUrl }),
+        ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
+        ...(getArtifacts !== undefined && { get_job_artifacts: getArtifacts }),
+        ...(maxArtifactsSize !== undefined && { jenkins_artifacts_max_size_mb: maxArtifactsSize }),
+        ...(contextLines !== undefined && { jenkins_artifacts_context_lines: contextLines }),
+        ...(rawPrompt && { raw_prompt: rawPrompt }),
+        ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
         peer_ai_configs: enablePeers ? peerConfigs : [],
         peer_analysis_max_rounds: maxRounds,
         additional_repos: additionalRepos
@@ -190,12 +188,9 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           .map((r) => ({
             name: r.name,
             url: r.url,
-            ref: r.ref || undefined,
+            ...(r.ref && { ref: r.ref }),
           })),
       }
-      const body = Object.fromEntries(
-        Object.entries(overrides).filter(([, v]) => v !== undefined),
-      )
       const data = await api.post<{ job_id: string }>(`/re-analyze/${jobId}`, body)
       onOpenChange(false)
       navigate(`/results/${data.job_id}`)
@@ -258,8 +253,9 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
                 <Input
                   type="number"
                   min={1}
-                  value={aiCliTimeout}
-                  onChange={(e) => setAiCliTimeout(Number(e.target.value) || 1)}
+                  value={aiCliTimeout ?? ''}
+                  placeholder="10"
+                  onChange={(e) => setAiCliTimeout(e.target.value ? Number(e.target.value) || 1 : undefined)}
                 />
               </div>
             </div>
@@ -455,7 +451,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           <Section title="Jira Integration" dotColor="bg-signal-orange">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Enable Jira search</span>
-              <Toggle checked={enableJira} onChange={setEnableJira} label="Enable Jira search" />
+              <Toggle checked={enableJira ?? true} onChange={setEnableJira} label="Enable Jira search" />
             </div>
             {enableJira && (
               <>
@@ -490,7 +486,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
           <Section title="Jenkins Artifacts" dotColor="bg-[#58a6ff]">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Fetch build artifacts</span>
-              <Toggle checked={getArtifacts} onChange={setGetArtifacts} label="Fetch build artifacts" />
+              <Toggle checked={getArtifacts ?? true} onChange={setGetArtifacts} label="Fetch build artifacts" />
             </div>
             {getArtifacts && (
               <div className="grid grid-cols-2 gap-3">
@@ -499,8 +495,9 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
                   <Input
                     type="number"
                     min={1}
-                    value={maxArtifactsSize}
-                    onChange={(e) => setMaxArtifactsSize(Number(e.target.value) || 1)}
+                    value={maxArtifactsSize ?? ''}
+                    placeholder="50"
+                    onChange={(e) => setMaxArtifactsSize(e.target.value ? Number(e.target.value) || 1 : undefined)}
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -508,8 +505,9 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
                   <Input
                     type="number"
                     min={1}
-                    value={contextLines}
-                    onChange={(e) => setContextLines(Number(e.target.value) || 1)}
+                    value={contextLines ?? ''}
+                    placeholder="100"
+                    onChange={(e) => setContextLines(e.target.value ? Number(e.target.value) || 1 : undefined)}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -18,6 +18,7 @@ interface ReportState {
   error: string
   /** Number of comment editors with non-empty text (pauses comment polling when > 0). */
   commentDraftCount: number
+  reAnalyzeOpen: boolean
   /** Incremented on every optimistic local mutation (ADD_COMMENT, REMOVE_COMMENT, SET_REVIEW)
    *  so that in-flight poll responses can detect stale data and skip overwriting. */
   localMutationRev: number
@@ -38,6 +39,7 @@ type ReportAction =
   | { type: 'SET_ERROR'; payload: string }
   | { type: 'INCREMENT_DRAFT_COUNT' }
   | { type: 'DECREMENT_DRAFT_COUNT' }
+  | { type: 'SET_RE_ANALYZE_OPEN'; payload: boolean }
   | {
       type: 'OVERRIDE_CLASSIFICATION'
       payload: {
@@ -64,6 +66,7 @@ const initialState: ReportState = {
   loading: true,
   error: '',
   commentDraftCount: 0,
+  reAnalyzeOpen: false,
   localMutationRev: 0,
 }
 
@@ -97,6 +100,8 @@ function reportReducer(state: ReportState, action: ReportAction): ReportState {
       return { ...state, commentDraftCount: state.commentDraftCount + 1 }
     case 'DECREMENT_DRAFT_COUNT':
       return { ...state, commentDraftCount: Math.max(0, state.commentDraftCount - 1) }
+    case 'SET_RE_ANALYZE_OPEN':
+      return { ...state, reAnalyzeOpen: action.payload }
     case 'OVERRIDE_CLASSIFICATION': {
       if (!state.result) return state
       const { testName, testNames: explicitNames, classification, childJobName, childBuildNumber } = action.payload

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     proxy: {
       '/api': BACKEND_URL,
       '/analyze': BACKEND_URL,
+      '/re-analyze': BACKEND_URL,
       '/results': createSpaProxy(),
       '/history': createSpaProxy(),
       '/status': createSpaProxy(),

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -153,6 +153,22 @@ class JJIClient:
             accept_statuses=(202,),
         )
 
+    def re_analyze(self, job_id: str) -> dict:
+        """Re-analyze a previously analyzed job with the same settings. POST /re-analyze/{job_id}
+
+        Args:
+            job_id: Job ID of the original analysis to re-run.
+
+        Returns:
+            Queued status with new job_id for polling.
+        """
+        return self._request(
+            "POST",
+            f"/re-analyze/{job_id}",
+            json={},
+            accept_statuses=(202,),
+        )
+
     # -- History --------------------------------------------------------------
 
     def get_test_history(

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -723,17 +723,12 @@ def re_analyze_cmd(
     json_output: bool = _JSON_OPTION,
 ):
     """Re-analyze a previously analyzed job with the same settings."""
-    _set_json(json_output)
-
-    try:
-        client = _get_client()
-        data = client.re_analyze(job_id)
-    except JJIError as err:
-        _handle_error(err)
-
-    if _state.get("json", False):
-        print_output(data, columns=[], as_json=True)
-    else:
+    data = _run_client_command(
+        json_output,
+        lambda c: c.re_analyze(job_id),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
         typer.echo(f"Re-analysis queued: {data.get('job_id', '')}")
         typer.echo(f"Status: {data.get('status', '')}")
         typer.echo(f"Poll: {data.get('result_url', '')}")

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -717,6 +717,28 @@ def analyze(
         typer.echo(f"Poll: {data.get('result_url', '')}")
 
 
+@app.command("re-analyze")
+def re_analyze_cmd(
+    job_id: str = typer.Argument(help="Job ID of the analysis to re-run."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Re-analyze a previously analyzed job with the same settings."""
+    _set_json(json_output)
+
+    try:
+        client = _get_client()
+        data = client.re_analyze(job_id)
+    except JJIError as err:
+        _handle_error(err)
+
+    if _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
+    else:
+        typer.echo(f"Re-analysis queued: {data.get('job_id', '')}")
+        typer.echo(f"Status: {data.get('status', '')}")
+        typer.echo(f"Poll: {data.get('result_url', '')}")
+
+
 # -- Status -------------------------------------------------------------------
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1354,6 +1354,91 @@ async def analyze_failures(
         repo_manager.cleanup()
 
 
+@app.post("/re-analyze/{job_id}", status_code=202, response_model=None)
+async def re_analyze(
+    job_id: str,
+    request: Request,
+    body: BaseAnalysisRequest,
+    background_tasks: BackgroundTasks,
+) -> dict:
+    """Re-analyze a previously analyzed job with the same (or overridden) settings.
+
+    Loads stored request_params from the original analysis, applies any
+    overrides from the request body, and queues a new analysis with a
+    fresh job_id.
+    """
+    base_url = _extract_base_url()
+
+    # Load the original result (with sensitive fields for credential reuse)
+    stored = await get_result(job_id, strip_sensitive=False)
+    if not stored or not stored.get("result"):
+        raise HTTPException(status_code=404, detail=f"Result {job_id} not found")
+
+    result_data = stored["result"]
+    if "request_params" not in result_data:
+        raise HTTPException(
+            status_code=400,
+            detail="Original analysis has no stored request_params; cannot re-analyze",
+        )
+
+    # Reconstruct the original AnalyzeRequest + Settings
+    try:
+        original_body, original_settings = _reconstruct_from_params(result_data)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to reconstruct original request: {exc}",
+        )
+
+    # Apply overrides from request body onto the reconstructed request
+    # For each non-None field in the override body, set it on original_body
+    for field_name in body.model_fields_set:
+        setattr(original_body, field_name, getattr(body, field_name))
+
+    # Re-merge settings with overrides applied
+    merged = _merge_settings(original_body, original_settings)
+
+    # Validate AI config and peers
+    _resolve_ai_config(original_body)
+    resolved_peers = _validate_peer_configs(original_body, merged)
+
+    # Generate new job_id
+    new_job_id = str(uuid.uuid4())
+
+    jenkins_url = build_jenkins_url(
+        merged.jenkins_url, original_body.job_name, original_body.build_number
+    )
+
+    initial_result: dict = {
+        "job_name": original_body.job_name,
+        "build_number": original_body.build_number,
+        "request_params": _build_request_params(
+            original_body,
+            merged,
+            original_body.ai_provider or AI_PROVIDER,
+            original_body.ai_model or AI_MODEL,
+            peer_ai_configs_resolved=resolved_peers,
+        ),
+    }
+    can_resume_wait = merged.wait_for_completion and bool(merged.jenkins_url)
+    await save_result(
+        new_job_id,
+        jenkins_url,
+        "waiting" if can_resume_wait else "pending",
+        initial_result,
+    )
+    background_tasks.add_task(
+        process_analysis_with_id, new_job_id, original_body, merged
+    )
+
+    response: dict = {
+        "status": "queued",
+        "job_id": new_job_id,
+        "message": f"Re-analysis job queued. Poll /results/{new_job_id} for status.",
+    }
+    return _attach_result_links(response, base_url, new_job_id)
+
+
 @app.get("/results/{job_id}", response_model=None)
 async def get_job_result(request: Request, job_id: str, response: Response):
     """Retrieve stored result by job_id, or serve SPA for browser requests."""

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1079,37 +1079,24 @@ def _build_request_params(
     return encrypt_sensitive_fields(params)
 
 
-@app.post("/analyze", status_code=202, response_model=None)
-async def analyze(
-    request: Request,
+async def _enqueue_analysis_job(
     body: AnalyzeRequest,
+    merged: Settings,
+    resolved_peers: list | None,
     background_tasks: BackgroundTasks,
+    base_url: str,
     *,
-    settings: Settings = Depends(get_settings),
+    message_prefix: str = "Analysis",
 ) -> dict:
-    """Submit a Jenkins job for analysis.
+    """Create, save, and enqueue a new analysis job.
 
-    Returns immediately with a job_id. Poll /results/{job_id} for status.
+    Shared by ``/analyze`` and ``/re-analyze`` to avoid duplicating
+    job setup, persistence, and response shaping.
     """
-    logger.debug(f"Starting analysis for {body.job_name} #{body.build_number}")
-    base_url = _extract_base_url()
-
-    # Validate AI config early -- fail fast before queuing invalid jobs.
-    _resolve_ai_config(body)
-
-    # Generate job_id here so we can return it to the client for polling
     job_id = str(uuid.uuid4())
-    merged = _merge_settings(body, settings)
-
-    # Validate peer configs early -- fail fast before returning 202.
-    resolved_peers = _validate_peer_configs(body, merged)
     jenkins_url = build_jenkins_url(
         merged.jenkins_url, body.job_name, body.build_number
     )
-    # Save initial pending state before queueing background task.
-    # request_params is always persisted so the status page can display
-    # AI provider/model and peer configs, and waiting jobs can resume
-    # after a server restart.
     initial_result: dict = {
         "job_name": body.job_name,
         "build_number": body.build_number,
@@ -1129,15 +1116,43 @@ async def analyze(
         initial_result,
     )
     background_tasks.add_task(process_analysis_with_id, job_id, body, merged)
-    message = f"Analysis job queued. Poll /results/{job_id} for status."
-
     response: dict = {
         "status": "queued",
         "job_id": job_id,
-        "message": message,
+        "message": f"{message_prefix} job queued. Poll /results/{job_id} for status.",
     }
-
     return _attach_result_links(response, base_url, job_id)
+
+
+@app.post("/analyze", status_code=202, response_model=None)
+async def analyze(
+    request: Request,
+    body: AnalyzeRequest,
+    background_tasks: BackgroundTasks,
+    *,
+    settings: Settings = Depends(get_settings),
+) -> dict:
+    """Submit a Jenkins job for analysis.
+
+    Returns immediately with a job_id. Poll /results/{job_id} for status.
+    """
+    logger.debug(f"Starting analysis for {body.job_name} #{body.build_number}")
+    base_url = _extract_base_url()
+
+    # Validate AI config early -- fail fast before queuing invalid jobs.
+    _resolve_ai_config(body)
+
+    merged = _merge_settings(body, settings)
+
+    # Validate peer configs early -- fail fast before returning 202.
+    resolved_peers = _validate_peer_configs(body, merged)
+    return await _enqueue_analysis_job(
+        body,
+        merged,
+        resolved_peers,
+        background_tasks,
+        base_url,
+    )
 
 
 @app.post("/analyze-failures", response_model=None)
@@ -1384,11 +1399,11 @@ async def re_analyze(
     # Reconstruct the original AnalyzeRequest + Settings
     try:
         original_body, original_settings = _reconstruct_from_params(result_data)
-    except Exception as exc:
+    except (ValueError, KeyError) as exc:
         raise HTTPException(
             status_code=400,
             detail=f"Failed to reconstruct original request: {exc}",
-        )
+        ) from exc
 
     # Apply overrides from request body onto the reconstructed request
     # For each non-None field in the override body, set it on original_body
@@ -1402,41 +1417,14 @@ async def re_analyze(
     _resolve_ai_config(original_body)
     resolved_peers = _validate_peer_configs(original_body, merged)
 
-    # Generate new job_id
-    new_job_id = str(uuid.uuid4())
-
-    jenkins_url = build_jenkins_url(
-        merged.jenkins_url, original_body.job_name, original_body.build_number
+    return await _enqueue_analysis_job(
+        original_body,
+        merged,
+        resolved_peers,
+        background_tasks,
+        base_url,
+        message_prefix="Re-analysis",
     )
-
-    initial_result: dict = {
-        "job_name": original_body.job_name,
-        "build_number": original_body.build_number,
-        "request_params": _build_request_params(
-            original_body,
-            merged,
-            original_body.ai_provider or AI_PROVIDER,
-            original_body.ai_model or AI_MODEL,
-            peer_ai_configs_resolved=resolved_peers,
-        ),
-    }
-    can_resume_wait = merged.wait_for_completion and bool(merged.jenkins_url)
-    await save_result(
-        new_job_id,
-        jenkins_url,
-        "waiting" if can_resume_wait else "pending",
-        initial_result,
-    )
-    background_tasks.add_task(
-        process_analysis_with_id, new_job_id, original_body, merged
-    )
-
-    response: dict = {
-        "status": "queued",
-        "job_id": new_job_id,
-        "message": f"Re-analysis job queued. Poll /results/{new_job_id} for status.",
-    }
-    return _attach_result_links(response, base_url, new_job_id)
 
 
 @app.get("/results/{job_id}", response_model=None)

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -777,3 +777,24 @@ class TestJJIClientAnalyzeExtras:
         client = _make_client(handler)
         result = client.analyze("my-job", 1)
         assert result["status"] == "queued"
+
+
+class TestJJIClientReAnalyze:
+    def test_re_analyze(self):
+        response_data = {
+            "status": "queued",
+            "job_id": "new-reanalysis-1",
+            "message": "Re-analysis job queued.",
+        }
+
+        def handler(request):
+            assert request.method == "POST"
+            assert "/re-analyze/old-job-1" in str(request.url)
+            body = json.loads(request.content)
+            assert body == {}
+            return httpx.Response(202, json=response_data)
+
+        client = _make_client(handler)
+        result = client.re_analyze("old-job-1")
+        assert result["status"] == "queued"
+        assert result["job_id"] == "new-reanalysis-1"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2026,3 +2026,37 @@ class TestAnalyzeWaitFlags:
         assert result.exit_code == 0
         kwargs = mock_client.analyze.call_args[1]
         assert "wait_for_completion" not in kwargs
+
+
+class TestReAnalyzeCommand:
+    def test_re_analyze(self, mock_client):
+        mock_client.re_analyze.return_value = {
+            "status": "queued",
+            "job_id": "new-1",
+            "result_url": "/results/new-1",
+        }
+        result = runner.invoke(app, ["re-analyze", "old-job-1"])
+        assert result.exit_code == 0
+        assert "new-1" in result.output
+        assert "queued" in result.output.lower()
+        mock_client.re_analyze.assert_called_once_with("old-job-1")
+
+    def test_re_analyze_json(self, mock_client):
+        mock_client.re_analyze.return_value = {
+            "status": "queued",
+            "job_id": "new-1",
+            "result_url": "/results/new-1",
+        }
+        result = runner.invoke(app, ["--json", "re-analyze", "old-job-1"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "queued"
+        assert parsed["job_id"] == "new-1"
+
+    def test_re_analyze_error(self, mock_client):
+        mock_client.re_analyze.side_effect = JJIError(
+            status_code=404, detail="Job not found"
+        )
+        result = runner.invoke(app, ["re-analyze", "nonexistent"])
+        assert result.exit_code != 0
+        assert "404" in result.output or "not found" in result.output.lower()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3773,3 +3773,65 @@ class TestRequestParamsPreservation:
         rp = result["request_params"]
         assert rp["ai_provider"] == "cursor"
         assert rp["ai_model"] == "test-model"
+
+
+class TestReAnalyzeEndpoint:
+    """Tests for POST /re-analyze/{job_id}."""
+
+    def test_re_analyze_not_found(self, test_client) -> None:
+        """Re-analyze returns 404 when job_id does not exist."""
+        response = test_client.post("/re-analyze/nonexistent", json={})
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_re_analyze_no_request_params(self, test_client) -> None:
+        """Re-analyze returns 400 when original has no request_params."""
+        from jenkins_job_insight import storage
+
+        # Save a result WITHOUT request_params
+        await storage.save_result(
+            "job-no-params",
+            "http://jenkins/job/test/1/",
+            "completed",
+            {"summary": "done", "failures": []},
+        )
+        response = test_client.post("/re-analyze/job-no-params", json={})
+        assert response.status_code == 400
+        assert "request_params" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_re_analyze_success(self, test_client) -> None:
+        """Re-analyze returns 202 with new job_id when original has request_params."""
+        from jenkins_job_insight import storage
+
+        # Save a result WITH request_params (mimicking a completed analysis)
+        result_data = {
+            "summary": "1 failure",
+            "job_name": "my-job",
+            "build_number": 42,
+            "failures": [],
+            "request_params": {
+                "job_name": "my-job",
+                "build_number": 42,
+                "ai_provider": "claude",
+                "ai_model": "opus",
+                "jenkins_url": "https://jenkins.example.com",
+                "jenkins_user": "testuser",
+                "jenkins_password": "testpw",  # pragma: allowlist secret
+            },
+        }
+        await storage.save_result(
+            "job-reanalyze-ok",
+            "http://jenkins/job/my-job/42/",
+            "completed",
+            result_data,
+        )
+        with patch("jenkins_job_insight.main.process_analysis_with_id"):
+            response = test_client.post("/re-analyze/job-reanalyze-ok", json={})
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "queued"
+        assert "job_id" in data
+        assert data["job_id"] != "job-reanalyze-ok"  # New job_id
+        assert "result_url" in data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ import pytest
 
 from jenkins_job_insight import storage
 from jenkins_job_insight.config import Settings
+from jenkins_job_insight.encryption import encrypt_sensitive_fields
 from jenkins_job_insight.models import (
     AiConfigEntry,
     AnalysisDetail,
@@ -3811,15 +3812,17 @@ class TestReAnalyzeEndpoint:
             "job_name": "my-job",
             "build_number": 42,
             "failures": [],
-            "request_params": {
-                "job_name": "my-job",
-                "build_number": 42,
-                "ai_provider": "claude",
-                "ai_model": "opus",
-                "jenkins_url": "https://jenkins.example.com",
-                "jenkins_user": "testuser",
-                "jenkins_password": "testpw",  # pragma: allowlist secret
-            },
+            "request_params": encrypt_sensitive_fields(
+                {
+                    "job_name": "my-job",
+                    "build_number": 42,
+                    "ai_provider": "claude",
+                    "ai_model": "opus",
+                    "jenkins_url": "https://jenkins.example.com",
+                    "jenkins_user": "testuser",
+                    "jenkins_password": "testpw",  # pragma: allowlist secret
+                }
+            ),
         }
         await storage.save_result(
             "job-reanalyze-ok",
@@ -3827,7 +3830,7 @@ class TestReAnalyzeEndpoint:
             "completed",
             result_data,
         )
-        with patch("jenkins_job_insight.main.process_analysis_with_id"):
+        with patch("jenkins_job_insight.main.process_analysis_with_id") as mock_process:
             response = test_client.post("/re-analyze/job-reanalyze-ok", json={})
         assert response.status_code == 202
         data = response.json()
@@ -3835,3 +3838,5 @@ class TestReAnalyzeEndpoint:
         assert "job_id" in data
         assert data["job_id"] != "job-reanalyze-ok"  # New job_id
         assert "result_url" in data
+        mock_process.assert_called_once()
+        assert data["result_url"].endswith(f"/results/{data['job_id']}")


### PR DESCRIPTION
## Summary

Adds a "Re-Analyze" button to the report page that opens a dialog pre-populated with the original analysis settings. Users can adjust settings before submitting, which creates a new analysis with a fresh job_id.

Closes #98

## Changes

### Backend
- New `POST /re-analyze/{job_id}` endpoint in `main.py`
  - Loads stored `request_params`, reconstructs original request via `_reconstruct_from_params()`
  - Accepts optional `BaseAnalysisRequest` overrides
  - Generates new `job_id`, queues analysis
  - Returns 202 with job_id for polling

### Frontend
- New `ReAnalyzeDialog` component (`pages/report/ReAnalyzeDialog.tsx`) with 5 collapsible sections:
  - AI Configuration (provider, model, timeout, raw prompt)
  - Peer Analysis (enable toggle, peer configs, max rounds)
  - Source Repositories (tests repo URL/ref, additional repos)
  - Jira Integration (enable toggle, URL, project key)
  - Jenkins Artifacts (download toggle, max size, context lines)
- Pre-populated from `result.request_params`
- On submit → redirects to new result page
- Uses Command Deck design system throughout
- Accessible: `role="switch"`, `aria-checked`, `aria-label` on toggles

### CLI
- `jji re-analyze <job_id>` command — pure re-analyze with same params
- `re_analyze()` client method in `cli/client.py`

### Other
- Added `.envrc` and `.claude/` to `.gitignore`

## Tests

- 3 API endpoint tests (404, 400, 202 success)
- 2 CLI command tests (text output, JSON output)
- 1 CLI client test (transport)
- 1 CLI error handling test
- Full suite: 938 backend + 67 frontend = **1005 tests pass**

## Peer Review

Peer reviewed with Cursor (2 rounds). Key findings addressed:
- Fixed `tests_repo_url`/`tests_repo_ref` split bug (ref was silently dropped)
- Eliminated duplicate form initialization (extracted `initFormState()`)
- Added toggle accessibility (aria attributes)

## Screenshots

A mockup was created and approved before implementation. The dialog matches the Command Deck design system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-Analyze: re-run a past analysis from the report header; opens a modal to edit AI, peer review, repos, Jira, and artifact options, submits re-analysis and navigates to the new result.

* **CLI**
  * Added a re-analyze command to queue re-analysis jobs and display queued job info (supports JSON output).

* **API**
  * Added POST /re-analyze to enqueue re-analysis requests based on stored results.

* **Frontend**
  * Added UI state and dev-server proxy support for re-analyze.

* **Tests**
  * Added tests for client, CLI, and re-analyze endpoint.

* **Chores**
  * Updated .gitignore with local config patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->