### PR TITLE
refactor: remove jenkins_artifacts_context_lines setting (#101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -106,7 +106,6 @@ function initFormState(p: AnalysisResult['request_params']) {
     jiraProjectKey: (p?.jira_project_key as string) || '',
     getArtifacts: p?.get_job_artifacts != null ? (p.get_job_artifacts as boolean) : undefined,
     maxArtifactsSize: p?.jenkins_artifacts_max_size_mb != null ? (p.jenkins_artifacts_max_size_mb as number) : undefined,
-    contextLines: p?.jenkins_artifacts_context_lines != null ? (p.jenkins_artifacts_context_lines as number) : undefined,
   }
 }
 
@@ -136,7 +135,6 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
 
   const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(init.getArtifacts)
   const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(init.maxArtifactsSize)
-  const [contextLines, setContextLines] = useState<number | undefined>(init.contextLines)
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -160,7 +158,6 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
     setJiraProjectKey(s.jiraProjectKey)
     setGetArtifacts(s.getArtifacts)
     setMaxArtifactsSize(s.maxArtifactsSize)
-    setContextLines(s.contextLines)
     setSubmitting(false)
     setError('')
   }, [open, result.request_params])
@@ -178,7 +175,6 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
         ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
         ...(getArtifacts !== undefined && { get_job_artifacts: getArtifacts }),
         ...(maxArtifactsSize !== undefined && { jenkins_artifacts_max_size_mb: maxArtifactsSize }),
-        ...(contextLines !== undefined && { jenkins_artifacts_context_lines: contextLines }),
         ...(rawPrompt && { raw_prompt: rawPrompt }),
         ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
         peer_ai_configs: enablePeers ? peerConfigs : [],
@@ -215,7 +211,6 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
     jiraProjectKey,
     getArtifacts,
     maxArtifactsSize,
-    contextLines,
     jobId,
     onOpenChange,
     navigate,
@@ -489,27 +484,15 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
               <Toggle checked={getArtifacts ?? true} onChange={setGetArtifacts} label="Fetch build artifacts" />
             </div>
             {getArtifacts && (
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <FieldLabel>Max Size (MB)</FieldLabel>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={maxArtifactsSize ?? ''}
-                    placeholder="50"
-                    onChange={(e) => setMaxArtifactsSize(e.target.value ? Number(e.target.value) || 1 : undefined)}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <FieldLabel>Context Lines</FieldLabel>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={contextLines ?? ''}
-                    placeholder="100"
-                    onChange={(e) => setContextLines(e.target.value ? Number(e.target.value) || 1 : undefined)}
-                  />
-                </div>
+              <div className="space-y-1.5">
+                <FieldLabel>Max Size (MB)</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  value={maxArtifactsSize ?? ''}
+                  placeholder="50"
+                  onChange={(e) => setMaxArtifactsSize(e.target.value ? Number(e.target.value) || 1 : undefined)}
+                />
               </div>
             )}
           </Section>

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -157,7 +157,7 @@ RETRYABLE_AI_CLI_PATTERNS: list[str] = [
 
 # Pattern for error detection in console output (word boundaries, case-insensitive)
 _CONSOLE_ERROR_PATTERN = re.compile(
-    r"\b(error|fail(ed|ure)?|exception|traceback|assert(ion)?|warn(ing)?|critical|fatal)\b",
+    r"\b(errors?|fail(?:ed|ures?)?|exceptions?|tracebacks?|assert(?:ion)?s?|warnings?|critical|fatal)\b",
     re.IGNORECASE,
 )
 

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -21,7 +21,6 @@ from simple_logger.logger import get_logger
 
 from jenkins_job_insight.config import Settings, parse_additional_repos, parse_repo_ref
 from jenkins_job_insight.jenkins_artifacts import (
-    ERROR_PATTERN,
     cleanup_extract_dir,
     process_build_artifacts,
 )
@@ -155,6 +154,12 @@ PROVIDER_CLI_FLAGS: dict[str, list[str]] = {
 RETRYABLE_AI_CLI_PATTERNS: list[str] = [
     "ENOENT: no such file or directory",  # Cursor CLI config race condition
 ]
+
+# Pattern for error detection in console output (word boundaries, case-insensitive)
+_CONSOLE_ERROR_PATTERN = re.compile(
+    r"\b(error|fail(ed|ure)?|exception|traceback|assert(ion)?|warn(ing)?|critical|fatal)\b",
+    re.IGNORECASE,
+)
 
 
 async def _call_ai_cli_with_retry(
@@ -573,7 +578,7 @@ def extract_relevant_console_lines(console_output: str) -> str:
 
     for i, line in enumerate(lines):
         # Check if line matches error pattern (word boundaries, case-insensitive)
-        if ERROR_PATTERN.search(line):
+        if _CONSOLE_ERROR_PATTERN.search(line):
             # Add some context: 2 lines before
             start = max(0, i - 2)
             for j in range(start, i):
@@ -1501,7 +1506,6 @@ async def analyze_job(
                         build_url,
                         artifacts,
                         settings.jenkins_artifacts_max_size_mb,
-                        settings.jenkins_artifacts_context_lines,
                     )
                 except Exception as exc:
                     logger.warning(f"Failed to process artifacts: {exc}")

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -157,7 +157,8 @@ RETRYABLE_AI_CLI_PATTERNS: list[str] = [
 
 # Pattern for error detection in console output (word boundaries, case-insensitive)
 _CONSOLE_ERROR_PATTERN = re.compile(
-    r"\b(errors?|fail(?:ed|ures?)?|exceptions?|tracebacks?|assert(?:ion)?s?|warnings?|critical|fatal)\b",
+    r"\b(?:errors?|fail(?:ed|ures?)?|tracebacks?|warn(?:ings?)?|critical|fatal|assert(?:ion)?(?:error)?s?)\b"
+    r"|(?:^|[\s\[])[A-Za-z_][\w.]*?(?:error|exception)(?=[:\s\]]|$)",
     re.IGNORECASE,
 )
 
@@ -268,12 +269,12 @@ def _build_artifacts_section(artifacts_context: str) -> str:
     return f"""
 
 === BUILD ARTIFACTS ===
-The following is a PREVIEW of build artifact contents. The full files are available at build-artifacts/ in your working directory.
+The following is a PREVIEW of the build-artifacts/ directory structure and file listing. File contents are not inlined here; open the files under build-artifacts/ in your working directory to inspect them.
 
 {artifacts_context}
 
 IMPORTANT INSTRUCTIONS FOR ARTIFACT ANALYSIS:
-1. READ the actual files under build-artifacts/ — the preview above is incomplete
+1. READ the actual files under build-artifacts/ — the listing above is incomplete and does not include file contents
 2. Look for error messages, stack traces, service logs, and status information
 3. In your artifacts_evidence field, include VERBATIM lines with the file path, e.g.: [build-artifacts/logs/app.log]: actual error line here
 4. Do NOT classify based solely on the test error message — check the artifact logs for the real root cause"""

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -459,11 +459,6 @@ def analyze(
         "--jenkins-artifacts-max-size-mb",
         help="Maximum Jenkins artifacts size in MB.",
     ),
-    jenkins_artifacts_context_lines: int = typer.Option(
-        None,
-        "--jenkins-artifacts-context-lines",
-        help="Maximum Jenkins artifacts context lines for AI prompt.",
-    ),
     get_job_artifacts: bool | None = typer.Option(
         None,
         "--get-job-artifacts/--no-get-job-artifacts",
@@ -547,7 +542,6 @@ def analyze(
         "--jira-max-results": jira_max_results,
         "--ai-cli-timeout": ai_cli_timeout,
         "--jenkins-artifacts-max-size-mb": jenkins_artifacts_max_size_mb,
-        "--jenkins-artifacts-context-lines": jenkins_artifacts_context_lines,
     }
     for flag_name, flag_value in _positive_int_fields.items():
         if flag_value is not None and flag_value <= 0:
@@ -649,7 +643,6 @@ def analyze(
         "jira_max_results": jira_max_results,
         "ai_cli_timeout": ai_cli_timeout,
         "jenkins_artifacts_max_size_mb": jenkins_artifacts_max_size_mb,
-        "jenkins_artifacts_context_lines": jenkins_artifacts_context_lines,
         "poll_interval_minutes": poll_interval,
         "max_wait_minutes": max_wait,
     }

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -160,7 +160,6 @@ class Settings(BaseSettings):
 
     # Jenkins artifacts configuration
     jenkins_artifacts_max_size_mb: int = Field(default=500, gt=0)
-    jenkins_artifacts_context_lines: int = Field(default=200, gt=0)
 
     # Artifact download toggle
     get_job_artifacts: bool = True

--- a/src/jenkins_job_insight/jenkins_artifacts.py
+++ b/src/jenkins_job_insight/jenkins_artifacts.py
@@ -2,7 +2,6 @@
 
 import io
 import os
-import re
 import shutil
 import tarfile
 import urllib.parse
@@ -16,12 +15,6 @@ from simple_logger.logger import get_logger
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
 EXTRACT_BASE = Path("/tmp/jenkins-insight")
-
-# Pre-compiled pattern for error detection with word boundaries
-ERROR_PATTERN = re.compile(
-    r"\b(error|fail(ed|ure)?|exception|traceback|assert(ion)?|warn(ing)?|critical|fatal)\b",
-    re.IGNORECASE,
-)
 
 # Maximum ratio of extracted size to compressed size. Typical compression ratios
 # for Jenkins artifacts (logs, YAML, JSON) range from 3-8x; 10x provides safe
@@ -317,18 +310,12 @@ def validate_and_extract_archive(
     return extract_dir
 
 
-def _discover_files(
-    extract_path: Path,
-) -> tuple[list[Path], list[Path], list[Path], list[tuple[str, int]]]:
-    """Discover and classify files in extracted archive.
+def _discover_files(extract_path: Path) -> list[tuple[str, int]]:
+    """Discover files in extracted archive.
 
     Returns:
-        Tuple of (log_files, event_files, yaml_json_files, all_files).
-        all_files contains (relative_path, size_in_bytes) tuples.
+        List of (relative_path, size_in_bytes) tuples.
     """
-    log_files: list[Path] = []
-    yaml_json_files: list[Path] = []
-    event_files: list[Path] = []
     all_files: list[tuple[str, int]] = []
 
     for file_path in extract_path.rglob("*"):
@@ -340,95 +327,21 @@ def _discover_files(
         except OSError:
             size = 0
         all_files.append((relative, size))
-        name_lower = file_path.name.lower()
-        if (
-            name_lower.endswith((".log", ".txt"))
-            or "/logs/" in relative
-            or "/log/" in relative
-        ):
-            log_files.append(file_path)
-        elif name_lower.endswith((".yaml", ".yml", ".json")):
-            if "event" in name_lower or "event" in relative.lower():
-                event_files.append(file_path)
-            else:
-                yaml_json_files.append(file_path)
 
-    return log_files, event_files, yaml_json_files, all_files
+    return all_files
 
 
-def _extract_error_lines(
-    log_files: list[Path], extract_path: Path, seen: set[str]
-) -> list[str]:
-    """Extract deduplicated error/warning lines from log files."""
-    lines: list[str] = []
-    for log_file in log_files:
-        try:
-            text = log_file.read_text(errors="replace")
-            name = str(log_file.relative_to(extract_path))
-            for line in text.splitlines():
-                if ERROR_PATTERN.search(line):
-                    key = line.strip()
-                    if key not in seen:
-                        seen.add(key)
-                        lines.append(f"[{name}]: {line.rstrip()}")
-        except OSError:
-            continue
-    return lines
-
-
-def _extract_event_lines(event_files: list[Path], extract_path: Path) -> list[str]:
-    """Extract warning event lines from event files."""
-    lines: list[str] = []
-    for event_file in event_files:
-        try:
-            text = event_file.read_text(errors="replace")
-            name = str(event_file.relative_to(extract_path))
-            for line in text.splitlines():
-                if "Warning" in line or "warning" in line:
-                    lines.append(f"[{name}]: {line.rstrip()}")
-        except OSError:
-            continue
-    return lines
-
-
-def _extract_status_issues(
-    yaml_json_files: list[Path], extract_path: Path, seen: set[str]
-) -> list[str]:
-    """Extract error/status lines from YAML/JSON files."""
-    lines: list[str] = []
-    for resource_file in yaml_json_files:
-        try:
-            text = resource_file.read_text(errors="replace")
-            name = str(resource_file.relative_to(extract_path))
-            for line in text.splitlines():
-                if ERROR_PATTERN.search(line):
-                    key = line.strip()
-                    if key not in seen:
-                        seen.add(key)
-                        lines.append(f"[{name}]: {line.strip()}")
-        except OSError:
-            continue
-    return lines
-
-
-def build_artifacts_context(extract_path: Path, max_lines: int = 1000) -> str:
+def build_artifacts_context(extract_path: Path) -> str:
     """Walk an extracted archive directory and build a structured artifacts summary."""
     logger.info(f"Building artifacts context from {extract_path}")
 
-    log_files, event_files, yaml_json_files, all_files = _discover_files(extract_path)
+    all_files = _discover_files(extract_path)
     total_size = sum(size for _, size in all_files)
     total_size_mb = total_size / (1024 * 1024)
 
     logger.info(
-        f"Archive file discovery: {len(all_files)} total files ({total_size_mb:.1f} MB), "
-        f"{len(log_files)} log files, {len(event_files)} event files, "
-        f"{len(yaml_json_files)} yaml/json files"
+        f"Archive file discovery: {len(all_files)} total files ({total_size_mb:.1f} MB)"
     )
-
-    seen_errors: set[str] = set()
-    error_lines = _extract_error_lines(log_files, extract_path, seen_errors)
-    event_lines = _extract_event_lines(event_files, extract_path)
-    status_issues = _extract_status_issues(yaml_json_files, extract_path, seen_errors)
 
     # Build the structured context
     sections: list[str] = [
@@ -438,26 +351,25 @@ def build_artifacts_context(extract_path: Path, max_lines: int = 1000) -> str:
         f"Contains {len(all_files)} files ({total_size_mb:.1f} MB total).",
         "",
         "IMPORTANT: You MUST explore the build-artifacts/ directory (or the absolute path above).",
-        "The summary below is only a preview. Read the actual files for full evidence.",
+        "The index below lists paths and sizes. Read files under the artifacts directory for full content.",
         "",
     ]
 
-    # Always show directory structure so AI knows what to explore
-    dirs = sorted(
-        {
-            str(Path(path).parent)
-            for path, _ in all_files
-            if str(Path(path).parent) != "."
-        }
-    )
-    if dirs:
+    # Aggregate per-directory stats in a single pass
+    dir_stats: dict[str, tuple[int, int]] = {}  # dir -> (count, total_size)
+    root_files: list[tuple[str, int]] = []
+    for path, size in all_files:
+        parent = str(Path(path).parent)
+        if parent == ".":
+            root_files.append((path, size))
+        else:
+            count, total = dir_stats.get(parent, (0, 0))
+            dir_stats[parent] = (count + 1, total + size)
+
+    if dir_stats or root_files:
         sections.append("--- Directory Structure ---")
-        for d in dirs:
-            # Count files in this directory
-            file_count = sum(1 for path, _ in all_files if str(Path(path).parent) == d)
-            dir_size = sum(
-                size for path, size in all_files if str(Path(path).parent) == d
-            )
+        for d in sorted(dir_stats):
+            file_count, dir_size = dir_stats[d]
             if dir_size >= 1024 * 1024:
                 sections.append(
                     f"  {d}/ ({file_count} files, {dir_size / (1024 * 1024):.1f} MB)"
@@ -468,10 +380,6 @@ def build_artifacts_context(extract_path: Path, max_lines: int = 1000) -> str:
                 )
             else:
                 sections.append(f"  {d}/ ({file_count} files, {dir_size} B)")
-        # Also list root-level files
-        root_files = [
-            (path, size) for path, size in all_files if str(Path(path).parent) == "."
-        ]
         if root_files:
             for path, size in root_files:
                 if size >= 1024:
@@ -480,42 +388,13 @@ def build_artifacts_context(extract_path: Path, max_lines: int = 1000) -> str:
                     sections.append(f"  {path} ({size} B)")
         sections.append("")
 
-    if error_lines:
-        sections.append("--- Error/Warning Lines from Logs ---")
-        sections.extend(error_lines)
-        sections.append("")
-
-    if event_lines:
-        sections.append("--- Warning Events ---")
-        sections.extend(event_lines)
-        sections.append("")
-
-    if status_issues:
-        sections.append("--- Abnormal Status Indicators ---")
-        sections.extend(status_issues)
-        sections.append("")
-
-    if not error_lines and not event_lines and not status_issues:
-        sections.append(
-            "No errors, warnings, or status issues found in build artifacts."
-        )
-        sections.append("")
-
-    if len(sections) > max_lines:
-        sections = sections[:max_lines]
-        sections.append("... [truncated to max_lines limit]")
-
     sections.append(f"--- Full artifacts available at: {extract_path} ---")
     sections.append(
         "Explore the build-artifacts/ directory (or current working directory) for complete evidence before classifying."
     )
 
     context = "\n".join(sections)
-    logger.info(
-        f"Artifacts context built: {len(error_lines)} error lines, "
-        f"{len(event_lines)} event lines, {len(status_issues)} status issues, "
-        f"total context: {len(context)} chars"
-    )
+    logger.info(f"Artifacts context built: {len(context)} chars")
     return context
 
 
@@ -524,7 +403,6 @@ def process_build_artifacts(
     build_url: str,
     artifact_list: list[dict],
     max_size_mb: int = 500,
-    max_context_lines: int = 1000,
 ) -> tuple[str, Path | None]:
     """Download, store, and analyze all build artifacts in a single pass.
 
@@ -536,7 +414,6 @@ def process_build_artifacts(
         build_url: Full Jenkins build URL (from API response).
         artifact_list: List of artifact dicts from Jenkins API.
         max_size_mb: Maximum allowed size per artifact in megabytes.
-        max_context_lines: Maximum lines in the context summary.
 
     Returns:
         Tuple of (context_string, artifacts_dir_or_None).
@@ -576,7 +453,7 @@ def process_build_artifacts(
         logger.info(
             f"Downloaded and stored {downloaded}/{len(artifact_list)} artifacts"
         )
-        context = build_artifacts_context(artifacts_dir, max_context_lines)
+        context = build_artifacts_context(artifacts_dir)
         return context, artifacts_dir
 
     except Exception:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -278,7 +278,6 @@ def _reconstruct_from_params(
         "jira_max_results",
         "ai_cli_timeout",
         "jenkins_artifacts_max_size_mb",
-        "jenkins_artifacts_context_lines",
         "get_job_artifacts",
         "peer_analysis_max_rounds",
     ]
@@ -639,7 +638,6 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
         "ai_cli_timeout",
         "enable_jira",
         "jenkins_artifacts_max_size_mb",
-        "jenkins_artifacts_context_lines",
         "get_job_artifacts",
     ]
     for field in direct_fields:
@@ -1069,7 +1067,6 @@ def _build_request_params(
             else "",
             "ai_cli_timeout": merged.ai_cli_timeout,
             "jenkins_artifacts_max_size_mb": merged.jenkins_artifacts_max_size_mb,
-            "jenkins_artifacts_context_lines": merged.jenkins_artifacts_context_lines,
             "get_job_artifacts": merged.get_job_artifacts,
             "raw_prompt": body.raw_prompt or "",
             "peer_analysis_max_rounds": merged.peer_analysis_max_rounds,

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -206,10 +206,6 @@ class AnalyzeRequest(BaseAnalysisRequest):
         default=None,
         description="Maximum Jenkins artifacts size in MB (overrides JENKINS_ARTIFACTS_MAX_SIZE_MB env var)",
     )
-    jenkins_artifacts_context_lines: Annotated[int, Field(gt=0)] | None = Field(
-        default=None,
-        description="Maximum Jenkins artifacts context lines for AI prompt (overrides JENKINS_ARTIFACTS_CONTEXT_LINES env var)",
-    )
     get_job_artifacts: bool | None = Field(
         default=None,
         description="Download all build artifacts for AI context (default: true, overrides GET_JOB_ARTIFACTS env var)",

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -692,7 +692,6 @@ class TestJJIClientAnalyzeExtras:
             "jenkins_password": "s3cret",  # pragma: allowlist secret
             "jenkins_ssl_verify": False,
             "jenkins_artifacts_max_size_mb": 50,
-            "jenkins_artifacts_context_lines": 200,
             "get_job_artifacts": True,
             "tests_repo_url": "https://github.com/org/tests",
             "jira_url": "https://jira.example.com",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -843,12 +843,6 @@ class TestAnalyzeAllOptions:
                 "jenkins_artifacts_max_size_mb",
                 50,
             ),
-            (
-                "--jenkins-artifacts-context-lines",
-                "200",
-                "jenkins_artifacts_context_lines",
-                200,
-            ),
         ],
     )
     def test_int_options(

--- a/tests/test_jenkins_artifacts.py
+++ b/tests/test_jenkins_artifacts.py
@@ -177,8 +177,8 @@ class TestExtractZip:
 class TestBuildArtifactsContext:
     """Tests for build_artifacts_context."""
 
-    def test_extracts_error_lines_from_logs(self, tmp_path: Path) -> None:
-        """Error and failure lines from .log files appear in context."""
+    def test_does_not_include_error_lines_in_context(self, tmp_path: Path) -> None:
+        """Context contains directory structure but not pre-extracted error lines."""
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
         log_file = log_dir / "app.log"
@@ -191,12 +191,14 @@ class TestBuildArtifactsContext:
 
         context = build_artifacts_context(tmp_path)
 
-        assert "Connection refused" in context
-        assert "FAILURE Something broke" in context
-        assert "Starting up" not in context
+        assert "BUILD ARTIFACTS CONTEXT" in context
+        assert "logs/" in context
+        # Error lines should NOT be pre-extracted into the context
+        assert "Connection refused" not in context
+        assert "FAILURE Something broke" not in context
 
-    def test_extracts_warning_events(self, tmp_path: Path) -> None:
-        """Warning lines from event files appear in the events section."""
+    def test_does_not_include_warning_events_in_context(self, tmp_path: Path) -> None:
+        """Context contains directory structure but not pre-extracted warning events."""
         event_dir = tmp_path / "cluster-scoped-resources"
         event_dir.mkdir(parents=True)
         event_file = event_dir / "events.yaml"
@@ -210,15 +212,14 @@ class TestBuildArtifactsContext:
 
         context = build_artifacts_context(tmp_path)
 
-        assert "Warning" in context
-        # Only lines containing "Warning" are extracted; the message line is not
-        assert "type: Warning" in context
-        # Normal events should not appear
-        assert "type: Normal" not in context
-        assert "Scheduled successfully" not in context
+        assert "BUILD ARTIFACTS CONTEXT" in context
+        assert "cluster-scoped-resources/" in context
+        # Warning events should NOT be pre-extracted
+        assert "Warning Events" not in context
+        assert "type: Warning" not in context
 
-    def test_detects_status_issues(self, tmp_path: Path) -> None:
-        """YAML files with error/failure keywords appear in abnormal status indicators."""
+    def test_does_not_include_status_issues_in_context(self, tmp_path: Path) -> None:
+        """Context contains directory structure but not pre-extracted status issues."""
         resource_dir = tmp_path / "namespaces" / "default"
         resource_dir.mkdir(parents=True)
         pod_file = resource_dir / "pods.yaml"
@@ -235,33 +236,33 @@ class TestBuildArtifactsContext:
 
         context = build_artifacts_context(tmp_path)
 
-        assert "Failed" in context
-        assert "Error pulling image" in context
-        assert "Abnormal Status Indicators" in context
+        assert "BUILD ARTIFACTS CONTEXT" in context
+        assert "namespaces/default/" in context
+        # Status issues should NOT be pre-extracted
+        assert "Abnormal Status Indicators" not in context
 
     def test_empty_directory_returns_note(self, tmp_path: Path) -> None:
-        """Empty directory returns the 'no issues found' note."""
+        """Empty directory still produces valid context with header."""
         context = build_artifacts_context(tmp_path)
 
-        assert "No errors, warnings, or status issues found" in context
+        assert "BUILD ARTIFACTS CONTEXT" in context
+        assert "Contains 0 files" in context
+        # The old "no issues found" message should not appear
+        assert "No errors, warnings, or status issues found" not in context
 
-    def test_max_lines_truncation(self, tmp_path: Path) -> None:
-        """Context is truncated when it exceeds max_lines."""
-        log_dir = tmp_path / "logs"
-        log_dir.mkdir()
-        log_file = log_dir / "big.log"
-        # Generate many error lines to exceed a small max_lines
-        lines = [f"ERROR failure number {i}\n" for i in range(200)]
-        log_file.write_text("".join(lines))
+    def test_root_only_files_listed_in_directory_structure(
+        self, tmp_path: Path
+    ) -> None:
+        """Root-level files with no subdirectories still produce a directory structure."""
+        (tmp_path / "build.log").write_text("some log content\n")
+        (tmp_path / "results.xml").write_text("<results/>\n")
 
-        max_lines = 10
-        context = build_artifacts_context(tmp_path, max_lines=max_lines)
+        context = build_artifacts_context(tmp_path)
 
-        assert "truncated" in context.lower()
-        # The total line count in the output should not greatly exceed max_lines
-        output_lines = context.splitlines()
-        # max_lines + truncation message + 2 footer lines + empty line
-        assert len(output_lines) <= max_lines + 4
+        assert "BUILD ARTIFACTS CONTEXT" in context
+        assert "Directory Structure" in context
+        assert "build.log" in context
+        assert "results.xml" in context
 
 
 class TestCleanupExtractDir:
@@ -466,8 +467,6 @@ class TestProcessBuildArtifacts:
         assert (artifacts_dir / "config.yaml").exists()
         # Context should contain artifacts output from the stored files
         assert "BUILD ARTIFACTS CONTEXT" in context
-        # The error line from the log should appear in context
-        assert "something failed" in context
 
         # Cleanup
         shutil.rmtree(artifacts_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Remove pre-fed artifact error/warning lines from AI prompt. The AI already gets the artifacts directory path and explores files itself, making the pre-extraction redundant and violating the project's "AI Tool Access" principle:

> Never pre-feed data to the AI in the prompt. Instead, give the AI tools and let it decide what data it needs and extract it itself.

## Changes

### Backend
- **`jenkins_artifacts.py`**: Simplified `build_artifacts_context()` to provide directory structure + file listing only (no pre-extracted error/warning/status lines). Removed `_extract_error_lines()`, `_extract_event_lines()`, `_extract_status_issues()` helpers and `ERROR_PATTERN` constant. Optimized directory listing from O(dirs × files) to single-pass aggregation. Fixed bug where root-level files weren't listed when no subdirectories exist.
- **`config.py`**: Removed `jenkins_artifacts_context_lines` from Settings
- **`models.py`**: Removed `jenkins_artifacts_context_lines` from AnalyzeRequest
- **`main.py`**: Removed from `_merge_settings()`, `_reconstruct_from_params()`, and `_build_request_params()`
- **`analyzer.py`**: Removed `max_context_lines` param from `process_build_artifacts()` call. Added local `_CONSOLE_ERROR_PATTERN` (was importing removed `ERROR_PATTERN` for console output extraction)
- **`cli/main.py`**: Removed `--jenkins-artifacts-context-lines` CLI flag

### Frontend
- **`ReAnalyzeDialog.tsx`**: Removed Context Lines field from Jenkins Artifacts section

### Tests
- Updated test assertions to verify error/warning lines are NOT in context
- Renamed misleading test methods (`test_extracts_*` → `test_does_not_include_*`)
- Added regression test for root-only files (no subdirs)
- Removed `jenkins_artifacts_context_lines` from CLI and client tests

### Other
- Added `AGENTS.md` symlink → `CLAUDE.md` (zero-duplication)

## Peer Review
Reviewed by Cursor AI (2 rounds). 5 findings addressed, all resolved.

## Tests
All 1004 tests pass (937 backend + 67 frontend).

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed "Context Lines" input from Jenkins Artifacts in the UI.
  * Removed `--jenkins-artifacts-context-lines` CLI option.
  * Removed `jenkins_artifacts_context_lines` configuration/setting and request parameter.

* **Behavior Changes**
  * Console error detection updated with broader matching.
  * Artifact analysis now reports file/index and directory structure only (no extracted log error/warning/status snippets).

* **Documentation**
  * Added CLAUDE.md to the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->