### PR TITLE
feat: INFRASTRUCTURE classification, Jira project selector, security level, multi-repo (#104)

### DIFF
--- a/frontend/src/constants/classifications.ts
+++ b/frontend/src/constants/classifications.ts
@@ -10,6 +10,6 @@ export const CLASSIFICATIONS = [
 
 export type Classification = (typeof CLASSIFICATIONS)[number]
 
-export const OVERRIDE_CLASSIFICATIONS = ['CODE ISSUE', 'PRODUCT BUG'] as const
+export const OVERRIDE_CLASSIFICATIONS = ['CODE ISSUE', 'PRODUCT BUG', 'INFRASTRUCTURE'] as const
 
 export type OverrideClassification = (typeof OVERRIDE_CLASSIFICATIONS)[number]

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -32,6 +32,8 @@ interface BugCreationDialogProps {
   aiProvider?: string
   aiModel?: string
   includeLinks?: boolean
+  availableRepos?: Array<{ name: string; url: string }>
+  defaultProjectKey?: string
 }
 
 export function BugCreationDialog({
@@ -45,6 +47,8 @@ export function BugCreationDialog({
   includeLinks = false,
   aiProvider,
   aiModel,
+  availableRepos,
+  defaultProjectKey,
 }: BugCreationDialogProps) {
   const dispatch = useReportDispatch()
   const refreshEnrichments = useRefreshEnrichments()
@@ -54,6 +58,10 @@ export function BugCreationDialog({
   const [similar, setSimilar] = useState<SimilarIssue[]>([])
   const [createdUrl, setCreatedUrl] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
+  const [selectedRepo, setSelectedRepo] = useState(availableRepos?.[0]?.url ?? '')
+  const [jiraProjectKey, setJiraProjectKey] = useState(defaultProjectKey || '')
+  const [jiraProjects, setJiraProjects] = useState<Array<{key: string; name: string}>>([])
+  const [jiraSecurityLevel, setJiraSecurityLevel] = useState('')
 
   const previewPath = target === 'github' ? 'preview-github-issue' : 'preview-jira-bug'
   const createPath = target === 'github' ? 'create-github-issue' : 'create-jira-bug'
@@ -65,8 +73,27 @@ export function BugCreationDialog({
       github_token: target === 'github' ? getGithubToken() : '',
       jira_token: target === 'jira' ? getJiraToken() : '',
       jira_email: target === 'jira' ? getJiraEmail() : '',
+      ...(target === 'github' && selectedRepo ? { github_repo_url: selectedRepo } : {}),
+      ...(target === 'jira' && jiraProjectKey ? { jira_project_key: jiraProjectKey } : {}),
+      ...(target === 'jira' && jiraSecurityLevel ? { jira_security_level: jiraSecurityLevel } : {}),
     }
   }
+
+  // Fetch Jira projects when dialog opens for Jira target
+  useEffect(() => {
+    if (!open || target !== 'jira') return
+    api.get<Array<{key: string; name: string}>>('/api/jira-projects')
+      .then((projects) => {
+        setJiraProjects(projects)
+        if (projects.length > 0) {
+          const match = defaultProjectKey
+            ? projects.find((p) => p.key === defaultProjectKey)
+            : undefined
+          setJiraProjectKey(match?.key ?? projects[0].key)
+        }
+      })
+      .catch((err) => console.warn('Failed to fetch Jira projects:', err))
+  }, [open, target])
 
   // Load preview when dialog opens
   useEffect(() => {
@@ -130,6 +157,10 @@ export function BugCreationDialog({
       setSimilar([])
       setCreatedUrl('')
       setErrorMsg('')
+      setSelectedRepo(availableRepos?.[0]?.url ?? '')
+      setJiraProjectKey(defaultProjectKey || '')
+      setJiraProjects([])
+      setJiraSecurityLevel('')
     }, 200)
   }
 
@@ -152,6 +183,39 @@ export function BugCreationDialog({
         {/* Preview */}
         {phase === 'preview' && (
           <div className="space-y-4">
+            {target === 'github' && availableRepos && availableRepos.length > 1 && (
+              <div className="space-y-2">
+                <label htmlFor="bug-repo" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Repository</label>
+                <select id="bug-repo" value={selectedRepo} onChange={(e) => setSelectedRepo(e.target.value)} className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary">
+                  {availableRepos.map((r) => (
+                    <option key={r.url} value={r.url}>{r.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {target === 'jira' && jiraProjects.length > 0 && (
+              <div className="space-y-2">
+                <label htmlFor="bug-jira-project" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Jira Project</label>
+                <select id="bug-jira-project" value={jiraProjectKey} onChange={(e) => setJiraProjectKey(e.target.value)} className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary">
+                  {jiraProjects.map((p) => (
+                    <option key={p.key} value={p.key}>{p.key} — {p.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {target === 'jira' && (
+              <div className="space-y-2">
+                <label htmlFor="bug-security-level" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Security Level</label>
+                <input
+                  id="bug-security-level"
+                  type="text"
+                  value={jiraSecurityLevel}
+                  onChange={(e) => setJiraSecurityLevel(e.target.value)}
+                  placeholder="e.g. Red Hat Employee"
+                  className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary placeholder:text-text-tertiary"
+                />
+              </div>
+            )}
             {similar.length > 0 && (
               <div className="rounded-md border border-signal-orange/30 bg-glow-orange p-3">
                 <div className="flex items-center gap-2 text-sm font-medium text-signal-orange">

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -466,6 +466,11 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
           childBuildNumber={scopedChildBuildNumber}
           aiProvider={selectedProvider}
           aiModel={selectedModel}
+          availableRepos={
+            repoUrls.length > 0
+              ? repoUrls.map(({ name, url }) => ({ name, url }))
+              : undefined
+          }
         />
       )}
     </>

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -110,9 +110,15 @@ function reportReducer(state: ReportState, action: ReportAction): ReportState {
       const normalizedChildBuildNumber = childJobName ? (childBuildNumber ?? 0) : childBuildNumber
       const names = explicitNames ?? [testName]
       const nameSet = new Set(names)
+      // Determine which classification-specific fields to clear based on the new classification
+      const clearFields: Partial<Record<'code_fix' | 'product_bug_report', undefined>> =
+        classification === 'CODE ISSUE' ? { product_bug_report: undefined }
+        : classification === 'PRODUCT BUG' ? { code_fix: undefined }
+        : classification === 'INFRASTRUCTURE' ? { code_fix: undefined, product_bug_report: undefined }
+        : {}
       const patchFailures = (fs: typeof state.result.failures) =>
         (fs ?? []).map((f) =>
-          nameSet.has(f.test_name) ? { ...f, analysis: { ...f.analysis, classification } } : f,
+          nameSet.has(f.test_name) ? { ...f, analysis: { ...f.analysis, classification, ...clearFields } } : f,
         )
       const isWildcard = normalizedChildBuildNumber === 0
       /** Check whether a child node matches the target job name with wildcard/exact build semantics. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,9 @@ pythonpath = ["src"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/jenkins_job_insight"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]

--- a/src/jenkins_job_insight/bug_creation.py
+++ b/src/jenkins_job_insight/bug_creation.py
@@ -613,6 +613,8 @@ async def create_jira_bug(
     body: str,
     settings: Settings,
     priority: str = "",
+    project_key: str = "",
+    security_level: str = "",
 ) -> dict:
     """Create a Jira Bug issue via the REST API.
 
@@ -622,7 +624,7 @@ async def create_jira_bug(
     Raises httpx.HTTPStatusError on failure.
     """
     base_url = (settings.jira_url or "").rstrip("/")
-    project_key = settings.jira_project_key or ""
+    effective_project_key = project_key or settings.jira_project_key or ""
 
     # Resolve auth (same logic as JiraClient)
     token_value = ""
@@ -647,7 +649,7 @@ async def create_jira_bug(
 
     payload: dict = {
         "fields": {
-            "project": {"key": project_key},
+            "project": {"key": effective_project_key},
             "summary": title,
             "description": body,
             "issuetype": {"name": "Bug"},
@@ -655,6 +657,8 @@ async def create_jira_bug(
     }
     if priority:
         payload["fields"]["priority"] = {"name": priority}
+    if security_level:
+        payload["fields"]["security"] = {"name": security_level}
 
     async with httpx.AsyncClient(
         verify=settings.jira_ssl_verify, timeout=15, auth=auth

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -359,8 +359,11 @@ class JJIClient:
         title: str = "",
         body_text: str = "",
         github_token: str = "",
+        github_repo_url: str = "",
         jira_token: str = "",
         jira_email: str = "",
+        jira_project_key: str = "",
+        jira_security_level: str = "",
         include_github: bool = True,
         include_jira: bool = True,
     ) -> dict:
@@ -378,10 +381,16 @@ class JJIClient:
             payload["ai_model"] = ai_model
         if include_github and github_token:
             payload["github_token"] = github_token
+        if include_github and github_repo_url:
+            payload["github_repo_url"] = github_repo_url
         if include_jira and jira_token:
             payload["jira_token"] = jira_token
         if include_jira and jira_email:
             payload["jira_email"] = jira_email
+        if include_jira and jira_project_key:
+            payload["jira_project_key"] = jira_project_key
+        if include_jira and jira_security_level:
+            payload["jira_security_level"] = jira_security_level
         return self._with_child_scope(payload, child_job_name, child_build_number)
 
     def preview_github_issue(
@@ -394,8 +403,7 @@ class JJIClient:
         ai_provider: str = "",
         ai_model: str = "",
         github_token: str = "",
-        jira_token: str = "",
-        jira_email: str = "",
+        github_repo_url: str = "",
     ) -> dict:
         """Preview a GitHub issue. POST /results/{job_id}/preview-github-issue"""
         body = self._build_tracker_body(
@@ -406,8 +414,7 @@ class JJIClient:
             ai_provider=ai_provider,
             ai_model=ai_model,
             github_token=github_token,
-            jira_token=jira_token,
-            jira_email=jira_email,
+            github_repo_url=github_repo_url,
             include_jira=False,
         )
         return self._request(
@@ -423,9 +430,10 @@ class JJIClient:
         include_links: bool = False,
         ai_provider: str = "",
         ai_model: str = "",
-        github_token: str = "",
         jira_token: str = "",
         jira_email: str = "",
+        jira_project_key: str = "",
+        jira_security_level: str = "",
     ) -> dict:
         """Preview a Jira bug. POST /results/{job_id}/preview-jira-bug"""
         body = self._build_tracker_body(
@@ -435,9 +443,10 @@ class JJIClient:
             include_links=include_links,
             ai_provider=ai_provider,
             ai_model=ai_model,
-            github_token=github_token,
             jira_token=jira_token,
             jira_email=jira_email,
+            jira_project_key=jira_project_key,
+            jira_security_level=jira_security_level,
             include_github=False,
         )
         return self._request("POST", f"/results/{job_id}/preview-jira-bug", json=body)
@@ -451,8 +460,7 @@ class JJIClient:
         child_job_name: str = "",
         child_build_number: int = 0,
         github_token: str = "",
-        jira_token: str = "",
-        jira_email: str = "",
+        github_repo_url: str = "",
     ) -> dict:
         """Create a GitHub issue. POST /results/{job_id}/create-github-issue"""
         payload = self._build_tracker_body(
@@ -462,8 +470,7 @@ class JJIClient:
             title=title,
             body_text=body,
             github_token=github_token,
-            jira_token=jira_token,
-            jira_email=jira_email,
+            github_repo_url=github_repo_url,
             include_jira=False,
         )
         return self._request(
@@ -481,9 +488,10 @@ class JJIClient:
         body: str,
         child_job_name: str = "",
         child_build_number: int = 0,
-        github_token: str = "",
         jira_token: str = "",
         jira_email: str = "",
+        jira_project_key: str = "",
+        jira_security_level: str = "",
     ) -> dict:
         """Create a Jira bug. POST /results/{job_id}/create-jira-bug"""
         payload = self._build_tracker_body(
@@ -492,9 +500,10 @@ class JJIClient:
             child_build_number,
             title=title,
             body_text=body,
-            github_token=github_token,
             jira_token=jira_token,
             jira_email=jira_email,
+            jira_project_key=jira_project_key,
+            jira_security_level=jira_security_level,
             include_github=False,
         )
         return self._request(
@@ -523,6 +532,12 @@ class JJIClient:
     def capabilities(self) -> dict:
         """Get server-level automation capabilities (GitHub issues, Jira bugs). GET /api/capabilities"""
         return self._request("GET", "/api/capabilities")
+
+    # -- Jira Projects --------------------------------------------------------
+
+    def jira_projects(self) -> list[dict]:
+        """List Jira projects. GET /api/jira-projects"""
+        return self._request("GET", "/api/jira-projects")
 
     # -- AI Configs -----------------------------------------------------------
 

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -40,11 +40,13 @@ class ServerConfig:
     jira_pat: str = ""
     jira_token: str = ""
     jira_project_key: str = ""
+    jira_security_level: str = ""
     jira_ssl_verify: bool | None = None
     jira_max_results: int = 0  # 0 means use server default
     enable_jira: bool | None = None
     # GitHub
     github_token: str = ""
+    github_repo_url: str = ""
     # Peer analysis
     peers: str = ""  # "provider:model,provider:model" format
     peer_analysis_max_rounds: int = 0  # 0 = not set, use server default
@@ -219,11 +221,13 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jira_pat=data.get("jira_pat", ""),
         jira_token=_validated_str(data, "jira_token"),
         jira_project_key=data.get("jira_project_key", ""),
+        jira_security_level=_validated_str(data, "jira_security_level"),
         jira_ssl_verify=data.get("jira_ssl_verify"),
         jira_max_results=data.get("jira_max_results", 0),
         enable_jira=data.get("enable_jira"),
         # GitHub
         github_token=data.get("github_token", ""),
+        github_repo_url=_validated_str(data, "github_repo_url"),
         # Jenkins job monitoring
         wait_for_completion=data.get("wait_for_completion"),
         poll_interval_minutes=data.get("poll_interval_minutes", 0),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1102,6 +1102,28 @@ def capabilities(
         print_output(data, columns=[], as_json=True)
 
 
+@app.command("jira-projects")
+def jira_projects_cmd(
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """List available Jira projects."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.jira_projects(),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        if not data:
+            typer.echo("No Jira projects found.")
+        else:
+            print_output(
+                data,
+                columns=["key", "name"],
+                labels={"key": "KEY", "name": "NAME"},
+                as_json=False,
+            )
+
+
 @app.command("ai-configs")
 def ai_configs(
     json_output: bool = _JSON_OPTION,
@@ -1132,14 +1154,24 @@ def ai_configs(
 
 
 def _resolve_tracker_tokens(
-    github_token: str, jira_token: str, jira_email: str
-) -> tuple[str, str, str]:
-    """Resolve tracker tokens with config fallback."""
+    github_token: str,
+    jira_token: str,
+    jira_email: str,
+    jira_project_key: str = "",
+    github_repo_url: str = "",
+    jira_security_level: str = "",
+) -> tuple[str, str, str, str, str, str]:
+    """Resolve tracker tokens and related fields with config fallback."""
     cfg = _state.get("server_config")
     return (
         github_token.strip() or ((cfg.github_token or "").strip() if cfg else ""),
         jira_token.strip() or ((cfg.jira_token or "").strip() if cfg else ""),
         jira_email.strip() or ((cfg.jira_email or "").strip() if cfg else ""),
+        jira_project_key.strip()
+        or ((cfg.jira_project_key or "").strip() if cfg else ""),
+        github_repo_url.strip() or ((cfg.github_repo_url or "").strip() if cfg else ""),
+        jira_security_level.strip()
+        or ((cfg.jira_security_level or "").strip() if cfg else ""),
     )
 
 
@@ -1176,6 +1208,11 @@ def preview_issue(
         "--github-token",
         help="GitHub PAT for issue creation (overrides server config).",
     ),
+    github_repo_url: str = typer.Option(
+        "",
+        "--github-repo-url",
+        help="GitHub repository URL (overrides server config).",
+    ),
     jira_token: str = typer.Option(
         "",
         "--jira-token",
@@ -1184,13 +1221,35 @@ def preview_issue(
     jira_email: str = typer.Option(
         "", "--jira-email", help="Jira email for Cloud auth (used with --jira-token)."
     ),
+    jira_project_key: str = typer.Option(
+        "",
+        "--jira-project-key",
+        help="Jira project key for bug creation (overrides server config).",
+    ),
+    jira_security_level: str = typer.Option(
+        "",
+        "--jira-security-level",
+        help="Jira security level name for restricted issues.",
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Preview generated issue content (GitHub or Jira)."""
     _set_json(json_output)
     normalized_type = _validate_issue_type(issue_type)
-    _github_token, _jira_token, _jira_email = _resolve_tracker_tokens(
-        github_token, jira_token, jira_email
+    (
+        _github_token,
+        _jira_token,
+        _jira_email,
+        _jira_project_key,
+        _github_repo_url,
+        _jira_security_level,
+    ) = _resolve_tracker_tokens(
+        github_token,
+        jira_token,
+        jira_email,
+        jira_project_key,
+        github_repo_url,
+        jira_security_level,
     )
     try:
         client = _get_client()
@@ -1204,6 +1263,7 @@ def preview_issue(
                 ai_provider=ai_provider,
                 ai_model=ai_model,
                 github_token=_github_token,
+                github_repo_url=_github_repo_url,
             )
         else:
             data = client.preview_jira_bug(
@@ -1216,6 +1276,8 @@ def preview_issue(
                 ai_model=ai_model,
                 jira_token=_jira_token,
                 jira_email=_jira_email,
+                jira_project_key=_jira_project_key,
+                jira_security_level=_jira_security_level,
             )
     except JJIError as err:
         _handle_error(err)
@@ -1247,6 +1309,11 @@ def create_issue(
         "--github-token",
         help="GitHub PAT for issue creation (overrides server config).",
     ),
+    github_repo_url: str = typer.Option(
+        "",
+        "--github-repo-url",
+        help="GitHub repository URL (overrides server config).",
+    ),
     jira_token: str = typer.Option(
         "",
         "--jira-token",
@@ -1255,13 +1322,35 @@ def create_issue(
     jira_email: str = typer.Option(
         "", "--jira-email", help="Jira email for Cloud auth (used with --jira-token)."
     ),
+    jira_project_key: str = typer.Option(
+        "",
+        "--jira-project-key",
+        help="Jira project key for bug creation (overrides server config).",
+    ),
+    jira_security_level: str = typer.Option(
+        "",
+        "--jira-security-level",
+        help="Jira security level name for restricted issues.",
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Create a GitHub issue or Jira bug from a failure analysis."""
     _set_json(json_output)
     normalized_type = _validate_issue_type(issue_type)
-    _github_token, _jira_token, _jira_email = _resolve_tracker_tokens(
-        github_token, jira_token, jira_email
+    (
+        _github_token,
+        _jira_token,
+        _jira_email,
+        _jira_project_key,
+        _github_repo_url,
+        _jira_security_level,
+    ) = _resolve_tracker_tokens(
+        github_token,
+        jira_token,
+        jira_email,
+        jira_project_key,
+        github_repo_url,
+        jira_security_level,
     )
     try:
         client = _get_client()
@@ -1274,6 +1363,7 @@ def create_issue(
                 child_job_name=child_job_name,
                 child_build_number=child_build_number,
                 github_token=_github_token,
+                github_repo_url=_github_repo_url,
             )
         else:
             data = client.create_jira_bug(
@@ -1285,6 +1375,8 @@ def create_issue(
                 child_build_number=child_build_number,
                 jira_token=_jira_token,
                 jira_email=_jira_email,
+                jira_project_key=_jira_project_key,
+                jira_security_level=_jira_security_level,
             )
     except JJIError as err:
         _handle_error(err)
@@ -1330,7 +1422,10 @@ def override_classification_cmd(
     job_id: str = typer.Argument(help="Job ID."),
     test_name: str = typer.Option(..., "--test", "-t", help="Test name."),
     classification: str = typer.Option(
-        ..., "--classification", "-c", help="CODE ISSUE or PRODUCT BUG."
+        ...,
+        "--classification",
+        "-c",
+        help="CODE ISSUE, PRODUCT BUG, or INFRASTRUCTURE.",
     ),
     child_job_name: str = typer.Option("", "--child-job"),
     child_build_number: int = typer.Option(0, "--child-build"),

--- a/src/jenkins_job_insight/jira.py
+++ b/src/jenkins_job_insight/jira.py
@@ -101,6 +101,17 @@ class JiraClient:
     async def __aexit__(self, *exc) -> None:
         await self.close()
 
+    async def list_projects(self) -> list[dict]:
+        """List all accessible Jira projects."""
+        try:
+            response = await self._client.get(f"{self._api_path}/project")
+            response.raise_for_status()
+            data = response.json()
+            return [{"key": p["key"], "name": p.get("name", p["key"])} for p in data]
+        except Exception:
+            logger.warning("Failed to fetch Jira projects", exc_info=True)
+            return []
+
     async def search(self, keywords: list[str]) -> list[dict]:
         """Search Jira for Bug issues matching the given keywords.
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -41,6 +41,7 @@ from jenkins_job_insight.encryption import (
 )
 from jenkins_job_insight.jira import enrich_with_jira_matches
 from jenkins_job_insight.bug_creation import (
+    _parse_github_repo_url,
     create_github_issue,
     create_jira_bug,
     generate_github_issue_content,
@@ -1602,6 +1603,9 @@ async def _resolve_effective_failure(
         updates["product_bug_report"] = False
     elif effective_cls == "PRODUCT BUG":
         updates["code_fix"] = False
+    elif effective_cls == "INFRASTRUCTURE":
+        updates["code_fix"] = False
+        updates["product_bug_report"] = False
     return failure.model_copy(
         update={"analysis": failure.analysis.model_copy(update=updates)}
     )
@@ -1823,6 +1827,29 @@ def _resolve_tests_repo_url(settings: Settings, result_data: dict) -> str:
     return url
 
 
+def _resolve_github_repo_url(
+    body_repo_url: str, settings: Settings, result_data: dict
+) -> str:
+    """Validate and resolve GitHub repo URL from request body or fallback.
+
+    If *body_repo_url* is provided it is validated via ``_parse_github_repo_url``
+    (which raises ``ValueError`` on bad input).  Otherwise falls back to
+    ``_resolve_tests_repo_url``.
+
+    Raises:
+        HTTPException: 400 when *body_repo_url* is invalid.
+    """
+    if body_repo_url:
+        try:
+            _parse_github_repo_url(body_repo_url)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid github_repo_url: {exc}"
+            ) from exc
+        return body_repo_url
+    return _resolve_tests_repo_url(settings, result_data)
+
+
 async def _load_effective_failure(
     job_id: str,
     test_name: str,
@@ -1905,7 +1932,9 @@ async def preview_github_issue(
     )
 
     # Duplicate detection (best-effort: failures must not break preview)
-    tests_repo_url = _resolve_tests_repo_url(settings, result_data)
+    tests_repo_url = _resolve_github_repo_url(
+        body.github_repo_url, settings, result_data
+    )
     github_token = (body.github_token or "").strip() or (
         settings.github_token.get_secret_value() if settings.github_token else ""
     )
@@ -1978,7 +2007,7 @@ async def preview_jira_bug(
     # Duplicate detection (best-effort: failures must not break preview)
     similar: list[dict] = []
     effective_jira_settings = _build_effective_jira_settings(
-        settings, body.jira_token, body.jira_email
+        settings, body.jira_token, body.jira_email, body.jira_project_key
     )
     if (
         _has_jira_credentials(effective_jira_settings)
@@ -2041,7 +2070,10 @@ def _build_capabilities(settings: Settings) -> dict[str, bool]:
 
 
 def _build_effective_jira_settings(
-    settings: Settings, user_jira_token: str, user_jira_email: str
+    settings: Settings,
+    user_jira_token: str,
+    user_jira_email: str,
+    user_jira_project_key: str = "",
 ) -> Settings:
     """Build effective settings with user Jira credentials overriding server defaults.
 
@@ -2056,16 +2088,23 @@ def _build_effective_jira_settings(
     incorrectly trigger Cloud Basic auth). Cloud users must explicitly provide
     their email; without it, the non-Cloud auth path is used, which may
     fail against Cloud-only Jira hosts.
+
+    An optional *user_jira_project_key* overrides the server-level project key
+    so that duplicate searches and bug creation target the user's chosen project.
     """
-    if not user_jira_token or not user_jira_token.strip():
+    overrides: dict = {}
+    if user_jira_token and user_jira_token.strip():
+        overrides["jira_api_token"] = SecretStr(user_jira_token.strip())
+        overrides["jira_pat"] = None
+        overrides["jira_email"] = (
+            user_jira_email.strip()
+            if user_jira_email and user_jira_email.strip()
+            else None
+        )
+    if user_jira_project_key and user_jira_project_key.strip():
+        overrides["jira_project_key"] = user_jira_project_key.strip()
+    if not overrides:
         return settings
-    overrides: dict = {
-        "jira_api_token": SecretStr(user_jira_token.strip()),
-        "jira_pat": None,
-        "jira_email": user_jira_email.strip()
-        if user_jira_email and user_jira_email.strip()
-        else None,
-    }
     return settings.model_copy(update=overrides)
 
 
@@ -2166,7 +2205,9 @@ async def create_github_issue_endpoint(
     if username:
         issue_body += f"\n\n---\n_Reported by: {username} via jenkins-job-insight_"
 
-    tests_repo_url = _resolve_tests_repo_url(settings, _result_data)
+    tests_repo_url = _resolve_github_repo_url(
+        body.github_repo_url, settings, _result_data
+    )
     if not tests_repo_url:
         raise HTTPException(
             status_code=400,
@@ -2253,12 +2294,12 @@ async def create_jira_bug_endpoint(
 
     try:
         effective_jira_settings = _build_effective_jira_settings(
-            settings, body.jira_token, body.jira_email
+            settings, body.jira_token, body.jira_email, body.jira_project_key
         )
         if not effective_jira_settings.jira_project_key:
             raise HTTPException(
                 status_code=400,
-                detail="Jira project key is not configured on the server.",
+                detail="Jira project key is required. Provide it in the request or configure JIRA_PROJECT_KEY on the server.",
             )
         if not _has_jira_credentials(effective_jira_settings):
             raise HTTPException(
@@ -2269,6 +2310,8 @@ async def create_jira_bug_endpoint(
             title=body.title,
             body=bug_body,
             settings=effective_jira_settings,
+            project_key=body.jira_project_key,
+            security_level=body.jira_security_level,
         )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code in (401, 403):
@@ -2308,8 +2351,10 @@ def _patch_failure_classification(
 ) -> None:
     """Patch classification for matching failures in a list.
 
-    Also clears stale subtype fields: when switching to CODE ISSUE the
-    old product_bug_report is removed, and vice-versa.
+    Also clears stale subtype fields:
+    - CODE ISSUE: clears product_bug_report
+    - PRODUCT BUG: clears code_fix
+    - INFRASTRUCTURE: clears both product_bug_report and code_fix
     """
     for f in failures:
         if f.get("test_name") == test_name:
@@ -2319,6 +2364,9 @@ def _patch_failure_classification(
                 if classification == "CODE ISSUE":
                     analysis.pop("product_bug_report", None)
                 elif classification == "PRODUCT BUG":
+                    analysis.pop("code_fix", None)
+                elif classification == "INFRASTRUCTURE":
+                    analysis.pop("product_bug_report", None)
                     analysis.pop("code_fix", None)
 
 
@@ -2385,7 +2433,7 @@ async def override_classification_endpoint(
     body: OverrideClassificationRequest,
     request: Request,
 ) -> dict:
-    """Override the classification of a failure (CODE ISSUE / PRODUCT BUG)."""
+    """Override the classification of a failure (CODE ISSUE, PRODUCT BUG, or INFRASTRUCTURE)."""
     logger.debug(
         f"PUT /results/{job_id}/override-classification: test_name={body.test_name}, "
         f"classification={body.classification}"
@@ -2494,6 +2542,20 @@ async def get_capabilities(settings: Settings = Depends(get_settings)) -> dict:
     UI can decide if user-supplied tokens are required or optional.
     """
     return _build_capabilities(settings)
+
+
+@app.get("/api/jira-projects")
+async def list_jira_projects(
+    settings: Settings = Depends(get_settings),
+) -> list[dict]:
+    """List available Jira projects for the project selector."""
+    if not settings.jira_url:
+        return []
+
+    from jenkins_job_insight.jira import JiraClient
+
+    async with JiraClient(settings) as client:
+        return await client.list_projects()
 
 
 class ValidateTokenRequest(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -269,7 +269,9 @@ class CodeFix(BaseModel):
 class AnalysisDetail(BaseModel):
     """Structured AI analysis broken into sections."""
 
-    classification: str = Field(default="", description="CODE ISSUE or PRODUCT BUG")
+    classification: str = Field(
+        default="", description="CODE ISSUE, PRODUCT BUG, or INFRASTRUCTURE (override)"
+    )
     affected_tests: list[str] = Field(
         default_factory=list, description="List of affected test names"
     )
@@ -529,6 +531,20 @@ class _TrackerCredentialsMixin(BaseModel):
         default="", description="User's Jira token for bug creation"
     )
     jira_email: str = Field(default="", description="User's Jira email for Cloud auth")
+    jira_project_key: str = Field(
+        default="", description="Override Jira project key for bug creation"
+    )
+    jira_security_level: str = Field(
+        default="", description="Jira security level name for restricted issues"
+    )
+    github_repo_url: str = Field(
+        default="", description="Override GitHub repo URL for issue creation"
+    )
+
+    @field_validator("jira_project_key", "jira_security_level", "github_repo_url")
+    @classmethod
+    def _strip_tracker_overrides(cls, v: str) -> str:
+        return v.strip() if isinstance(v, str) else v
 
 
 # NOTE: Preview/create request models intentionally do NOT inherit
@@ -563,7 +579,7 @@ class CreateIssueRequest(_ChildJobFieldsValidator, _TrackerCredentialsMixin):
         return v
 
 
-OverrideClassificationLiteral = Literal["CODE ISSUE", "PRODUCT BUG"]
+OverrideClassificationLiteral = Literal["CODE ISSUE", "PRODUCT BUG", "INFRASTRUCTURE"]
 HistoryClassificationLiteral = Literal[
     "FLAKY", "REGRESSION", "INFRASTRUCTURE", "KNOWN_BUG", "INTERMITTENT"
 ]

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -637,6 +637,34 @@ class TestJJIClientIssueTokens:
             test_name="tests.TestA.test_one",
         )
 
+    def test_create_jira_bug_includes_jira_security_level(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/results/job-1/create-jira-bug" in str(request.url)
+            body = json.loads(request.content)
+            assert body["jira_security_level"] == "Restricted"
+            return httpx.Response(
+                201,
+                json={
+                    "url": "https://jira.example.com/browse/PROJ-2",
+                    "key": "PROJ-2",
+                    "title": "Bug",
+                    "comment_id": 1,
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.create_jira_bug(
+            job_id="job-1",
+            test_name="tests.TestA.test_one",
+            title="Bug",
+            body="Details",
+            jira_token="jira-tok-test",  # noqa: S106
+            jira_email="test@example.com",
+            jira_security_level="Restricted",
+        )
+        assert result["key"] == "PROJ-2"
+
 
 class TestJJIClientCrossCredentialLeakage:
     """Verify that GitHub methods never include Jira credentials and vice versa."""
@@ -661,8 +689,6 @@ class TestJJIClientCrossCredentialLeakage:
             job_id="job-1",
             test_name="tests.TestA.test_one",
             github_token="ghp_test",  # noqa: S106
-            jira_token="jira-should-not-appear",  # noqa: S106
-            jira_email="leak@example.com",
         )
 
     def test_create_github_issue_excludes_jira_credentials(self):
@@ -691,8 +717,6 @@ class TestJJIClientCrossCredentialLeakage:
             title="Bug",
             body="Details",
             github_token="ghp_test",  # noqa: S106
-            jira_token="jira-should-not-appear",  # noqa: S106
-            jira_email="leak@example.com",
         )
 
     def test_preview_jira_bug_excludes_github_credentials(self):
@@ -711,7 +735,6 @@ class TestJJIClientCrossCredentialLeakage:
         client.preview_jira_bug(
             job_id="job-1",
             test_name="tests.TestA.test_one",
-            github_token="ghp-should-not-appear",  # noqa: S106
             jira_token="jira-tok",  # noqa: S106
         )
 
@@ -737,7 +760,6 @@ class TestJJIClientCrossCredentialLeakage:
             test_name="tests.TestA.test_one",
             title="Bug",
             body="Details",
-            github_token="ghp-should-not-appear",  # noqa: S106
             jira_token="jira-tok",  # noqa: S106
         )
 
@@ -1065,6 +1087,19 @@ class TestJJIClientValidateToken:
 
         client = _make_client(handler)
         client.validate_token(token_type="jira", token="jira-tok")  # noqa: S106
+
+
+class TestJJIClientJiraProjects:
+    def test_jira_projects(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert "/api/jira-projects" in str(request.url)
+            return httpx.Response(200, json=[{"key": "PROJ", "name": "My Project"}])
+
+        client = _make_client(handler)
+        result = client.jira_projects()
+        assert len(result) == 1
+        assert result[0]["key"] == "PROJ"
 
 
 class TestJJIClientReAnalyze:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2213,6 +2213,31 @@ class TestValidateTokenCommand:
         assert kwargs["email"] == "user@example.com"
 
 
+class TestJiraProjectsCommand:
+    def test_jira_projects(self, mock_client):
+        mock_client.jira_projects.return_value = [
+            {"key": "PROJ", "name": "My Project"},
+        ]
+        result = runner.invoke(app, ["jira-projects"])
+        assert result.exit_code == 0
+        assert "PROJ" in result.output
+
+    def test_jira_projects_json(self, mock_client):
+        mock_client.jira_projects.return_value = [
+            {"key": "PROJ", "name": "My Project"},
+        ]
+        result = runner.invoke(app, ["--json", "jira-projects"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
+        assert parsed[0]["key"] == "PROJ"
+
+    def test_jira_projects_empty(self, mock_client):
+        mock_client.jira_projects.return_value = []
+        result = runner.invoke(app, ["jira-projects"])
+        assert result.exit_code == 0
+
+
 class TestReAnalyzeCommand:
     def test_re_analyze(self, mock_client):
         mock_client.re_analyze.return_value = {

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -227,6 +227,36 @@ class TestJiraClient:
                 == "Bearer ATATT3xFfGF0AbM93-cloud-api-token"
             )
 
+    async def test_list_projects_returns_projects(self, jira_settings) -> None:
+        """list_projects returns project key and name."""
+        mock_response = httpx.Response(
+            200,
+            json=[
+                {"key": "PROJ", "name": "My Project"},
+                {"key": "OTHER", "name": "Other Project"},
+            ],
+            request=httpx.Request("GET", "https://jira.example.com"),
+        )
+        client = JiraClient(jira_settings)
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            projects = await client.list_projects()
+        assert len(projects) == 2
+        assert projects[0] == {"key": "PROJ", "name": "My Project"}
+        assert projects[1] == {"key": "OTHER", "name": "Other Project"}
+        await client.close()
+
+    async def test_list_projects_returns_empty_on_error(self, jira_settings) -> None:
+        """list_projects returns empty list on error."""
+        client = JiraClient(jira_settings)
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, side_effect=Exception("fail")
+        ):
+            projects = await client.list_projects()
+        assert projects == []
+        await client.close()
+
     async def test_search_returns_candidates(self, jira_settings) -> None:
         """Search returns candidate dicts from API response."""
         mock_response = httpx.Response(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1851,6 +1851,60 @@ class TestOverrideClassification:
         )
         assert response.status_code == 422
 
+    @pytest.mark.asyncio
+    async def test_override_to_infrastructure(self, test_client):
+        """Override classification to INFRASTRUCTURE clears code_fix and product_bug_report."""
+        result_data = {
+            "status": "completed",
+            "summary": "",
+            "failures": [
+                {
+                    "test_name": "test_deploy_check",
+                    "error": "timeout",
+                    "analysis": {
+                        "classification": "CODE ISSUE",
+                        "code_fix": {
+                            "file": "deploy.py",
+                            "line": "42",
+                            "change": "fix timeout",
+                        },
+                        "product_bug_report": {
+                            "title": "stale report",
+                            "severity": "high",
+                            "component": "deploy",
+                            "description": "leftover",
+                            "evidence": "none",
+                        },
+                    },
+                }
+            ],
+        }
+        await storage.save_result(
+            "job-override-infra", "http://jenkins", "completed", result_data
+        )
+        with patch(
+            "jenkins_job_insight.storage.override_classification",
+            return_value=["test_deploy_check"],
+        ) as mock_override:
+            response = test_client.put(
+                "/results/job-override-infra/override-classification",
+                json={
+                    "test_name": "test_deploy_check",
+                    "classification": "INFRASTRUCTURE",
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["classification"] == "INFRASTRUCTURE"
+        mock_override.assert_called_once()
+
+        # Verify code_fix and product_bug_report are cleared from persisted result
+        stored = await storage.get_result("job-override-infra")
+        failure_analysis = stored["result"]["failures"][0]["analysis"]
+        assert "code_fix" not in failure_analysis
+        assert "product_bug_report" not in failure_analysis
+
 
 class TestBugCreationIntegration:
     """Integration tests for the full bug creation flow."""
@@ -4080,3 +4134,34 @@ class TestValidateToken:
         data = response.json()
         assert data["valid"] is False
         assert "not configured" in data["message"]
+
+
+class TestJiraProjectsEndpoint:
+    """Tests for GET /api/jira-projects."""
+
+    def test_no_jira_url_returns_empty(self, test_client):
+        """No JIRA_URL configured returns empty list."""
+        response = test_client.get("/api/jira-projects")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_projects(self, test_client):
+        """Returns project list from JiraClient.list_projects."""
+        from jenkins_job_insight.main import app, get_settings
+
+        projects = [{"key": "PROJ", "name": "My Project"}]
+        jira_settings = _build_wait_settings(jira_url="https://jira.example.com")
+        app.dependency_overrides[get_settings] = lambda: jira_settings
+        try:
+            with patch("jenkins_job_insight.jira.JiraClient") as MockJiraClient:
+                mock_client = AsyncMock()
+                mock_client.list_projects = AsyncMock(return_value=projects)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockJiraClient.return_value = mock_client
+                response = test_client.get("/api/jira-projects")
+            assert response.status_code == 200
+            assert response.json() == projects
+        finally:
+            app.dependency_overrides.pop(get_settings, None)

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,12 @@ tests = [
     { name = "pytest-asyncio" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "ai-cli-runner", specifier = ">=0.1.1" },
@@ -409,6 +415,12 @@ requires-dist = [
     { name = "uvicorn" },
 ]
 provides-extras = ["tests"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+]
 
 [[package]]
 name = "markdown-it-py"


### PR DESCRIPTION
## Summary

Adds INFRASTRUCTURE as a user-override classification, Jira project selection, security level support, and multi-repo GitHub issue creation.

Closes #104

## Changes

### INFRASTRUCTURE Classification
- Added to `OverrideClassificationLiteral` and frontend `OVERRIDE_CLASSIFICATIONS`
- Stale `code_fix` and `product_bug_report` fields cleared when overriding to INFRASTRUCTURE
- Both backend (`_patch_failure_classification`) and frontend (`OVERRIDE_CLASSIFICATION` reducer) handle cleanup
- INFRASTRUCTURE is human-override only — AI continues to classify as CODE ISSUE / PRODUCT BUG

### Jira Project Selector
- New `GET /api/jira-projects` endpoint using `JiraClient.list_projects()`
- Frontend: project dropdown in BugCreationDialog with server default pre-selected
- `jira_project_key` override in `CreateIssueRequest` / `PreviewIssueRequest`
- CLI: `jji jira-projects` command + `--jira-project-key` option

### Jira Security Level
- `jira_security_level` field in request models
- Passed to Jira API as `fields.security.name`
- Frontend: text input in BugCreationDialog (e.g. "Red Hat Employee")
- CLI: `--jira-security-level` option

### Multi-Repo GitHub Issues
- `github_repo_url` override in request models
- Frontend: repo dropdown when multiple repos available (tests_repo_url + additional_repos)
- URL validated against GitHub pattern via `_parse_github_repo_url()`
- CLI: `--github-repo-url` option

### CLI Parity
- `jji jira-projects` command
- `--jira-project-key`, `--github-repo-url`, `--jira-security-level` on preview-issue/create-issue
- Config file support for all new fields

## Peer Review
Reviewed by Cursor (2 rounds). Key findings addressed:
- CLI parity for jira_security_level
- Stale sub-documents when overriding to INFRASTRUCTURE
- Updated help strings and docstrings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "INFRASTRUCTURE" as a failure classification.
  * UI & CLI: select Jira project and security level when creating Jira bugs; UI auto-fetches projects and picks a default.
  * UI & CLI: select GitHub repository when creating GitHub issues.
  * New API/CLI command to list available Jira projects.

* **Behavior Changes**
  * Choosing INFRASTRUCTURE clears other classification-specific analysis fields.

* **Tests**
  * Added tests for INFRASTRUCTURE classification, Jira projects listing, and create/preview flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->