### PR TITLE
feat: User-level GitHub/Jira tokens for issue creation (#105)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ frontend/.vite/
 # Local config
 .envrc
 .claude/
+jji.db

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ProtectedRoute } from '@/components/shared/ProtectedRoute'
 import { RegisterPage } from '@/pages/RegisterPage'
 import { DashboardPage } from '@/pages/DashboardPage'
 import { StatusPage } from '@/pages/StatusPage'
+import { SettingsPage } from '@/pages/SettingsPage'
 import { HistoryPage } from '@/pages/HistoryPage'
 import { ReportPage } from '@/pages/ReportPage'
 import { TestHistoryPage } from '@/pages/TestHistoryPage'
@@ -22,6 +23,7 @@ export default function App() {
           <Route path="/history/test/:testName" element={<ProtectedRoute><TestHistoryPage /></ProtectedRoute>} />
           <Route path="/results/:jobId" element={<ProtectedRoute><ReportPage /></ProtectedRoute>} />
           <Route path="/status/:jobId" element={<ProtectedRoute><StatusPage /></ProtectedRoute>} />
+          <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/layout/UserBadge.tsx
+++ b/frontend/src/components/layout/UserBadge.tsx
@@ -1,15 +1,15 @@
 import { useNavigate } from 'react-router-dom'
-import { getUsername, clearUsername } from '@/lib/cookies'
-import { LogOut } from 'lucide-react'
+import { getUsername, clearUsername, clearTokens } from '@/lib/cookies'
+import { LogOut, Settings } from 'lucide-react'
 
 export function UserBadge() {
   const username = getUsername()
   const navigate = useNavigate()
-
   if (!username) return null
 
   function handleLogout() {
     clearUsername()
+    clearTokens()
     navigate('/register')
   }
 
@@ -17,13 +17,12 @@ export function UserBadge() {
     <div className="flex items-center gap-2 rounded-full bg-surface-elevated px-3 py-1 text-sm text-text-secondary">
       <div className="h-2 w-2 rounded-full bg-signal-green" />
       <span className="font-mono text-xs">{username}</span>
-      <button
-        type="button"
-        aria-label="Logout"
-        onClick={handleLogout}
-        className="ml-1 rounded-sm p-0.5 text-text-tertiary transition-colors hover:text-signal-red"
-        title="Logout"
-      >
+      <button type="button" aria-label="Settings" onClick={() => navigate('/settings')}
+        className="ml-1 rounded-sm p-0.5 text-text-tertiary transition-colors hover:text-signal-blue" title="Settings">
+        <Settings className="h-3 w-3" />
+      </button>
+      <button type="button" aria-label="Logout" onClick={handleLogout}
+        className="rounded-sm p-0.5 text-text-tertiary transition-colors hover:text-signal-red" title="Logout">
         <LogOut className="h-3 w-3" />
       </button>
     </div>

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -1,0 +1,234 @@
+import { useState, type FormEvent, type ReactNode } from 'react'
+import { api } from '@/lib/api'
+import {
+  setUsername,
+  setGithubToken,
+  setJiraToken,
+  setJiraEmail,
+  getUsername,
+  getGithubToken,
+  getJiraToken,
+  getJiraEmail,
+} from '@/lib/cookies'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Eye, EyeOff } from 'lucide-react'
+
+interface ProfileFormProps {
+  onSaved: () => void
+}
+
+interface TokenValidationResult {
+  valid: boolean
+  username: string
+  message: string
+}
+
+function TokenField({ id, label, value, onChange, show, onToggleShow, validation, placeholder, helpContent }: {
+  id: string
+  label: string
+  value: string
+  onChange: (value: string) => void
+  show: boolean
+  onToggleShow: () => void
+  validation: TokenValidationResult | null
+  placeholder: string
+  helpContent: ReactNode
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="block font-display text-xs font-medium uppercase tracking-widest text-text-secondary">
+        {label} <span className="text-text-tertiary font-normal normal-case tracking-normal">(optional)</span>
+      </label>
+      <div className="relative">
+        <Input id={id} type={show ? 'text' : 'password'} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} autoComplete="off" className="h-10 pr-10 font-mono" />
+        <button type="button" onClick={onToggleShow} className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-text-tertiary hover:text-text-secondary transition-colors" aria-label={show ? 'Hide token' : 'Show token'}>
+          {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
+      </div>
+      {validation && (
+        <p className={`text-xs ${validation.valid ? 'text-signal-green' : 'text-signal-red'}`}>{validation.message}</p>
+      )}
+      <p className="text-xs text-text-tertiary">{helpContent}</p>
+    </div>
+  )
+}
+
+export function ProfileForm({ onSaved }: ProfileFormProps) {
+  const [username, setUsernameValue] = useState(getUsername())
+  const [githubToken, setGithubTokenValue] = useState(getGithubToken())
+  const [jiraEmail, setJiraEmailValue] = useState(getJiraEmail())
+  const [jiraToken, setJiraTokenValue] = useState(getJiraToken())
+  const [showGithubToken, setShowGithubToken] = useState(false)
+  const [showJiraToken, setShowJiraToken] = useState(false)
+  const [validatingGithub, setValidatingGithub] = useState(false)
+  const [validatingJira, setValidatingJira] = useState(false)
+  const [githubValidation, setGithubValidation] = useState<TokenValidationResult | null>(null)
+  const [jiraValidation, setJiraValidation] = useState<TokenValidationResult | null>(null)
+
+  const [saving, setSaving] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const trimmed = username.trim()
+    if (!trimmed) return
+
+    const needsGithubValidation = githubToken.trim() && (!githubValidation || !githubValidation.valid)
+    const needsJiraValidation = jiraToken.trim() && (!jiraValidation || !jiraValidation.valid)
+
+    if (needsGithubValidation || needsJiraValidation) {
+      setSaving(true)
+      const validations = await Promise.allSettled([
+        needsGithubValidation ? validateGithub() : Promise.resolve(),
+        needsJiraValidation ? validateJira() : Promise.resolve(),
+      ])
+      setSaving(false)
+
+      // Check if any validation failed — block save
+      const results = validations.map((r) => r.status === 'fulfilled' ? r.value : false)
+      // validateGithub/validateJira return true if valid, false if invalid
+      if (needsGithubValidation && results[0] === false) return
+      if (needsJiraValidation && results[1] === false) return
+    }
+
+    setUsername(trimmed)
+    setGithubToken(githubToken.trim())
+    setJiraEmail(jiraEmail.trim())
+    setJiraToken(jiraToken.trim())
+    onSaved()
+  }
+
+  async function validateToken(
+    tokenType: 'github' | 'jira',
+    payload: Record<string, string>,
+    setValidating: (v: boolean) => void,
+    setValidation: (r: TokenValidationResult | null) => void,
+  ): Promise<boolean> {
+    setValidating(true)
+    setValidation(null)
+    try {
+      const result = await api.post<TokenValidationResult>('/api/validate-token', {
+        token_type: tokenType,
+        ...payload,
+      })
+      setValidation(result)
+      return result.valid
+    } catch {
+      setValidation({ valid: false, username: '', message: 'Validation request failed' })
+      return false
+    } finally {
+      setValidating(false)
+    }
+  }
+
+  function validateGithub(): Promise<boolean> {
+    return validateToken('github', { token: githubToken.trim() }, setValidatingGithub, setGithubValidation)
+  }
+
+  function validateJira(): Promise<boolean> {
+    const email = jiraEmail.trim()
+    return validateToken('jira', email ? { token: jiraToken.trim(), email } : { token: jiraToken.trim() }, setValidatingJira, setJiraValidation)
+  }
+
+  return (
+    <Card className="border-border-muted">
+      <CardContent className="p-5">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <fieldset disabled={saving || validatingGithub || validatingJira} className="space-y-4">
+          {/* Username field */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="username"
+              className="block font-display text-xs font-medium uppercase tracking-widest text-text-secondary"
+            >
+              Username
+            </label>
+            <Input
+              id="username"
+              value={username}
+              onChange={(e) => setUsernameValue(e.target.value)}
+              placeholder="e.g. jdoe"
+              autoFocus
+              autoComplete="username"
+              className="h-10 font-mono"
+            />
+          </div>
+
+          {/* Divider */}
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-px flex-1 bg-border-muted" />
+            <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
+              Tracker Tokens
+            </span>
+            <div className="h-px flex-1 bg-border-muted" />
+          </div>
+          <p className="text-xs text-text-tertiary">
+            Provide your personal tokens to create issues and bugs directly
+            under your name. Without tokens, you can still preview generated
+            content but cannot submit.
+          </p>
+
+          {/* GitHub Token field */}
+          <TokenField
+            id="github-token"
+            label="GitHub Token"
+            value={githubToken}
+            onChange={(v) => { setGithubTokenValue(v); setGithubValidation(null) }}
+            show={showGithubToken}
+            onToggleShow={() => setShowGithubToken(!showGithubToken)}
+            validation={githubValidation}
+            placeholder="ghp_..."
+            helpContent={<>Personal Access Token with{' '}<code className="text-text-secondary">repo</code> scope.{' '}<a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">Generate token →</a></>}
+          />
+
+          {/* Jira Email + Token fields */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="jira-email"
+              className="block font-display text-xs font-medium uppercase tracking-widest text-text-secondary"
+            >
+              Jira Email{' '}
+              <span className="text-text-tertiary font-normal normal-case tracking-normal">
+                (optional)
+              </span>
+            </label>
+            <Input
+              id="jira-email"
+              type="email"
+              value={jiraEmail}
+              onChange={(e) => {
+                setJiraEmailValue(e.target.value)
+                setJiraValidation(null)
+              }}
+              placeholder="e.g. jdoe@company.com"
+              autoComplete="email"
+              className="h-10 font-mono"
+            />
+            <p className="text-xs text-text-tertiary">
+              Required for Jira Cloud authentication. Use the same email as
+              your Atlassian account.
+            </p>
+          </div>
+
+          <TokenField
+            id="jira-token"
+            label="Jira Token"
+            value={jiraToken}
+            onChange={(v) => { setJiraTokenValue(v); setJiraValidation(null) }}
+            show={showJiraToken}
+            onToggleShow={() => setShowJiraToken(!showJiraToken)}
+            validation={jiraValidation}
+            placeholder="Token..."
+            helpContent={<>Jira Cloud: API token from{' '}<a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">Atlassian account →</a>{' '}· Jira Server/DC: Personal Access Token</>}
+          />
+
+          <Button type="submit" className="w-full" disabled={!username.trim() || saving || validatingGithub || validatingJira}>
+            {saving ? 'Validating tokens...' : 'Save'}
+          </Button>
+          </fieldset>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/lib/__tests__/cookies.test.ts
+++ b/frontend/src/lib/__tests__/cookies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getUsername, setUsername, isLoggedIn } from '../cookies'
+import { getUsername, setUsername, isLoggedIn, getGithubToken, setGithubToken, getJiraToken, setJiraToken, getJiraEmail, setJiraEmail, clearTokens } from '../cookies'
 
 describe('cookies', () => {
   beforeEach(() => {
@@ -8,6 +8,8 @@ describe('cookies', () => {
       const name = c.split('=')[0].trim()
       if (name) document.cookie = `${name}=; max-age=0; path=/`
     })
+    // Clear localStorage
+    localStorage.clear()
   })
 
   it('getUsername returns empty when no cookie set', () => {
@@ -31,5 +33,43 @@ describe('cookies', () => {
   it('isLoggedIn returns true after setUsername', () => {
     setUsername('user1')
     expect(isLoggedIn()).toBe(true)
+  })
+
+  // --- Token helpers ---
+
+  describe.each([
+    { label: 'GitHub token', get: getGithubToken, set: setGithubToken, value: 'ghp_abc123' },
+    { label: 'Jira token', get: getJiraToken, set: setJiraToken, value: 'jira_token_xyz' },
+    { label: 'Jira email', get: getJiraEmail, set: setJiraEmail, value: 'user@example.com' },
+  ])('$label helper', ({ get, set, value }) => {
+    it('returns empty when unset', () => {
+      expect(get()).toBe('')
+    })
+
+    it('stores and retrieves value', () => {
+      set(value)
+      expect(get()).toBe(value)
+    })
+
+    it('removes value when set to empty string', () => {
+      set(value)
+      set('')
+      expect(get()).toBe('')
+    })
+
+    it('trims whitespace before storing', () => {
+      set(`  ${value}  `)
+      expect(get()).toBe(value)
+    })
+  })
+
+  it('clearTokens removes all tokens and email', () => {
+    setGithubToken('ghp_abc')
+    setJiraToken('jira_xyz')
+    setJiraEmail('user@example.com')
+    clearTokens()
+    expect(getGithubToken()).toBe('')
+    expect(getJiraToken()).toBe('')
+    expect(getJiraEmail()).toBe('')
   })
 })

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -1,4 +1,7 @@
 const COOKIE_NAME = 'jji_username'
+const GITHUB_TOKEN_KEY = 'jji_github_token'
+const JIRA_TOKEN_KEY = 'jji_jira_token'
+const JIRA_EMAIL_KEY = 'jji_jira_email'
 
 export function getUsername(): string {
   const match = document.cookie.match(
@@ -9,7 +12,6 @@ export function getUsername(): string {
 
 export function setUsername(username: string): void {
   const encoded = encodeURIComponent(username.trim())
-  // 1 year expiry, path=/ so all routes can read it
   document.cookie = `${COOKIE_NAME}=${encoded}; path=/; max-age=${365 * 24 * 60 * 60}; SameSite=Lax`
 }
 
@@ -19,4 +21,59 @@ export function clearUsername(): void {
 
 export function isLoggedIn(): boolean {
   return getUsername() !== ''
+}
+
+function readStoredValue(key: string): string {
+  try {
+    return localStorage.getItem(key) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function writeStoredValue(key: string, value: string): void {
+  try {
+    const trimmed = value.trim()
+    if (trimmed) {
+      localStorage.setItem(key, trimmed)
+    } else {
+      localStorage.removeItem(key)
+    }
+  } catch {
+    // Storage unavailable — silently ignore
+  }
+}
+
+export function getGithubToken(): string {
+  return readStoredValue(GITHUB_TOKEN_KEY)
+}
+
+export function setGithubToken(token: string): void {
+  writeStoredValue(GITHUB_TOKEN_KEY, token)
+}
+
+export function getJiraToken(): string {
+  return readStoredValue(JIRA_TOKEN_KEY)
+}
+
+export function setJiraToken(token: string): void {
+  writeStoredValue(JIRA_TOKEN_KEY, token)
+}
+
+export function getJiraEmail(): string {
+  return readStoredValue(JIRA_EMAIL_KEY)
+}
+
+export function setJiraEmail(email: string): void {
+  writeStoredValue(JIRA_EMAIL_KEY, email)
+}
+
+export function clearTokens(): void {
+  try {
+    localStorage.removeItem(GITHUB_TOKEN_KEY)
+    localStorage.removeItem(JIRA_TOKEN_KEY)
+    localStorage.removeItem(JIRA_EMAIL_KEY)
+  } catch {
+    // Storage unavailable — silently ignore
+  }
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,92 +1,32 @@
-import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { setUsername } from '@/lib/cookies'
-import { Card, CardContent } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
+import { ProfileForm } from '@/components/shared/ProfileForm'
 
 export function RegisterPage() {
-  const [value, setValue] = useState('')
   const navigate = useNavigate()
-
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    const trimmed = value.trim()
-    if (!trimmed) return
-    setUsername(trimmed)
-    navigate('/')
-  }
 
   return (
     <div className="relative flex min-h-screen items-center justify-center bg-surface-page overflow-hidden">
       {/* Ambient grid */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.03]"
-        style={{
-          backgroundImage:
-            'linear-gradient(rgba(56,139,253,.4) 1px, transparent 1px), linear-gradient(90deg, rgba(56,139,253,.4) 1px, transparent 1px)',
-          backgroundSize: '48px 48px',
-        }}
-      />
-
+      <div className="pointer-events-none absolute inset-0 opacity-[0.03]" style={{backgroundImage: 'linear-gradient(rgba(56,139,253,.4) 1px, transparent 1px), linear-gradient(90deg, rgba(56,139,253,.4) 1px, transparent 1px)', backgroundSize: '48px 48px'}} />
       {/* Radial glow behind card */}
       <div className="pointer-events-none absolute left-1/2 top-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-signal-blue/[0.04] blur-3xl" />
-
-      <div className="relative z-10 w-full max-w-sm px-4">
+      <div className="relative z-10 w-full max-w-md px-4">
         {/* Logo / Title block */}
         <div className="mb-8 animate-slide-up text-center">
           <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg border border-border-default bg-surface-card">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="text-signal-blue">
-              <path
-                d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
+              <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </div>
-          <h1 className="font-display text-xl font-bold tracking-tight text-text-primary">
-            Jenkins Job Insight
-          </h1>
-          <p className="mt-1 text-sm text-text-tertiary">
-            Identify yourself to continue
-          </p>
+          <h1 className="font-display text-xl font-bold tracking-tight text-text-primary">Jenkins Job Insight</h1>
+          <p className="mt-1 text-sm text-text-tertiary">Set up your profile to continue</p>
         </div>
-
-        {/* Card */}
-        <Card className="animate-slide-up border-border-muted [animation-delay:80ms] [animation-fill-mode:backwards]">
-          <CardContent className="p-5">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <label
-                  htmlFor="username"
-                  className="block font-display text-xs font-medium uppercase tracking-widest text-text-secondary"
-                >
-                  Callsign
-                </label>
-                <Input
-                  id="username"
-                  value={value}
-                  onChange={(e) => setValue(e.target.value)}
-                  placeholder="e.g. jdoe"
-                  autoFocus
-                  autoComplete="username"
-                  className="h-10 font-mono"
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={!value.trim()}>
-                Enter Command Deck
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-
-        {/* Subtle footer */}
+        {/* Form */}
+        <div className="animate-slide-up [animation-delay:80ms] [animation-fill-mode:backwards]">
+          <ProfileForm onSaved={() => navigate('/')} />
+        </div>
         <p className="mt-6 animate-slide-up text-center text-xs text-text-tertiary [animation-delay:160ms] [animation-fill-mode:backwards]">
-          Your callsign is stored as a browser cookie.
-          <br />
-          No account or password required.
+          Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.<br />No account or password required.
         </p>
       </div>
     </div>

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -172,8 +172,8 @@ function ReportContent() {
 
         // Use capabilities from the result response (job-scoped, avoids separate call)
         if (resultRes.capabilities) {
-          dispatch({ type: 'SET_GITHUB_AVAILABLE', payload: resultRes.capabilities.github_issues })
-          dispatch({ type: 'SET_JIRA_AVAILABLE', payload: resultRes.capabilities.jira_bugs })
+          dispatch({ type: 'SET_GITHUB_ISSUES_ENABLED', payload: resultRes.capabilities?.github_issues_enabled ?? false })
+          dispatch({ type: 'SET_JIRA_ISSUES_ENABLED', payload: resultRes.capabilities?.jira_issues_enabled ?? false })
         }
 
         // Initial comment fetch via the shared single-flight helper
@@ -193,10 +193,15 @@ function ReportContent() {
         }
         if (classificationsResult.status === 'fulfilled') {
           const classMap: Record<string, string> = {}
-          for (const c of classificationsResult.value.classifications ?? []) {
+          const sorted = [...(classificationsResult.value.classifications ?? [])]
+            .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+          for (const c of sorted) {
             // Use composite key to handle same test_name across different child jobs
             const key = reviewKey(c.test_name, c.job_name, c.child_build_number)
-            classMap[key] = c.classification
+            // API returns newest first — only keep the latest classification per key
+            if (!(key in classMap)) {
+              classMap[key] = c.classification
+            }
           }
           dispatch({ type: 'SET_CLASSIFICATIONS', payload: classMap })
         }
@@ -390,7 +395,7 @@ function ReportContent() {
           <div className="ml-auto flex items-center gap-3">
             {result.request_params && (
               <Button
-                variant="outline"
+                variant="ghost"
                 size="sm"
                 className="gap-1.5 text-xs"
                 onClick={() => dispatch({ type: 'SET_RE_ANALYZE_OPEN', payload: true })}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom'
+import { ProfileForm } from '@/components/shared/ProfileForm'
+
+export function SettingsPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="mb-6 font-display text-lg font-bold tracking-tight text-text-primary">Settings</h1>
+      <ProfileForm onSaved={() => navigate('/')} />
+      <p className="mt-4 text-center text-xs text-text-tertiary">
+        Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { CheckCircle2, ExternalLink, AlertTriangle } from 'lucide-react'
 import type { PreviewIssueResponse, CreateIssueResponse, SimilarIssue, CommentsAndReviews } from '@/types'
+import { getGithubToken, getJiraToken, getJiraEmail } from '@/lib/cookies'
 import { useReportDispatch, useRefreshEnrichments } from './ReportContext'
 
 type BugTarget = 'github' | 'jira'
@@ -57,6 +58,15 @@ export function BugCreationDialog({
   const previewPath = target === 'github' ? 'preview-github-issue' : 'preview-jira-bug'
   const createPath = target === 'github' ? 'create-github-issue' : 'create-jira-bug'
   const label = target === 'github' ? 'GitHub Issue' : 'Jira Bug'
+  const hasToken = target === 'github' ? !!getGithubToken() : !!getJiraToken()
+
+  function getTrackerCredentials() {
+    return {
+      github_token: target === 'github' ? getGithubToken() : '',
+      jira_token: target === 'jira' ? getJiraToken() : '',
+      jira_email: target === 'jira' ? getJiraEmail() : '',
+    }
+  }
 
   // Load preview when dialog opens
   useEffect(() => {
@@ -70,6 +80,7 @@ export function BugCreationDialog({
         ai_model: aiModel ?? '',
         child_job_name: childJobName ?? '',
         child_build_number: childBuildNumber ?? 0,
+        ...getTrackerCredentials(),
       })
       .then((res) => {
         setTitle(res.title)
@@ -92,6 +103,7 @@ export function BugCreationDialog({
         body,
         child_job_name: childJobName ?? '',
         child_build_number: childBuildNumber ?? 0,
+        ...getTrackerCredentials(),
       })
       setCreatedUrl(res.url)
       setPhase('success')
@@ -203,18 +215,26 @@ export function BugCreationDialog({
         {phase === 'error' && (
           <div className="flex flex-col items-center gap-4 py-8">
             <p className="text-sm text-signal-red">{errorMsg}</p>
+            {errorMsg.toLowerCase().includes('token') && errorMsg.toLowerCase().includes('invalid') && (
+              <p className="text-xs text-text-tertiary">You can update your tokens in <a href="/settings" className="text-text-link hover:underline">settings</a>.</p>
+            )}
           </div>
         )}
 
-        <DialogFooter>
+        <DialogFooter className="flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-between">
           {phase === 'preview' && (
             <>
-              <Button variant="ghost" onClick={handleClose}>Cancel</Button>
-              <Button onClick={handleCreate} disabled={!title.trim()}>Create {label}</Button>
+              {!hasToken && (
+                <p className="text-xs text-text-tertiary">Add a {target === 'github' ? 'GitHub' : 'Jira'} token in <a href="/settings" className="text-text-link hover:underline">settings</a> to create directly.</p>
+              )}
+              <div className="flex gap-2 sm:ml-auto">
+                <Button variant="ghost" onClick={handleClose}>Cancel</Button>
+                <Button onClick={handleCreate} disabled={!title.trim() || !hasToken} title={!hasToken ? `Add a ${target === 'github' ? 'GitHub' : 'Jira'} token to create issues` : undefined}>Create {label}</Button>
+              </div>
             </>
           )}
           {(phase === 'success' || phase === 'error') && (
-            <Button variant="ghost" onClick={handleClose}>Close</Button>
+            <Button variant="ghost" onClick={handleClose} className="sm:ml-auto">Close</Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -18,6 +18,20 @@ import { ClassificationSelect } from './ClassificationSelect'
 import { BugCreationDialog } from './BugCreationDialog'
 import { ChevronDown, ChevronRight, Bug, MessageSquare, CheckCircle2, Copy, Check, Clock } from 'lucide-react'
 
+function IssueButton({ disabled, tooltip, label, onClick }: {
+  disabled: boolean
+  tooltip: string | undefined
+  label: string
+  onClick: () => void
+}) {
+  const button = (
+    <Button variant="outline" size="sm" onClick={onClick} disabled={disabled}>
+      <Bug className="h-3.5 w-3.5 mr-1" /> {label}
+    </Button>
+  )
+  return tooltip ? <span title={tooltip} className="inline-flex">{button}</span> : button
+}
+
 function CopyableSectionHeader({ title, content, sectionId, copiedSection, onCopy, extra }: {
   title: string
   content: string
@@ -56,7 +70,7 @@ interface FailureCardProps {
 export function FailureCard({ group, jobId, childJobName, childBuildNumber, index }: FailureCardProps) {
   const scopedChildJobName = childJobName ?? ''
   const scopedChildBuildNumber = childBuildNumber ?? 0
-  const { githubAvailable, jiraAvailable, comments, reviews, aiConfigs, result, classifications } = useReportState()
+  const { githubIssuesEnabled, jiraIssuesEnabled, comments, reviews, aiConfigs, result, classifications } = useReportState()
   const dispatch = useReportDispatch()
   const expandKey = `jji-expand-${jobId}-${scopedChildJobName}-${scopedChildBuildNumber}-${group.id}`
   const [expanded, setExpanded] = useSessionState(expandKey, false)
@@ -116,11 +130,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const repKey = scopedReviewKey(rep.test_name)
   const classification = classifications[repKey] ?? analysis.classification
   const borderColor = classification === 'PRODUCT BUG' ? 'border-l-signal-orange' : 'border-l-signal-blue'
-  const issueCreationAvailable =
-    group.count === 1 &&
-    ((classification === 'PRODUCT BUG' && jiraAvailable) ||
-      (classification !== 'PRODUCT BUG' && githubAvailable))
-  const showAiSelector = (providers.length > 0 || models.length > 0) && issueCreationAvailable
+  const showAiSelector = providers.length > 0 || models.length > 0
 
   // Comment count for ALL tests in the group
   const groupTestNames = group.tests.map((t) => t.test_name)
@@ -412,7 +422,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   </div>
                 </>
               )}
-              {issueCreationAvailable && (
+              {(showAiSelector || githubIssuesEnabled || jiraIssuesEnabled) && (
                 <label className="flex items-center gap-1.5 text-xs text-text-secondary cursor-pointer">
                   <input
                     type="checkbox"
@@ -423,16 +433,18 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   Include links
                 </label>
               )}
-              {group.count === 1 && classification !== 'PRODUCT BUG' && githubAvailable && (
-                <Button variant="outline" size="sm" onClick={() => setBugTarget('github')}>
-                  <Bug className="h-3.5 w-3.5 mr-1" /> GitHub Issue
-                </Button>
-              )}
-              {group.count === 1 && classification === 'PRODUCT BUG' && jiraAvailable && (
-                <Button variant="outline" size="sm" onClick={() => setBugTarget('jira')}>
-                  <Bug className="h-3.5 w-3.5 mr-1" /> Jira Bug
-                </Button>
-              )}
+              <IssueButton
+                disabled={!githubIssuesEnabled}
+                tooltip={!githubIssuesEnabled ? 'GitHub issues are disabled on this server' : undefined}
+                label="GitHub Issue"
+                onClick={() => setBugTarget('github')}
+              />
+              <IssueButton
+                disabled={!jiraIssuesEnabled}
+                tooltip={!jiraIssuesEnabled ? 'Jira issues are disabled on this server' : undefined}
+                label="Jira Bug"
+                onClick={() => setBugTarget('jira')}
+              />
             </div>
 
             {/* Comments */}
@@ -441,7 +453,8 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
         )}
       </Card>
 
-      {group.count === 1 && bugTarget && (
+      {/* For grouped failures, the dialog creates an issue for the representative test (first in group) */}
+      {bugTarget && (
         <BugCreationDialog
           open={bugTarget !== null}
           onOpenChange={(o) => { if (!o) setBugTarget(null) }}

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -11,8 +11,8 @@ interface ReportState {
   reviews: Record<string, ReviewState>
   enrichments: Record<string, CommentEnrichment[]>
   classifications: Record<string, string>
-  githubAvailable: boolean
-  jiraAvailable: boolean
+  githubIssuesEnabled: boolean
+  jiraIssuesEnabled: boolean
   aiConfigs: AiConfig[]
   loading: boolean
   error: string
@@ -30,8 +30,8 @@ type ReportAction =
   | { type: 'ADD_COMMENT'; payload: Comment }
   | { type: 'REMOVE_COMMENT'; payload: number }
   | { type: 'SET_REVIEW'; payload: { key: string; state: ReviewState } }
-  | { type: 'SET_GITHUB_AVAILABLE'; payload: boolean }
-  | { type: 'SET_JIRA_AVAILABLE'; payload: boolean }
+  | { type: 'SET_GITHUB_ISSUES_ENABLED'; payload: boolean }
+  | { type: 'SET_JIRA_ISSUES_ENABLED'; payload: boolean }
   | { type: 'SET_AI_CONFIGS'; payload: AiConfig[] }
   | { type: 'SET_ENRICHMENTS'; payload: Record<string, CommentEnrichment[]> }
   | { type: 'SET_CLASSIFICATIONS'; payload: Record<string, string> }
@@ -60,8 +60,8 @@ const initialState: ReportState = {
   reviews: {},
   enrichments: {},
   classifications: {},
-  githubAvailable: false,
-  jiraAvailable: false,
+  githubIssuesEnabled: false,
+  jiraIssuesEnabled: false,
   aiConfigs: [],
   loading: true,
   error: '',
@@ -82,10 +82,10 @@ function reportReducer(state: ReportState, action: ReportAction): ReportState {
       return { ...state, comments: state.comments.filter((c) => c.id !== action.payload), localMutationRev: state.localMutationRev + 1 }
     case 'SET_REVIEW':
       return { ...state, reviews: { ...state.reviews, [action.payload.key]: action.payload.state }, localMutationRev: state.localMutationRev + 1 }
-    case 'SET_GITHUB_AVAILABLE':
-      return { ...state, githubAvailable: action.payload }
-    case 'SET_JIRA_AVAILABLE':
-      return { ...state, jiraAvailable: action.payload }
+    case 'SET_GITHUB_ISSUES_ENABLED':
+      return { ...state, githubIssuesEnabled: action.payload }
+    case 'SET_JIRA_ISSUES_ENABLED':
+      return { ...state, jiraIssuesEnabled: action.payload }
     case 'SET_AI_CONFIGS':
       return { ...state, aiConfigs: action.payload }
     case 'SET_ENRICHMENTS':

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -246,7 +246,14 @@ export interface ResultResponse {
   analysis_started_at?: string | null
   base_url: string | null
   result_url: string | null
-  capabilities?: { github_issues: boolean; jira_bugs: boolean }
+  capabilities?: {
+    github_issues_enabled: boolean
+    jira_issues_enabled: boolean
+    server_github_token?: boolean
+    server_jira_token?: boolean
+    server_jira_email?: boolean
+    server_jira_project_key?: boolean
+  }
 }
 
 // -- Comment enrichment ---------------------------------------------

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -347,6 +347,43 @@ class JJIClient:
             payload["child_build_number"] = child_build_number
         return payload
 
+    def _build_tracker_body(
+        self,
+        test_name: str,
+        child_job_name: str = "",
+        child_build_number: int = 0,
+        *,
+        include_links: bool = False,
+        ai_provider: str = "",
+        ai_model: str = "",
+        title: str = "",
+        body_text: str = "",
+        github_token: str = "",
+        jira_token: str = "",
+        jira_email: str = "",
+        include_github: bool = True,
+        include_jira: bool = True,
+    ) -> dict:
+        """Build the common payload for tracker preview/create endpoints."""
+        payload: dict = {"test_name": test_name}
+        if title:
+            payload["title"] = title
+        if body_text:
+            payload["body"] = body_text
+        if include_links:
+            payload["include_links"] = include_links
+        if ai_provider:
+            payload["ai_provider"] = ai_provider
+        if ai_model:
+            payload["ai_model"] = ai_model
+        if include_github and github_token:
+            payload["github_token"] = github_token
+        if include_jira and jira_token:
+            payload["jira_token"] = jira_token
+        if include_jira and jira_email:
+            payload["jira_email"] = jira_email
+        return self._with_child_scope(payload, child_job_name, child_build_number)
+
     def preview_github_issue(
         self,
         job_id: str,
@@ -356,14 +393,23 @@ class JJIClient:
         include_links: bool = False,
         ai_provider: str = "",
         ai_model: str = "",
+        github_token: str = "",
+        jira_token: str = "",
+        jira_email: str = "",
     ) -> dict:
         """Preview a GitHub issue. POST /results/{job_id}/preview-github-issue"""
-        body: dict = {"test_name": test_name, "include_links": include_links}
-        if ai_provider:
-            body["ai_provider"] = ai_provider
-        if ai_model:
-            body["ai_model"] = ai_model
-        body = self._with_child_scope(body, child_job_name, child_build_number)
+        body = self._build_tracker_body(
+            test_name,
+            child_job_name,
+            child_build_number,
+            include_links=include_links,
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+            github_token=github_token,
+            jira_token=jira_token,
+            jira_email=jira_email,
+            include_jira=False,
+        )
         return self._request(
             "POST", f"/results/{job_id}/preview-github-issue", json=body
         )
@@ -377,14 +423,23 @@ class JJIClient:
         include_links: bool = False,
         ai_provider: str = "",
         ai_model: str = "",
+        github_token: str = "",
+        jira_token: str = "",
+        jira_email: str = "",
     ) -> dict:
         """Preview a Jira bug. POST /results/{job_id}/preview-jira-bug"""
-        body: dict = {"test_name": test_name, "include_links": include_links}
-        if ai_provider:
-            body["ai_provider"] = ai_provider
-        if ai_model:
-            body["ai_model"] = ai_model
-        body = self._with_child_scope(body, child_job_name, child_build_number)
+        body = self._build_tracker_body(
+            test_name,
+            child_job_name,
+            child_build_number,
+            include_links=include_links,
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+            github_token=github_token,
+            jira_token=jira_token,
+            jira_email=jira_email,
+            include_github=False,
+        )
         return self._request("POST", f"/results/{job_id}/preview-jira-bug", json=body)
 
     def create_github_issue(
@@ -395,16 +450,21 @@ class JJIClient:
         body: str,
         child_job_name: str = "",
         child_build_number: int = 0,
+        github_token: str = "",
+        jira_token: str = "",
+        jira_email: str = "",
     ) -> dict:
         """Create a GitHub issue. POST /results/{job_id}/create-github-issue"""
-        payload = self._with_child_scope(
-            {
-                "test_name": test_name,
-                "title": title,
-                "body": body,
-            },
+        payload = self._build_tracker_body(
+            test_name,
             child_job_name,
             child_build_number,
+            title=title,
+            body_text=body,
+            github_token=github_token,
+            jira_token=jira_token,
+            jira_email=jira_email,
+            include_jira=False,
         )
         return self._request(
             "POST",
@@ -421,16 +481,21 @@ class JJIClient:
         body: str,
         child_job_name: str = "",
         child_build_number: int = 0,
+        github_token: str = "",
+        jira_token: str = "",
+        jira_email: str = "",
     ) -> dict:
         """Create a Jira bug. POST /results/{job_id}/create-jira-bug"""
-        payload = self._with_child_scope(
-            {
-                "test_name": test_name,
-                "title": title,
-                "body": body,
-            },
+        payload = self._build_tracker_body(
+            test_name,
             child_job_name,
             child_build_number,
+            title=title,
+            body_text=body,
+            github_token=github_token,
+            jira_token=jira_token,
+            jira_email=jira_email,
+            include_github=False,
         )
         return self._request(
             "POST",
@@ -438,6 +503,20 @@ class JJIClient:
             json=payload,
             accept_statuses=(201,),
         )
+
+    # -- Token Validation -----------------------------------------------------
+
+    def validate_token(
+        self,
+        token_type: str,
+        token: str,
+        email: str = "",
+    ) -> dict:
+        """Validate a tracker token. POST /api/validate-token"""
+        body: dict = {"token_type": token_type, "token": token}
+        if email:
+            body["email"] = email
+        return self._request("POST", "/api/validate-token", json=body)
 
     # -- Capabilities ---------------------------------------------------------
 

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -38,6 +38,7 @@ class ServerConfig:
     jira_email: str = ""
     jira_api_token: str = ""
     jira_pat: str = ""
+    jira_token: str = ""
     jira_project_key: str = ""
     jira_ssl_verify: bool | None = None
     jira_max_results: int = 0  # 0 means use server default
@@ -216,6 +217,7 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jira_email=data.get("jira_email", ""),
         jira_api_token=data.get("jira_api_token", ""),
         jira_pat=data.get("jira_pat", ""),
+        jira_token=_validated_str(data, "jira_token"),
         jira_project_key=data.get("jira_project_key", ""),
         jira_ssl_verify=data.get("jira_ssl_verify"),
         jira_max_results=data.get("jira_max_results", 0),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1093,11 +1093,13 @@ def capabilities(
     Reports whether the server is configured to create GitHub issues
     and Jira bugs automatically. Requires server-level credentials.
     """
-    _run_client_command(
+    data = _run_client_command(
         json_output,
         lambda c: c.capabilities(),
-        columns=["github_issues", "jira_bugs"],
+        emit_output=False,
     )
+    if not _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
 
 
 @app.command("ai-configs")
@@ -1129,6 +1131,18 @@ def ai_configs(
 # -- Bug Creation -------------------------------------------------------------
 
 
+def _resolve_tracker_tokens(
+    github_token: str, jira_token: str, jira_email: str
+) -> tuple[str, str, str]:
+    """Resolve tracker tokens with config fallback."""
+    cfg = _state.get("server_config")
+    return (
+        github_token.strip() or ((cfg.github_token or "").strip() if cfg else ""),
+        jira_token.strip() or ((cfg.jira_token or "").strip() if cfg else ""),
+        jira_email.strip() or ((cfg.jira_email or "").strip() if cfg else ""),
+    )
+
+
 def _validate_issue_type(issue_type: str) -> str:
     """Validate and normalize issue type, exit on invalid input."""
     normalized = issue_type.lower()
@@ -1157,11 +1171,27 @@ def preview_issue(
     ai_model: str = typer.Option(
         "", "--ai-model", help="AI model for content generation."
     ),
+    github_token: str = typer.Option(
+        "",
+        "--github-token",
+        help="GitHub PAT for issue creation (overrides server config).",
+    ),
+    jira_token: str = typer.Option(
+        "",
+        "--jira-token",
+        help="Jira token for bug creation (overrides server config).",
+    ),
+    jira_email: str = typer.Option(
+        "", "--jira-email", help="Jira email for Cloud auth (used with --jira-token)."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Preview generated issue content (GitHub or Jira)."""
     _set_json(json_output)
     normalized_type = _validate_issue_type(issue_type)
+    _github_token, _jira_token, _jira_email = _resolve_tracker_tokens(
+        github_token, jira_token, jira_email
+    )
     try:
         client = _get_client()
         if normalized_type == "github":
@@ -1173,6 +1203,7 @@ def preview_issue(
                 include_links=include_links,
                 ai_provider=ai_provider,
                 ai_model=ai_model,
+                github_token=_github_token,
             )
         else:
             data = client.preview_jira_bug(
@@ -1183,6 +1214,8 @@ def preview_issue(
                 include_links=include_links,
                 ai_provider=ai_provider,
                 ai_model=ai_model,
+                jira_token=_jira_token,
+                jira_email=_jira_email,
             )
     except JJIError as err:
         _handle_error(err)
@@ -1209,11 +1242,27 @@ def create_issue(
     body: str = typer.Option(..., "--body", help="Issue body."),
     child_job_name: str = typer.Option("", "--child-job"),
     child_build_number: int = typer.Option(0, "--child-build"),
+    github_token: str = typer.Option(
+        "",
+        "--github-token",
+        help="GitHub PAT for issue creation (overrides server config).",
+    ),
+    jira_token: str = typer.Option(
+        "",
+        "--jira-token",
+        help="Jira token for bug creation (overrides server config).",
+    ),
+    jira_email: str = typer.Option(
+        "", "--jira-email", help="Jira email for Cloud auth (used with --jira-token)."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Create a GitHub issue or Jira bug from a failure analysis."""
     _set_json(json_output)
     normalized_type = _validate_issue_type(issue_type)
+    _github_token, _jira_token, _jira_email = _resolve_tracker_tokens(
+        github_token, jira_token, jira_email
+    )
     try:
         client = _get_client()
         if normalized_type == "github":
@@ -1224,6 +1273,7 @@ def create_issue(
                 body=body,
                 child_job_name=child_job_name,
                 child_build_number=child_build_number,
+                github_token=_github_token,
             )
         else:
             data = client.create_jira_bug(
@@ -1233,6 +1283,8 @@ def create_issue(
                 body=body,
                 child_job_name=child_job_name,
                 child_build_number=child_build_number,
+                jira_token=_jira_token,
+                jira_email=_jira_email,
             )
     except JJIError as err:
         _handle_error(err)
@@ -1245,6 +1297,32 @@ def create_issue(
         typer.echo(f"URL: {data.get('url', '')}")
         if data.get("comment_id"):
             typer.echo(f"Comment added (id: {data['comment_id']})")
+
+
+@app.command("validate-token")
+def validate_token_cmd(
+    token_type: str = typer.Argument(help="Token type: 'github' or 'jira'"),
+    token: str = typer.Option(
+        ..., help="Token value to validate", prompt=True, hide_input=True
+    ),
+    email: str = typer.Option("", help="Email for Jira Cloud auth"),
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Validate a GitHub or Jira token."""
+    token_type = _validate_issue_type(token_type)
+    data = _run_client_command(
+        json_output,
+        lambda c: c.validate_token(token_type=token_type, token=token, email=email),
+        emit_output=False,
+    )
+    if data.get("valid"):
+        if not _state.get("json", False):
+            typer.echo(f"\u2713 Valid \u2014 {data.get('message', '')}")
+        return
+
+    if not _state.get("json", False):
+        typer.echo(f"\u2717 Invalid \u2014 {data.get('message', '')}")
+    raise typer.Exit(code=1)
 
 
 @app.command("override-classification")

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -148,6 +148,12 @@ class Settings(BaseSettings):
         description="Enable GitHub issue creation. When None, enabled if TESTS_REPO_URL and GITHUB_TOKEN are configured.",
     )
 
+    # Explicit Jira issue creation toggle (optional)
+    enable_jira_issues: bool | None = Field(
+        default=None,
+        description="Enable Jira bug creation. When None, follows jira_enabled.",
+    )
+
     # AI CLI timeout in minutes
     ai_cli_timeout: int = Field(default=10, gt=0)
 

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -33,6 +33,7 @@ SENSITIVE_KEYS: frozenset[str] = frozenset(
         "jira_api_token",
         "jira_pat",
         "jira_email",
+        "jira_token",
         "github_token",
     }
 )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -8,7 +8,7 @@ import uuid
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Coroutine
+from typing import Any, Coroutine, Literal
 from xml.etree.ElementTree import ParseError
 
 import httpx
@@ -16,7 +16,7 @@ from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Req
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
-from pydantic import SecretStr
+from pydantic import BaseModel, Field, SecretStr
 from simple_logger.logger import get_logger
 
 from ai_cli_runner import VALID_AI_PROVIDERS, run_parallel_with_limit
@@ -1441,10 +1441,7 @@ async def get_job_result(request: Request, job_id: str, response: Response):
         raise HTTPException(status_code=404, detail="Job not found")
     _attach_result_links(result, _extract_base_url(), job_id)
     settings = get_settings()
-    result["capabilities"] = {
-        "github_issues": settings.github_issues_enabled,
-        "jira_bugs": settings.jira_enabled,
-    }
+    result["capabilities"] = _build_capabilities(settings)
     if result.get("status") in IN_PROGRESS_STATUSES:
         response.status_code = 202
     return result
@@ -1818,6 +1815,14 @@ async def enrich_comments(
     return {"enrichments": enrichments}
 
 
+def _resolve_tests_repo_url(settings: Settings, result_data: dict) -> str:
+    """Resolve tests repo URL from settings or job request params."""
+    url = str(settings.tests_repo_url or "")
+    if not url:
+        url = str(result_data.get("request_params", {}).get("tests_repo_url", ""))
+    return url
+
+
 async def _load_effective_failure(
     job_id: str,
     test_name: str,
@@ -1869,7 +1874,7 @@ async def preview_github_issue(
     logger.debug(
         f"POST /results/{job_id}/preview-github-issue: test_name={body.test_name}"
     )
-    if not settings.github_issues_enabled:
+    if settings.enable_github_issues is False:
         raise HTTPException(
             status_code=403,
             detail="GitHub issue creation is disabled on this server",
@@ -1900,8 +1905,8 @@ async def preview_github_issue(
     )
 
     # Duplicate detection (best-effort: failures must not break preview)
-    tests_repo_url = str(settings.tests_repo_url or "")
-    github_token = (
+    tests_repo_url = _resolve_tests_repo_url(settings, result_data)
+    github_token = (body.github_token or "").strip() or (
         settings.github_token.get_secret_value() if settings.github_token else ""
     )
     similar: list[dict] = []
@@ -1935,10 +1940,15 @@ async def preview_jira_bug(
 ) -> dict:
     """Generate preview content for a Jira bug from a failure analysis."""
     logger.debug(f"POST /results/{job_id}/preview-jira-bug: test_name={body.test_name}")
-    if not settings.jira_enabled:
+    if not _jira_issue_creation_enabled(settings):
         raise HTTPException(
             status_code=403,
-            detail="Jira integration is disabled on this server",
+            detail="Jira issue creation is disabled on this server",
+        )
+    if not settings.jira_url:
+        raise HTTPException(
+            status_code=400,
+            detail="Jira URL is not configured on the server",
         )
     failure, result_data = await _load_effective_failure(
         job_id, body.test_name, body.child_job_name, body.child_build_number
@@ -1967,11 +1977,18 @@ async def preview_jira_bug(
 
     # Duplicate detection (best-effort: failures must not break preview)
     similar: list[dict] = []
-    if settings.jira_enabled:
+    effective_jira_settings = _build_effective_jira_settings(
+        settings, body.jira_token, body.jira_email
+    )
+    if (
+        _has_jira_credentials(effective_jira_settings)
+        and effective_jira_settings.jira_url
+        and effective_jira_settings.jira_project_key
+    ):
         try:
             similar = await search_jira_duplicates(
                 title=content["title"],
-                settings=settings,
+                settings=effective_jira_settings,
             )
         except Exception:
             logger.warning(
@@ -1985,6 +2002,71 @@ async def preview_jira_bug(
         "body": content["body"],
         "similar_issues": similar,
     }
+
+
+def _has_jira_credentials(settings: Settings) -> bool:
+    """Return True if the given settings contain usable Jira credentials."""
+    return bool(
+        (settings.jira_api_token and settings.jira_api_token.get_secret_value())
+        or (settings.jira_pat and settings.jira_pat.get_secret_value())
+    )
+
+
+def _jira_issue_creation_enabled(settings: Settings) -> bool:
+    """Check whether Jira issue creation is enabled.
+
+    ``ENABLE_JIRA_ISSUES`` takes precedence when explicitly set (True/False).
+    Falls back to ``ENABLE_JIRA`` when ``ENABLE_JIRA_ISSUES`` is None.
+    """
+    if settings.enable_jira_issues is not None:
+        return bool(settings.enable_jira_issues)
+    return settings.enable_jira is not False
+
+
+def _build_capabilities(settings: Settings) -> dict[str, bool]:
+    """Build the capabilities dict for API responses."""
+    return {
+        "github_issues_enabled": settings.enable_github_issues is not False,
+        "jira_issues_enabled": _jira_issue_creation_enabled(settings),
+        "server_github_token": bool(
+            settings.github_token and settings.github_token.get_secret_value()
+        ),
+        "server_jira_token": bool(
+            (settings.jira_api_token and settings.jira_api_token.get_secret_value())
+            or (settings.jira_pat and settings.jira_pat.get_secret_value())
+        ),
+        "server_jira_email": bool(settings.jira_email),
+        "server_jira_project_key": bool(settings.jira_project_key),
+    }
+
+
+def _build_effective_jira_settings(
+    settings: Settings, user_jira_token: str, user_jira_email: str
+) -> Settings:
+    """Build effective settings with user Jira credentials overriding server defaults.
+
+    Uses ``model_copy()`` to follow the same pattern as ``_merge_settings()``.
+    The user token is set as ``jira_api_token`` and ``jira_pat`` is cleared so
+    the user token takes precedence in all auth resolution paths
+    (``_resolve_jira_auth`` prefers PAT over API token, so leaving server PAT
+    intact would bypass the user override).
+
+    When the user provides a token but no email, ``jira_email`` is also cleared
+    to prevent pairing the server's email with the user's token (which would
+    incorrectly trigger Cloud Basic auth). Cloud users must explicitly provide
+    their email; without it, the non-Cloud auth path is used, which may
+    fail against Cloud-only Jira hosts.
+    """
+    if not user_jira_token or not user_jira_token.strip():
+        return settings
+    overrides: dict = {
+        "jira_api_token": SecretStr(user_jira_token.strip()),
+        "jira_pat": None,
+        "jira_email": user_jira_email.strip()
+        if user_jira_email and user_jira_email.strip()
+        else None,
+    }
+    return settings.model_copy(update=overrides)
 
 
 def _require_tracker_url(result: dict, tracker_name: str) -> str:
@@ -2061,36 +2143,35 @@ async def create_github_issue_endpoint(
     logger.debug(
         f"POST /results/{job_id}/create-github-issue: test_name={body.test_name}"
     )
-    if not settings.github_issues_enabled:
+    if settings.enable_github_issues is False:
         raise HTTPException(
             status_code=403,
             detail="GitHub issue creation is disabled on this server",
         )
-    tests_repo_url = str(settings.tests_repo_url or "")
-    github_token = (
+    github_token = (body.github_token or "").strip() or (
         settings.github_token.get_secret_value() if settings.github_token else ""
     )
-
-    if not tests_repo_url or not github_token:
+    if not github_token:
         raise HTTPException(
             status_code=400,
-            detail="TESTS_REPO_URL and GITHUB_TOKEN must be configured to create GitHub issues",
+            detail="GitHub token is required. Provide a token in your profile settings or configure GITHUB_TOKEN on the server.",
         )
 
-    # Verify classification matches tracker
-    failure, _result_data = await _load_effective_failure(
+    _failure, _result_data = await _load_effective_failure(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
-    if failure.analysis.classification == "PRODUCT BUG":
-        raise HTTPException(
-            status_code=422,
-            detail="Cannot create GitHub issue for a PRODUCT BUG classification. Use Jira instead.",
-        )
 
     username = request.cookies.get("jji_username", "")
     issue_body = body.body
     if username:
         issue_body += f"\n\n---\n_Reported by: {username} via jenkins-job-insight_"
+
+    tests_repo_url = _resolve_tests_repo_url(settings, _result_data)
+    if not tests_repo_url:
+        raise HTTPException(
+            status_code=400,
+            detail="No test repository URL available. The job was analyzed without tests_repo_url.",
+        )
 
     try:
         result = await create_github_issue(
@@ -2105,6 +2186,11 @@ async def create_github_issue_endpoint(
             detail=f"Invalid TESTS_REPO_URL: {exc}",
         ) from exc
     except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise HTTPException(
+                status_code=401,
+                detail="GitHub token is invalid or expired. Update your token in settings.",
+            ) from exc
         raise HTTPException(
             status_code=502,
             detail=f"GitHub API error: {exc.response.status_code}",
@@ -2145,21 +2231,20 @@ async def create_jira_bug_endpoint(
     """Create a Jira bug from a failure analysis."""
     logger.debug(f"POST /results/{job_id}/create-jira-bug: test_name={body.test_name}")
 
-    if not settings.jira_enabled:
+    if not _jira_issue_creation_enabled(settings):
         raise HTTPException(
             status_code=403,
-            detail="Jira integration is disabled on this server",
+            detail="Jira issue creation is disabled on this server",
+        )
+    if not settings.jira_url:
+        raise HTTPException(
+            status_code=400,
+            detail="Jira URL is not configured on the server",
         )
 
-    # Verify classification matches tracker
-    failure, _result_data = await _load_effective_failure(
+    _failure, _result_data = await _load_effective_failure(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
-    if failure.analysis.classification == "CODE ISSUE":
-        raise HTTPException(
-            status_code=422,
-            detail="Cannot create Jira bug for a CODE ISSUE classification. Use GitHub instead.",
-        )
 
     username = request.cookies.get("jji_username", "")
     bug_body = body.body
@@ -2167,12 +2252,30 @@ async def create_jira_bug_endpoint(
         bug_body += f"\n\n----\nReported by: {username} via jenkins-job-insight"
 
     try:
+        effective_jira_settings = _build_effective_jira_settings(
+            settings, body.jira_token, body.jira_email
+        )
+        if not effective_jira_settings.jira_project_key:
+            raise HTTPException(
+                status_code=400,
+                detail="Jira project key is not configured on the server.",
+            )
+        if not _has_jira_credentials(effective_jira_settings):
+            raise HTTPException(
+                status_code=400,
+                detail="Jira token is required. Provide a token in your profile settings or configure Jira credentials on the server.",
+            )
         result = await create_jira_bug(
             title=body.title,
             body=bug_body,
-            settings=settings,
+            settings=effective_jira_settings,
         )
     except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise HTTPException(
+                status_code=401,
+                detail="Jira token is invalid or expired. Update your token in settings.",
+            ) from exc
         raise HTTPException(
             status_code=502,
             detail=f"Jira API error: {exc.response.status_code}",
@@ -2383,17 +2486,106 @@ async def api_dashboard() -> list[dict]:
 
 @app.get("/api/capabilities")
 async def get_capabilities(settings: Settings = Depends(get_settings)) -> dict:
-    """Report which post-analysis automation features are available.
+    """Report server-level feature toggles and credential availability.
 
-    These capabilities indicate whether the server is configured to
-    automatically create GitHub issues or Jira bugs from analysis results.
-    They require server-level credentials (GITHUB_TOKEN, JIRA_API_TOKEN, etc.)
-    and cannot be provided per-request.
+    Feature toggles (ENABLE_GITHUB_ISSUES, ENABLE_JIRA_ISSUES) control
+    whether issue creation is available at all.  Credential flags tell
+    the frontend whether the server has its own tokens configured so the
+    UI can decide if user-supplied tokens are required or optional.
     """
-    return {
-        "github_issues": settings.github_issues_enabled,
-        "jira_bugs": settings.jira_enabled,
-    }
+    return _build_capabilities(settings)
+
+
+class ValidateTokenRequest(BaseModel):
+    """Request body for validating a tracker token."""
+
+    token_type: Literal["github", "jira"] = Field(description="Token type")
+    token: str = Field(description="Token value to validate")
+    email: str = Field(default="", description="Email for Jira Cloud auth")
+
+
+@app.post("/api/validate-token")
+async def validate_token(
+    body: ValidateTokenRequest,
+    settings: Settings = Depends(get_settings),
+) -> dict:
+    """Validate a GitHub or Jira token by making a lightweight API call.
+
+    GitHub: GET /user (returns authenticated user info)
+    Jira: GET /rest/api/2/myself (returns authenticated user info)
+    """
+    token = body.token.strip()
+    if not token:
+        return {"valid": False, "username": "", "message": "Token is required"}
+
+    def _invalid(msg: str) -> dict:
+        return {"valid": False, "username": "", "message": msg}
+
+    def _status_message(status_code: int) -> str:
+        if status_code in (401, 403):
+            return f"Invalid token (HTTP {status_code})"
+        return f"Tracker API returned HTTP {status_code}"
+
+    if body.token_type == "github":
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    "https://api.github.com/user",
+                    headers={
+                        "Accept": "application/vnd.github.v3+json",
+                        "Authorization": f"Bearer {token}",
+                    },
+                )
+                resp.raise_for_status()
+                try:
+                    data = resp.json()
+                except (ValueError, json.JSONDecodeError):
+                    return _invalid("Tracker API returned an unexpected response")
+                return {
+                    "valid": True,
+                    "username": data.get("login", ""),
+                    "message": f"Authenticated as {data.get('login', 'unknown')}",
+                }
+        except httpx.HTTPStatusError as exc:
+            return _invalid(_status_message(exc.response.status_code))
+        except httpx.RequestError:
+            return _invalid("Could not reach GitHub API")
+
+    elif body.token_type == "jira":
+        jira_url = (settings.jira_url or "").rstrip("/")
+        if not jira_url:
+            return _invalid("Jira URL not configured on server")
+        # Build auth based on whether email is provided (Cloud vs DC)
+        email = body.email.strip()
+        auth: tuple[str, str] | None = None
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if email:
+            auth = (email, token)
+        else:
+            headers["Authorization"] = f"Bearer {token}"
+        try:
+            async with httpx.AsyncClient(
+                verify=settings.jira_ssl_verify, timeout=10, auth=auth
+            ) as client:
+                resp = await client.get(
+                    f"{jira_url}/rest/api/2/myself",
+                    headers=headers,
+                )
+                resp.raise_for_status()
+                try:
+                    data = resp.json()
+                except (ValueError, json.JSONDecodeError):
+                    return _invalid("Tracker API returned an unexpected response")
+                display = data.get("displayName", data.get("name", ""))
+                return {
+                    "valid": True,
+                    "username": display,
+                    "message": f"Authenticated as {display}",
+                }
+        except httpx.HTTPStatusError as exc:
+            return _invalid(_status_message(exc.response.status_code))
+        except httpx.RequestError:
+            return _invalid("Could not reach Jira API")
 
 
 @app.get("/history/failures")

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -519,12 +519,25 @@ class ReviewStatusResponse(BaseModel):
     comment_count: int
 
 
+class _TrackerCredentialsMixin(BaseModel):
+    """Shared tracker credential fields for issue preview/create requests."""
+
+    github_token: str = Field(
+        default="", description="User's GitHub PAT for issue creation"
+    )
+    jira_token: str = Field(
+        default="", description="User's Jira token for bug creation"
+    )
+    jira_email: str = Field(default="", description="User's Jira email for Cloud auth")
+
+
 # NOTE: Preview/create request models intentionally do NOT inherit
-# BaseAnalysisRequest. These are server-level operations that use deployment
-# config (GITHUB_TOKEN, TESTS_REPO_URL, Jira credentials), not per-request
-# analysis overrides. The caller identifies *which* failure to act on, but
-# the credentials and target repos are fixed at the server level.
-class PreviewIssueRequest(_ChildJobFieldsValidator):
+# BaseAnalysisRequest. Target repositories (TESTS_REPO_URL, JIRA_URL) are
+# configured at the server level, but users may provide their own tracker
+# tokens (github_token, jira_token, jira_email) to create issues under
+# their own identity. When user tokens are absent, the server falls back
+# to its deployment credentials. Analysis overrides remain out of scope.
+class PreviewIssueRequest(_ChildJobFieldsValidator, _TrackerCredentialsMixin):
     """Request body for previewing a GitHub issue or Jira bug."""
 
     test_name: str
@@ -535,7 +548,7 @@ class PreviewIssueRequest(_ChildJobFieldsValidator):
     ai_model: str = Field(default="", description="AI model for content generation")
 
 
-class CreateIssueRequest(_ChildJobFieldsValidator):
+class CreateIssueRequest(_ChildJobFieldsValidator, _TrackerCredentialsMixin):
     """Request body for creating a GitHub issue or Jira bug."""
 
     test_name: str

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -425,12 +425,14 @@ class TestJJIClientCapabilities:
         def handler(request):
             assert request.method == "GET"
             assert request.url.path == "/api/capabilities"
-            return httpx.Response(200, json={"github_issues": True, "jira_bugs": False})
+            return httpx.Response(
+                200, json={"github_issues_enabled": True, "jira_issues_enabled": False}
+            )
 
         client = _make_client(handler)
         result = client.capabilities()
-        assert result["github_issues"] is True
-        assert result["jira_bugs"] is False
+        assert result["github_issues_enabled"] is True
+        assert result["jira_issues_enabled"] is False
 
 
 class TestJJIClientAiConfigs:
@@ -512,6 +514,231 @@ class TestJJIClientPreviewWithAiConfig:
         client.preview_github_issue(
             job_id="job-1",
             test_name="tests.TestA.test_one",
+        )
+
+
+class TestJJIClientIssueTokens:
+    def test_preview_github_issue_with_tokens(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/preview-github-issue" in str(request.url)
+            body = json.loads(request.content)
+            assert body["github_token"] == "ghp_test123"  # noqa: S105
+            assert "jira_token" not in body
+            assert "jira_email" not in body
+            return httpx.Response(
+                200,
+                json={"title": "Fix", "body": "Body", "similar_issues": []},
+            )
+
+        client = _make_client(handler)
+        result = client.preview_github_issue(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            github_token="ghp_test123",  # noqa: S106
+        )
+        assert result["title"] == "Fix"
+
+    def test_create_github_issue_with_tokens(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/create-github-issue" in str(request.url)
+            body = json.loads(request.content)
+            assert body["github_token"] == "ghp_test123"  # noqa: S105
+            assert "jira_token" not in body
+            assert "jira_email" not in body
+            return httpx.Response(
+                201,
+                json={
+                    "url": "https://github.com/org/repo/issues/99",
+                    "key": "",
+                    "title": "Bug",
+                    "comment_id": 1,
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.create_github_issue(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            title="Bug",
+            body="Details",
+            github_token="ghp_test123",  # noqa: S106
+        )
+        assert result["url"] == "https://github.com/org/repo/issues/99"
+
+    def test_preview_jira_bug_with_tokens(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/preview-jira-bug" in str(request.url)
+            body = json.loads(request.content)
+            assert "github_token" not in body
+            assert body["jira_token"] == "jira-tok-test"  # noqa: S105
+            assert body["jira_email"] == "test@example.com"
+            return httpx.Response(
+                200,
+                json={"title": "Bug", "body": "Desc", "similar_issues": []},
+            )
+
+        client = _make_client(handler)
+        result = client.preview_jira_bug(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            jira_token="jira-tok-test",  # noqa: S106
+            jira_email="test@example.com",
+        )
+        assert result["title"] == "Bug"
+
+    def test_create_jira_bug_with_tokens(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/create-jira-bug" in str(request.url)
+            body = json.loads(request.content)
+            assert "github_token" not in body
+            assert body["jira_token"] == "jira-tok-test"  # noqa: S105
+            assert body["jira_email"] == "test@example.com"
+            return httpx.Response(
+                201,
+                json={
+                    "url": "https://jira.example.com/browse/PROJ-1",
+                    "key": "PROJ-1",
+                    "title": "Bug",
+                    "comment_id": 1,
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.create_jira_bug(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            title="Bug",
+            body="Details",
+            jira_token="jira-tok-test",  # noqa: S106
+            jira_email="test@example.com",
+        )
+        assert result["key"] == "PROJ-1"
+
+    def test_preview_github_issue_without_tokens_omits_fields(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/preview-github-issue" in str(request.url)
+            body = json.loads(request.content)
+            assert "github_token" not in body
+            assert "jira_token" not in body
+            assert "jira_email" not in body
+            return httpx.Response(
+                200,
+                json={"title": "Fix", "body": "Body", "similar_issues": []},
+            )
+
+        client = _make_client(handler)
+        client.preview_github_issue(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+        )
+
+
+class TestJJIClientCrossCredentialLeakage:
+    """Verify that GitHub methods never include Jira credentials and vice versa."""
+
+    def test_preview_github_issue_excludes_jira_credentials(self):
+        def handler(request):
+            body = json.loads(request.content)
+            assert "jira_token" not in body, (
+                "jira_token leaked into GitHub preview payload"
+            )
+            assert "jira_email" not in body, (
+                "jira_email leaked into GitHub preview payload"
+            )
+            assert body["github_token"] == "ghp_test"  # noqa: S105
+            return httpx.Response(
+                200,
+                json={"title": "Fix", "body": "Body", "similar_issues": []},
+            )
+
+        client = _make_client(handler)
+        client.preview_github_issue(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            github_token="ghp_test",  # noqa: S106
+            jira_token="jira-should-not-appear",  # noqa: S106
+            jira_email="leak@example.com",
+        )
+
+    def test_create_github_issue_excludes_jira_credentials(self):
+        def handler(request):
+            body = json.loads(request.content)
+            assert "jira_token" not in body, (
+                "jira_token leaked into GitHub create payload"
+            )
+            assert "jira_email" not in body, (
+                "jira_email leaked into GitHub create payload"
+            )
+            return httpx.Response(
+                201,
+                json={
+                    "url": "https://github.com/org/repo/issues/1",
+                    "key": "",
+                    "title": "Bug",
+                    "comment_id": 1,
+                },
+            )
+
+        client = _make_client(handler)
+        client.create_github_issue(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            title="Bug",
+            body="Details",
+            github_token="ghp_test",  # noqa: S106
+            jira_token="jira-should-not-appear",  # noqa: S106
+            jira_email="leak@example.com",
+        )
+
+    def test_preview_jira_bug_excludes_github_credentials(self):
+        def handler(request):
+            body = json.loads(request.content)
+            assert "github_token" not in body, (
+                "github_token leaked into Jira preview payload"
+            )
+            assert body["jira_token"] == "jira-tok"  # noqa: S105
+            return httpx.Response(
+                200,
+                json={"title": "Bug", "body": "Desc", "similar_issues": []},
+            )
+
+        client = _make_client(handler)
+        client.preview_jira_bug(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            github_token="ghp-should-not-appear",  # noqa: S106
+            jira_token="jira-tok",  # noqa: S106
+        )
+
+    def test_create_jira_bug_excludes_github_credentials(self):
+        def handler(request):
+            body = json.loads(request.content)
+            assert "github_token" not in body, (
+                "github_token leaked into Jira create payload"
+            )
+            return httpx.Response(
+                201,
+                json={
+                    "url": "https://jira.example.com/browse/PROJ-1",
+                    "key": "PROJ-1",
+                    "title": "Bug",
+                    "comment_id": 1,
+                },
+            )
+
+        client = _make_client(handler)
+        client.create_jira_bug(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            title="Bug",
+            body="Details",
+            github_token="ghp-should-not-appear",  # noqa: S106
+            jira_token="jira-tok",  # noqa: S106
         )
 
 
@@ -696,12 +923,12 @@ class TestJJIClientAnalyzeExtras:
             "tests_repo_url": "https://github.com/org/tests",
             "jira_url": "https://jira.example.com",
             "jira_email": "user@example.com",
-            "jira_api_token": "tok-123",
-            "jira_pat": "pat-abc",
+            "jira_api_token": "tok-123",  # noqa: S105
+            "jira_pat": "pat-abc",  # noqa: S105
             "jira_project_key": "PROJ",
             "jira_ssl_verify": True,
             "jira_max_results": 25,
-            "github_token": "ghp_abc123",
+            "github_token": "ghp_abc123",  # noqa: S105
             "ai_cli_timeout": 10,
             "enable_jira": True,
             "raw_prompt": "extra instructions",
@@ -776,6 +1003,68 @@ class TestJJIClientAnalyzeExtras:
         client = _make_client(handler)
         result = client.analyze("my-job", 1)
         assert result["status"] == "queued"
+
+
+class TestJJIClientValidateToken:
+    def test_validate_github_token(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/api/validate-token" in str(request.url)
+            body = json.loads(request.content)
+            assert body["token_type"] == "github"  # noqa: S105
+            assert body["token"] == "ghp_test"  # noqa: S105
+            return httpx.Response(
+                200,
+                json={
+                    "valid": True,
+                    "username": "testuser",
+                    "message": "Authenticated as testuser",
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.validate_token(token_type="github", token="ghp_test")  # noqa: S106
+        assert result["valid"] is True
+
+    def test_validate_jira_token_with_email(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/api/validate-token" in str(request.url)
+            body = json.loads(request.content)
+            assert body["token_type"] == "jira"  # noqa: S105
+            assert body["token"] == "jira-tok"  # noqa: S105
+            assert body["email"] == "user@example.com"
+            return httpx.Response(
+                200,
+                json={
+                    "valid": True,
+                    "username": "User",
+                    "message": "Authenticated as User",
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.validate_token(
+            token_type="jira",  # noqa: S106
+            token="jira-tok",  # noqa: S106
+            email="user@example.com",
+        )
+        assert result["valid"] is True
+
+    def test_validate_token_without_email_omits_field(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/api/validate-token" in str(request.url)
+            body = json.loads(request.content)
+            assert "email" not in body
+            assert body["token_type"] == "jira"  # noqa: S105
+            assert body["token"] == "jira-tok"  # noqa: S105
+            return httpx.Response(
+                200, json={"valid": True, "username": "u", "message": "ok"}
+            )
+
+        client = _make_client(handler)
+        client.validate_token(token_type="jira", token="jira-tok")  # noqa: S106
 
 
 class TestJJIClientReAnalyze:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -40,6 +40,7 @@ jira_url = "https://jira.dev.local"
 jira_email = "dev@example.com"
 jira_api_token = "jira-tok-dev"
 jira_pat = "jira-pat-dev"
+jira_token = "jira-token-dev"
 jira_project_key = "DEV"
 jira_ssl_verify = false
 jira_max_results = 30
@@ -245,6 +246,7 @@ class TestGetServerConfig:
         assert cfg.jira_email == "dev@example.com"
         assert cfg.jira_api_token == "jira-tok-dev"  # noqa: S105
         assert cfg.jira_pat == "jira-pat-dev"  # noqa: S105
+        assert cfg.jira_token == "jira-token-dev"  # noqa: S105
         assert cfg.jira_project_key == "DEV"
         assert cfg.jira_ssl_verify is False
         assert cfg.jira_max_results == 30
@@ -267,6 +269,7 @@ class TestGetServerConfig:
         assert cfg.jira_max_results == 0
         assert cfg.enable_jira is None
         assert cfg.github_token == ""
+        assert cfg.jira_token == ""
         assert cfg.wait_for_completion is None
         assert cfg.poll_interval_minutes == 0
         assert cfg.max_wait_minutes == 0

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -939,13 +939,14 @@ class TestAnalyzeAllOptions:
 class TestCapabilitiesCommand:
     def test_capabilities(self, mock_client):
         mock_client.capabilities.return_value = {
-            "github_issues": True,
-            "jira_bugs": False,
+            "github_issues_enabled": True,
+            "jira_issues_enabled": False,
         }
-        result = runner.invoke(app, ["capabilities"])
+        result = runner.invoke(app, ["capabilities", "--json"])
         assert result.exit_code == 0
-        assert "github" in result.output.lower()
-        assert "jira" in result.output.lower()
+        data = json.loads(result.output)
+        assert data["github_issues_enabled"] is True
+        assert data["jira_issues_enabled"] is False
         mock_client.capabilities.assert_called_once()
 
 
@@ -1086,6 +1087,64 @@ class TestPreviewIssueCommand:
         assert result.exit_code == 0
         assert "Similar issues (1)" in result.output
 
+    def test_preview_with_user_tokens(self, mock_client):
+        mock_client.preview_github_issue.return_value = {
+            "title": "Fix: login handler",
+            "body": "## Details...",
+            "similar_issues": [],
+        }
+        result = runner.invoke(
+            app,
+            [
+                "preview-issue",
+                "job-1",
+                "--test",
+                "tests.TestA.test_one",
+                "--type",
+                "github",
+                "--github-token",
+                "ghp_tok",  # noqa: S106
+                "--jira-token",
+                "jira-tok",  # noqa: S106
+                "--jira-email",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.preview_github_issue.call_args[1]
+        assert kwargs["github_token"] == "ghp_tok"  # noqa: S105
+        assert "jira_token" not in kwargs
+        assert "jira_email" not in kwargs
+
+    def test_preview_jira_with_user_tokens(self, mock_client):
+        mock_client.preview_jira_bug.return_value = {
+            "title": "DNS timeout",
+            "body": "h2. Summary...",
+            "similar_issues": [],
+        }
+        result = runner.invoke(
+            app,
+            [
+                "preview-issue",
+                "job-1",
+                "--test",
+                "tests.TestA.test_one",
+                "--type",
+                "jira",
+                "--github-token",
+                "ghp_tok",  # noqa: S106
+                "--jira-token",
+                "jira-tok",  # noqa: S106
+                "--jira-email",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.preview_jira_bug.call_args[1]
+        assert "github_token" not in kwargs
+        assert kwargs["jira_token"] == "jira-tok"  # noqa: S105
+        assert kwargs["jira_email"] == "user@example.com"
+
 
 class TestCreateIssueCommand:
     def test_create_github(self, mock_client):
@@ -1155,6 +1214,74 @@ class TestCreateIssueCommand:
             ],
         )
         assert result.exit_code == 1
+
+    def test_create_with_user_tokens(self, mock_client):
+        mock_client.create_github_issue.return_value = {
+            "url": "https://github.com/org/repo/issues/99",
+            "key": "",
+            "title": "Bug fix",
+            "comment_id": 42,
+        }
+        result = runner.invoke(
+            app,
+            [
+                "create-issue",
+                "job-1",
+                "--test",
+                "tests.TestA.test_one",
+                "--type",
+                "github",
+                "--title",
+                "Bug fix",
+                "--body",
+                "Details...",
+                "--github-token",
+                "ghp_tok",  # noqa: S106
+                "--jira-token",
+                "jira-tok",  # noqa: S106
+                "--jira-email",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.create_github_issue.call_args[1]
+        assert kwargs["github_token"] == "ghp_tok"  # noqa: S105
+        assert "jira_token" not in kwargs
+        assert "jira_email" not in kwargs
+
+    def test_create_jira_with_user_tokens(self, mock_client):
+        mock_client.create_jira_bug.return_value = {
+            "url": "https://jira.example.com/browse/PROJ-456",
+            "key": "PROJ-456",
+            "title": "DNS timeout",
+            "comment_id": 43,
+        }
+        result = runner.invoke(
+            app,
+            [
+                "create-issue",
+                "job-1",
+                "--test",
+                "tests.TestA.test_one",
+                "--type",
+                "jira",
+                "--title",
+                "DNS timeout",
+                "--body",
+                "Description...",
+                "--github-token",
+                "ghp_tok",  # noqa: S106
+                "--jira-token",
+                "jira-tok",  # noqa: S106
+                "--jira-email",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.create_jira_bug.call_args[1]
+        assert "github_token" not in kwargs
+        assert kwargs["jira_token"] == "jira-tok"  # noqa: S105
+        assert kwargs["jira_email"] == "user@example.com"
 
 
 class TestOverrideClassificationCommand:
@@ -2020,6 +2147,70 @@ class TestAnalyzeWaitFlags:
         assert result.exit_code == 0
         kwargs = mock_client.analyze.call_args[1]
         assert "wait_for_completion" not in kwargs
+
+
+class TestValidateTokenCommand:
+    def test_validate_token_valid(self, mock_client):
+        mock_client.validate_token.return_value = {
+            "valid": True,
+            "username": "testuser",
+            "message": "Authenticated as testuser",
+        }
+        result = runner.invoke(app, ["validate-token", "github", "--token", "ghp_test"])  # noqa: S106
+        assert result.exit_code == 0
+        assert "Valid" in result.output
+        mock_client.validate_token.assert_called_once_with(
+            token_type="github",  # noqa: S106
+            token="ghp_test",  # noqa: S105, S106
+            email="",
+        )
+
+    def test_validate_token_invalid(self, mock_client):
+        mock_client.validate_token.return_value = {
+            "valid": False,
+            "username": "",
+            "message": "Invalid token (HTTP 401)",
+        }
+        result = runner.invoke(app, ["validate-token", "github", "--token", "bad"])  # noqa: S106
+        assert result.exit_code == 1
+        assert "Invalid" in result.output
+
+    def test_validate_token_json(self, mock_client):
+        mock_client.validate_token.return_value = {
+            "valid": True,
+            "username": "testuser",
+            "message": "Authenticated as testuser",
+        }
+        result = runner.invoke(
+            app,
+            ["--json", "validate-token", "github", "--token", "ghp_test"],  # noqa: S106
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["valid"] is True
+
+    def test_validate_token_with_email(self, mock_client):
+        mock_client.validate_token.return_value = {
+            "valid": True,
+            "username": "User",
+            "message": "Authenticated as User",
+        }
+        result = runner.invoke(
+            app,
+            [
+                "validate-token",
+                "jira",
+                "--token",
+                "jira-tok",  # noqa: S106
+                "--email",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.validate_token.call_args[1]
+        assert kwargs["token_type"] == "jira"  # noqa: S105
+        assert kwargs["token"] == "jira-tok"  # noqa: S105
+        assert kwargs["email"] == "user@example.com"
 
 
 class TestReAnalyzeCommand:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,12 +3,14 @@
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import jenkins
 import pytest
 
 from jenkins_job_insight import storage
+from pydantic import SecretStr
+
 from jenkins_job_insight.config import Settings
 from jenkins_job_insight.encryption import encrypt_sensitive_fields
 from jenkins_job_insight.models import (
@@ -46,18 +48,52 @@ def _with_github_issue_config():
 def _enable_feature(prop_name: str):
     """Context manager to enable a Settings boolean property for tests.
 
+    Also patches the underlying raw fields that endpoint guards check directly
+    (e.g. ``settings.tests_repo_url`` for GitHub, ``settings.jira_url`` for Jira).
+
     Usage::
 
         with _enable_feature("github_issues_enabled"):
             response = test_client.post(...)
     """
-    with patch.object(
-        Settings,
-        prop_name,
-        new_callable=PropertyMock,
-        return_value=True,
-    ):
-        yield
+    from contextlib import ExitStack
+
+    from jenkins_job_insight.config import get_settings
+
+    # Map computed properties to the env vars that endpoint guards check
+    raw_env_patches: dict[str, dict[str, str]] = {
+        "github_issues_enabled": {
+            "TESTS_REPO_URL": "https://github.com/test-org/test-repo",
+            "GITHUB_TOKEN": "ghp_test_token",
+            "ENABLE_GITHUB_ISSUES": "true",
+        },
+        "jira_enabled": {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PROJECT_KEY": "TEST",
+            "JIRA_API_TOKEN": "test_jira_token",
+            "ENABLE_JIRA_ISSUES": "true",
+        },
+    }
+
+    with ExitStack() as stack:
+        # Patch the computed property
+        stack.enter_context(
+            patch.object(
+                Settings,
+                prop_name,
+                new_callable=PropertyMock,
+                return_value=True,
+            )
+        )
+        # Also patch env vars so newly-created Settings instances have raw fields set
+        env_overrides = raw_env_patches.get(prop_name, {})
+        if env_overrides:
+            stack.enter_context(patch.dict(os.environ, env_overrides))
+        get_settings.cache_clear()
+        try:
+            yield
+        finally:
+            get_settings.cache_clear()
 
 
 def _build_wait_settings(**overrides) -> Settings:
@@ -1389,10 +1425,28 @@ class TestPreviewGithubIssue:
     @pytest.mark.asyncio
     async def test_preview_disabled_returns_403(self, test_client):
         """Preview returns 403 when GitHub issues are disabled."""
-        response = test_client.post(
-            "/results/any-job/preview-github-issue",
-            json={"test_name": "test_foo", "ai_provider": "claude", "ai_model": "opus"},
-        )
+        from jenkins_job_insight.config import get_settings
+
+        with patch.dict(
+            os.environ,
+            {
+                "ENABLE_GITHUB_ISSUES": "false",
+                "TESTS_REPO_URL": "https://github.com/test-org/test-repo",
+                "GITHUB_TOKEN": "ghp_test_token",
+            },
+        ):
+            get_settings.cache_clear()
+            try:
+                response = test_client.post(
+                    "/results/any-job/preview-github-issue",
+                    json={
+                        "test_name": "test_foo",
+                        "ai_provider": "claude",
+                        "ai_model": "opus",
+                    },
+                )
+            finally:
+                get_settings.cache_clear()
         assert response.status_code == 403
         assert "disabled" in response.json()["detail"].lower()
 
@@ -1490,10 +1544,29 @@ class TestPreviewJiraBug:
     @pytest.mark.asyncio
     async def test_preview_disabled_returns_403(self, test_client):
         """Preview returns 403 when Jira is disabled."""
-        response = test_client.post(
-            "/results/any-job/preview-jira-bug",
-            json={"test_name": "test_foo", "ai_provider": "claude", "ai_model": "opus"},
-        )
+        from jenkins_job_insight.config import get_settings
+
+        with patch.dict(
+            os.environ,
+            {
+                "ENABLE_JIRA_ISSUES": "false",
+                "JIRA_URL": "https://jira.example.com",
+                "JIRA_PROJECT_KEY": "TEST",
+                "JIRA_API_TOKEN": "test_jira_token",
+            },
+        ):
+            get_settings.cache_clear()
+            try:
+                response = test_client.post(
+                    "/results/any-job/preview-jira-bug",
+                    json={
+                        "test_name": "test_foo",
+                        "ai_provider": "claude",
+                        "ai_model": "opus",
+                    },
+                )
+            finally:
+                get_settings.cache_clear()
         assert response.status_code == 403
         assert "disabled" in response.json()["detail"].lower()
 
@@ -1548,6 +1621,8 @@ class TestCreateGithubIssue:
     @pytest.mark.asyncio
     async def test_create_disabled_returns_403(self, test_client):
         """Creating a GitHub issue when disabled returns 403."""
+        from jenkins_job_insight.config import get_settings
+
         result_data = {
             "status": "completed",
             "summary": "",
@@ -1562,14 +1637,26 @@ class TestCreateGithubIssue:
         await storage.save_result(
             "job-create-gh-noconfig", "http://jenkins", "completed", result_data
         )
-        response = test_client.post(
-            "/results/job-create-gh-noconfig/create-github-issue",
-            json={
-                "test_name": "test_foo",
-                "title": "Bug",
-                "body": "Details",
+        with patch.dict(
+            os.environ,
+            {
+                "ENABLE_GITHUB_ISSUES": "false",
+                "TESTS_REPO_URL": "https://github.com/test-org/test-repo",
+                "GITHUB_TOKEN": "ghp_test_token",
             },
-        )
+        ):
+            get_settings.cache_clear()
+            try:
+                response = test_client.post(
+                    "/results/job-create-gh-noconfig/create-github-issue",
+                    json={
+                        "test_name": "test_foo",
+                        "title": "Bug",
+                        "body": "Details",
+                    },
+                )
+            finally:
+                get_settings.cache_clear()
         assert response.status_code == 403
         assert "disabled" in response.json()["detail"].lower()
 
@@ -1626,6 +1713,8 @@ class TestCreateJiraBug:
     @pytest.mark.asyncio
     async def test_create_jira_disabled_returns_403(self, test_client):
         """Creating a Jira bug when Jira is disabled returns 403."""
+        from jenkins_job_insight.config import get_settings
+
         result_data = {
             "status": "completed",
             "summary": "",
@@ -1640,14 +1729,27 @@ class TestCreateJiraBug:
         await storage.save_result(
             "job-create-jira-noconfig", "http://jenkins", "completed", result_data
         )
-        response = test_client.post(
-            "/results/job-create-jira-noconfig/create-jira-bug",
-            json={
-                "test_name": "test_foo",
-                "title": "Bug",
-                "body": "Details",
+        with patch.dict(
+            os.environ,
+            {
+                "ENABLE_JIRA_ISSUES": "false",
+                "JIRA_URL": "https://jira.example.com",
+                "JIRA_PROJECT_KEY": "TEST",
+                "JIRA_API_TOKEN": "test_jira_token",
             },
-        )
+        ):
+            get_settings.cache_clear()
+            try:
+                response = test_client.post(
+                    "/results/job-create-jira-noconfig/create-jira-bug",
+                    json={
+                        "test_name": "test_foo",
+                        "title": "Bug",
+                        "body": "Details",
+                    },
+                )
+            finally:
+                get_settings.cache_clear()
         assert response.status_code == 403
         assert "disabled" in response.json()["detail"].lower()
 
@@ -1855,7 +1957,7 @@ class TestCreateGithubIssueApiErrors:
 
     @pytest.mark.asyncio
     async def test_github_api_http_error_returns_502(self, test_client):
-        """HTTPStatusError from GitHub API should surface as 502."""
+        """HTTPStatusError from GitHub API (non-auth) should surface as 502."""
         import httpx
 
         result_data = {
@@ -1874,9 +1976,9 @@ class TestCreateGithubIssueApiErrors:
         )
         with patch("jenkins_job_insight.main.create_github_issue") as mock_create:
             mock_create.side_effect = httpx.HTTPStatusError(
-                "Forbidden",
+                "Internal Server Error",
                 request=httpx.Request("POST", "https://api.github.com"),
-                response=httpx.Response(403),
+                response=httpx.Response(500),
             )
             with _with_github_issue_config():
                 response = test_client.post(
@@ -1932,7 +2034,7 @@ class TestCreateJiraBugApiErrors:
 
     @pytest.mark.asyncio
     async def test_jira_api_http_error_returns_502(self, test_client):
-        """HTTPStatusError from Jira API should surface as 502."""
+        """HTTPStatusError from Jira API (non-auth) should surface as 502."""
         import httpx
 
         result_data = {
@@ -1951,9 +2053,9 @@ class TestCreateJiraBugApiErrors:
         )
         with patch("jenkins_job_insight.main.create_jira_bug") as mock_create:
             mock_create.side_effect = httpx.HTTPStatusError(
-                "Forbidden",
+                "Internal Server Error",
                 request=httpx.Request("POST", "https://jira.example.com"),
-                response=httpx.Response(403),
+                response=httpx.Response(500),
             )
             with _enable_feature("jira_enabled"):
                 response = test_client.post(
@@ -3840,3 +3942,141 @@ class TestReAnalyzeEndpoint:
         assert "result_url" in data
         mock_process.assert_called_once()
         assert data["result_url"].endswith(f"/results/{data['job_id']}")
+
+
+class TestBuildEffectiveJiraSettings:
+    """Tests for _build_effective_jira_settings helper."""
+
+    def test_no_user_token_returns_original(self):
+        """When no user token, original settings returned unchanged."""
+        from jenkins_job_insight.main import _build_effective_jira_settings
+
+        settings = Settings()
+        result = _build_effective_jira_settings(settings, "", "")
+        assert result is settings
+
+    def test_user_token_clears_server_pat(self):
+        """User token clears server PAT so it takes precedence."""
+        from jenkins_job_insight.main import _build_effective_jira_settings
+
+        settings = Settings(
+            jira_url="https://jira.example.com",
+            jira_pat=SecretStr("server-pat"),
+            jira_api_token=SecretStr("server-api-token"),
+            jira_project_key="TEST",
+        )
+        result = _build_effective_jira_settings(settings, "user-token", "")
+        assert result.jira_pat is None
+        assert result.jira_api_token.get_secret_value() == "user-token"
+
+    def test_user_token_without_email_clears_server_email(self):
+        """User token without email clears server email to avoid mismatched Cloud auth."""
+        from jenkins_job_insight.main import _build_effective_jira_settings
+
+        settings = Settings(
+            jira_url="https://jira.example.com",
+            jira_email="server@example.com",
+            jira_api_token=SecretStr("server-api-token"),
+            jira_project_key="TEST",
+        )
+        result = _build_effective_jira_settings(settings, "user-token", "")
+        assert result.jira_email is None
+        assert result.jira_api_token.get_secret_value() == "user-token"
+
+    def test_user_token_with_email_sets_both(self):
+        """User token with email sets both for Cloud auth."""
+        from jenkins_job_insight.main import _build_effective_jira_settings
+
+        settings = Settings(
+            jira_url="https://jira.example.com",
+            jira_project_key="TEST",
+        )
+        result = _build_effective_jira_settings(
+            settings, "user-token", "user@example.com"
+        )
+        assert result.jira_api_token.get_secret_value() == "user-token"
+        assert result.jira_email == "user@example.com"
+        assert result.jira_pat is None
+
+    def test_original_settings_not_mutated(self):
+        """model_copy must not mutate the original Settings instance."""
+        from jenkins_job_insight.main import _build_effective_jira_settings
+
+        settings = Settings(
+            jira_url="https://jira.example.com",
+            jira_pat=SecretStr("server-pat"),
+            jira_email="server@example.com",
+            jira_project_key="TEST",
+        )
+        _build_effective_jira_settings(settings, "user-token", "user@example.com")
+        # Original must be untouched
+        assert settings.jira_pat.get_secret_value() == "server-pat"
+        assert settings.jira_email == "server@example.com"
+
+
+class TestValidateToken:
+    """Tests for POST /api/validate-token."""
+
+    @pytest.mark.asyncio
+    async def test_github_valid_token(self, test_client):
+        with patch("jenkins_job_insight.main.httpx.AsyncClient") as mock_client_class:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = {"login": "testuser"}
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_class.return_value = mock_client
+            response = test_client.post(
+                "/api/validate-token",
+                json={"token_type": "github", "token": "ghp_valid"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is True
+        assert data["username"] == "testuser"
+
+    @pytest.mark.asyncio
+    async def test_github_invalid_token(self, test_client):
+        import httpx
+
+        with patch("jenkins_job_insight.main.httpx.AsyncClient") as mock_client_class:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "Unauthorized", request=MagicMock(), response=mock_resp
+            )
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_class.return_value = mock_client
+            response = test_client.post(
+                "/api/validate-token",
+                json={"token_type": "github", "token": "ghp_invalid"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert "Invalid token" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_type(self, test_client):
+        response = test_client.post(
+            "/api/validate-token",
+            json={"token_type": "bitbucket", "token": "some-token"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_jira_no_url_configured(self, test_client):
+        response = test_client.post(
+            "/api/validate-token",
+            json={"token_type": "jira", "token": "jira-token"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert "not configured" in data["message"]


### PR DESCRIPTION
## Summary

Adds user-level tracker tokens so real users can create GitHub issues and Jira bugs under their own identity, while the server retains its own credentials for automated operations (enrichment, background analysis).

Closes #105

## Changes

### Frontend

**New Pages & Components:**
- **`ProfileForm`** — shared form component (username + optional tracker tokens with auto-validation on save)
- **`SettingsPage`** — settings page inside Layout with navbar (for logged-in users editing profile)
- **`RegisterPage`** — standalone full-page form (for first-time registration, no navbar)

**Token Storage:**
- Tokens stored in `localStorage` (`jji_github_token`, `jji_jira_token`, `jji_jira_email`)
- Username stays in cookie (`jji_username`)
- `clearTokens()` on logout

**Issue Creation Flow:**
- GitHub Issue + Jira Bug buttons always visible (never hidden by classification)
- Buttons greyed out with tooltip when: server disabled the feature, or job has no test repo (GitHub only)
- Dialog always opens (preview AI-generated content without tokens)
- "Create" button disabled without token, with link to settings
- User tokens sent in request body, server uses them or falls back to server credentials

**Other:**
- Classification override persistence fix (newest-first ordering bug)
- Re-Analyze button changed from `outline` to `ghost` variant

### Backend

**New Settings:**
- `ENABLE_JIRA_ISSUES` — admin toggle for Jira issue creation (separate from `enable_jira`)
- `enable_jira_issues` in `config.py`

**New Endpoint:**
- `POST /api/validate-token` — validates GitHub/Jira tokens via lightweight API calls (GET /user, GET /myself)
- Uses `Literal["github", "jira"]` for type safety

**Updated Capabilities:**
- `github_issues_enabled` / `jira_issues_enabled` — admin toggles
- `server_github_token` / `server_jira_token` / `server_jira_email` / `server_jira_project_key` — credential availability flags

**Updated Endpoints:**
- Preview/create endpoints accept optional `github_token`, `jira_token`, `jira_email` in request body
- User tokens take precedence over server credentials
- `_build_effective_jira_settings()` clears `jira_pat` and `jira_email` when user provides token (prevents credential mixing)
- Classification guard removed from create endpoints (users choose which tracker)
- GitHub create endpoint resolves `tests_repo_url` from job's `request_params` when not in server config
- Better error messages for 401/403 from tracker APIs

**Security:**
- `jira_token` added to `SENSITIVE_KEYS` for response stripping
- Tokens never logged, never stored server-side
- Whitespace-stripped at all boundaries

### CLI

- `--github-token`, `--jira-token`, `--jira-email` options on `preview-issue` and `create-issue` commands
- New `validate-token` command with hidden token prompt
- Token fields in `ServerConfig` for per-server config file
- Full test coverage

### Tests

- `TestBuildEffectiveJiraSettings` — 5 tests for credential override behavior
- `TestValidateToken` — 4 tests for token validation endpoint
- `TestJJIClientValidateToken` — 3 tests for CLI client
- CLI command tests for `validate-token`
- Updated `_enable_feature()` helper to patch raw fields alongside computed properties
- Updated cookie tests for new token/email helpers

## Peer Review

Reviewed by Cursor (2 rounds). Key findings addressed:
- PAT-clearing in `_build_effective_jira_settings` (server PAT would bypass user token)
- Server email inheritance when user omits email
- CLI parity for validate-token endpoint
- Dead code removal (`api.validateToken`)
- `Literal` type for `token_type`
- Token trimming at boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page and Profile form to store and validate GitHub & Jira tokens locally; API + CLI token validation and per-request token forwarding for issue preview/create
  * Capability responses now report explicit enabled flags and server credential availability

* **Bug Fixes / Chores**
  * Logout now clears stored tokens/credentials
  * .gitignore updated to exclude local DB file

* **UI/UX**
  * Settings link in user menu; issue-create controls disable and show inline hints/tooltips when tokens are missing

* **Tests**
  * Expanded tests for token storage, validation, CLI forwarding, and capability changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->