### PR TITLE
feat: Jira project selector, security levels, auth fix (#104)

### DIFF
--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -174,6 +174,7 @@ function ReportContent() {
         if (resultRes.capabilities) {
           dispatch({ type: 'SET_GITHUB_ISSUES_ENABLED', payload: resultRes.capabilities?.github_issues_enabled ?? false })
           dispatch({ type: 'SET_JIRA_ISSUES_ENABLED', payload: resultRes.capabilities?.jira_issues_enabled ?? false })
+          dispatch({ type: 'SET_SERVER_JIRA_PROJECT_KEY', payload: resultRes.capabilities?.server_jira_project_key ?? '' })
         }
 
         // Initial comment fetch via the shared single-flight helper

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -60,8 +60,12 @@ export function BugCreationDialog({
   const [errorMsg, setErrorMsg] = useState('')
   const [selectedRepo, setSelectedRepo] = useState(availableRepos?.[0]?.url ?? '')
   const [jiraProjectKey, setJiraProjectKey] = useState(defaultProjectKey || '')
+  const [confirmedProjectKey, setConfirmedProjectKey] = useState(defaultProjectKey || '')
   const [jiraProjects, setJiraProjects] = useState<Array<{key: string; name: string}>>([])
   const [jiraSecurityLevel, setJiraSecurityLevel] = useState('')
+  const [showProjectDropdown, setShowProjectDropdown] = useState(false)
+  const [showSecurityDropdown, setShowSecurityDropdown] = useState(false)
+  const [securityLevels, setSecurityLevels] = useState<Array<{id: string; name: string; description: string}>>([])
 
   const previewPath = target === 'github' ? 'preview-github-issue' : 'preview-jira-bug'
   const createPath = target === 'github' ? 'create-github-issue' : 'create-jira-bug'
@@ -79,21 +83,43 @@ export function BugCreationDialog({
     }
   }
 
-  // Fetch Jira projects when dialog opens for Jira target
+  // Debounced Jira project search
   useEffect(() => {
+    let ignore = false
     if (!open || target !== 'jira') return
-    api.get<Array<{key: string; name: string}>>('/api/jira-projects')
-      .then((projects) => {
-        setJiraProjects(projects)
-        if (projects.length > 0) {
-          const match = defaultProjectKey
-            ? projects.find((p) => p.key === defaultProjectKey)
-            : undefined
-          setJiraProjectKey(match?.key ?? projects[0].key)
-        }
+    if (jiraProjectKey.length < 2) {
+      setJiraProjects([])
+      setShowProjectDropdown(false)
+      return
+    }
+    const timer = setTimeout(() => {
+      api.post<Array<{key: string; name: string}>>('/api/jira-projects', {
+        jira_token: getJiraToken(),
+        jira_email: getJiraEmail(),
+        query: jiraProjectKey,
       })
-      .catch((err) => console.warn('Failed to fetch Jira projects:', err))
-  }, [open, target])
+        .then((data) => { if (!ignore) setJiraProjects(data) })
+        .catch((err) => console.warn('Failed to fetch Jira projects:', err))
+    }, 300)
+    return () => { ignore = true; clearTimeout(timer) }
+  }, [open, target, jiraProjectKey])
+
+  // Fetch security levels only after user confirms a project selection
+  useEffect(() => {
+    let ignore = false
+    if (!open || target !== 'jira' || !confirmedProjectKey) {
+      setSecurityLevels([])
+      return
+    }
+    api.post<Array<{id: string; name: string; description: string}>>('/api/jira-security-levels', {
+      jira_token: getJiraToken(),
+      jira_email: getJiraEmail(),
+      project_key: confirmedProjectKey,
+    })
+      .then((data) => { if (!ignore) setSecurityLevels(data) })
+      .catch((err) => console.warn('Failed to fetch security levels:', err))
+    return () => { ignore = true }
+  }, [open, target, confirmedProjectKey])
 
   // Load preview when dialog opens
   useEffect(() => {
@@ -148,7 +174,8 @@ export function BugCreationDialog({
     }
   }
 
-  function handleClose() {
+  function handleClose(nextOpen: boolean) {
+    if (nextOpen) return
     onOpenChange(false)
     setTimeout(() => {
       setPhase('idle')
@@ -159,8 +186,12 @@ export function BugCreationDialog({
       setErrorMsg('')
       setSelectedRepo(availableRepos?.[0]?.url ?? '')
       setJiraProjectKey(defaultProjectKey || '')
+      setConfirmedProjectKey(defaultProjectKey || '')
       setJiraProjects([])
       setJiraSecurityLevel('')
+      setSecurityLevels([])
+      setShowProjectDropdown(false)
+      setShowSecurityDropdown(false)
     }, 200)
   }
 
@@ -193,27 +224,101 @@ export function BugCreationDialog({
                 </select>
               </div>
             )}
-            {target === 'jira' && jiraProjects.length > 0 && (
+            {target === 'jira' && (
               <div className="space-y-2">
                 <label htmlFor="bug-jira-project" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Jira Project</label>
-                <select id="bug-jira-project" value={jiraProjectKey} onChange={(e) => setJiraProjectKey(e.target.value)} className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary">
-                  {jiraProjects.map((p) => (
-                    <option key={p.key} value={p.key}>{p.key} — {p.name}</option>
-                  ))}
-                </select>
+                <div className="relative">
+                  <input
+                    id="bug-jira-project"
+                    type="text"
+                    value={jiraProjectKey}
+                    onChange={(e) => {
+                      const val = e.target.value
+                      setJiraProjectKey(val)
+                      setShowProjectDropdown(true)
+                      if (val !== confirmedProjectKey) {
+                        setConfirmedProjectKey('')
+                        setJiraSecurityLevel('')
+                        setSecurityLevels([])
+                      }
+                    }}
+                    onFocus={() => setShowProjectDropdown(true)}
+                    onBlur={() => setTimeout(() => setShowProjectDropdown(false), 200)}
+                    placeholder="Type to search projects..."
+                    autoComplete="off"
+                    className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary placeholder:text-text-tertiary"
+                  />
+                  {showProjectDropdown && jiraProjects.length > 0 && (
+                    <div className="absolute z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-border-default bg-surface-card shadow-lg">
+                      {jiraProjects.map((p) => (
+                          <button
+                            key={p.key}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                              setJiraProjectKey(p.key)
+                              setConfirmedProjectKey(p.key)
+                              setShowProjectDropdown(false)
+                            }}
+                            className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-surface-hover"
+                          >
+                            <span className="font-mono text-text-primary">{p.key}</span>
+                            <span className="text-text-tertiary">{p.name}</span>
+                          </button>
+                        ))}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
             {target === 'jira' && (
               <div className="space-y-2">
                 <label htmlFor="bug-security-level" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Security Level</label>
-                <input
-                  id="bug-security-level"
-                  type="text"
-                  value={jiraSecurityLevel}
-                  onChange={(e) => setJiraSecurityLevel(e.target.value)}
-                  placeholder="e.g. Red Hat Employee"
-                  className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary placeholder:text-text-tertiary"
-                />
+                <div className="relative">
+                  <input
+                    id="bug-security-level"
+                    type="text"
+                    value={jiraSecurityLevel}
+                    onChange={(e) => {
+                      setJiraSecurityLevel(e.target.value)
+                      setShowSecurityDropdown(true)
+                    }}
+                    onFocus={() => setShowSecurityDropdown(true)}
+                    onBlur={() => setTimeout(() => setShowSecurityDropdown(false), 200)}
+                    placeholder="None (public)"
+                    autoComplete="off"
+                    className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary placeholder:text-text-tertiary"
+                  />
+                  {showSecurityDropdown && securityLevels.length > 0 && (
+                    <div className="absolute z-50 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-border-default bg-surface-card shadow-lg">
+                      <button
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => { setJiraSecurityLevel(''); setShowSecurityDropdown(false) }}
+                        className="flex w-full items-center px-2 py-1.5 text-left text-sm hover:bg-surface-hover text-text-tertiary"
+                      >
+                        None (public)
+                      </button>
+                      {securityLevels
+                        .filter((lv) => {
+                          const q = jiraSecurityLevel.toLowerCase()
+                          return !q || lv.name.toLowerCase().includes(q) || lv.description.toLowerCase().includes(q)
+                        })
+                        .map((lv) => (
+                          <button
+                            key={lv.id}
+                            type="button"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => { setJiraSecurityLevel(lv.name); setShowSecurityDropdown(false) }}
+                            className="flex w-full flex-col px-2 py-1.5 text-left text-sm hover:bg-surface-hover"
+                          >
+                            <span className="text-text-primary">{lv.name}</span>
+                            {lv.description && <span className="text-xs text-text-tertiary">{lv.description}</span>}
+                          </button>
+                        ))}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
             {similar.length > 0 && (
@@ -292,13 +397,13 @@ export function BugCreationDialog({
                 <p className="text-xs text-text-tertiary">Add a {target === 'github' ? 'GitHub' : 'Jira'} token in <a href="/settings" className="text-text-link hover:underline">settings</a> to create directly.</p>
               )}
               <div className="flex gap-2 sm:ml-auto">
-                <Button variant="ghost" onClick={handleClose}>Cancel</Button>
+                <Button variant="ghost" onClick={() => handleClose(false)}>Cancel</Button>
                 <Button onClick={handleCreate} disabled={!title.trim() || !hasToken} title={!hasToken ? `Add a ${target === 'github' ? 'GitHub' : 'Jira'} token to create issues` : undefined}>Create {label}</Button>
               </div>
             </>
           )}
           {(phase === 'success' || phase === 'error') && (
-            <Button variant="ghost" onClick={handleClose} className="sm:ml-auto">Close</Button>
+            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -70,7 +70,7 @@ interface FailureCardProps {
 export function FailureCard({ group, jobId, childJobName, childBuildNumber, index }: FailureCardProps) {
   const scopedChildJobName = childJobName ?? ''
   const scopedChildBuildNumber = childBuildNumber ?? 0
-  const { githubIssuesEnabled, jiraIssuesEnabled, comments, reviews, aiConfigs, result, classifications } = useReportState()
+  const { githubIssuesEnabled, jiraIssuesEnabled, serverJiraProjectKey, comments, reviews, aiConfigs, result, classifications } = useReportState()
   const dispatch = useReportDispatch()
   const expandKey = `jji-expand-${jobId}-${scopedChildJobName}-${scopedChildBuildNumber}-${group.id}`
   const [expanded, setExpanded] = useSessionState(expandKey, false)
@@ -466,6 +466,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
           childBuildNumber={scopedChildBuildNumber}
           aiProvider={selectedProvider}
           aiModel={selectedModel}
+          defaultProjectKey={serverJiraProjectKey}
           availableRepos={
             repoUrls.length > 0
               ? repoUrls.map(({ name, url }) => ({ name, url }))

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -13,6 +13,7 @@ interface ReportState {
   classifications: Record<string, string>
   githubIssuesEnabled: boolean
   jiraIssuesEnabled: boolean
+  serverJiraProjectKey: string
   aiConfigs: AiConfig[]
   loading: boolean
   error: string
@@ -32,6 +33,7 @@ type ReportAction =
   | { type: 'SET_REVIEW'; payload: { key: string; state: ReviewState } }
   | { type: 'SET_GITHUB_ISSUES_ENABLED'; payload: boolean }
   | { type: 'SET_JIRA_ISSUES_ENABLED'; payload: boolean }
+  | { type: 'SET_SERVER_JIRA_PROJECT_KEY'; payload: string }
   | { type: 'SET_AI_CONFIGS'; payload: AiConfig[] }
   | { type: 'SET_ENRICHMENTS'; payload: Record<string, CommentEnrichment[]> }
   | { type: 'SET_CLASSIFICATIONS'; payload: Record<string, string> }
@@ -62,6 +64,7 @@ const initialState: ReportState = {
   classifications: {},
   githubIssuesEnabled: false,
   jiraIssuesEnabled: false,
+  serverJiraProjectKey: '',
   aiConfigs: [],
   loading: true,
   error: '',
@@ -86,6 +89,8 @@ function reportReducer(state: ReportState, action: ReportAction): ReportState {
       return { ...state, githubIssuesEnabled: action.payload }
     case 'SET_JIRA_ISSUES_ENABLED':
       return { ...state, jiraIssuesEnabled: action.payload }
+    case 'SET_SERVER_JIRA_PROJECT_KEY':
+      return { ...state, serverJiraProjectKey: action.payload }
     case 'SET_AI_CONFIGS':
       return { ...state, aiConfigs: action.payload }
     case 'SET_ENRICHMENTS':

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -252,7 +252,7 @@ export interface ResultResponse {
     server_github_token?: boolean
     server_jira_token?: boolean
     server_jira_email?: boolean
-    server_jira_project_key?: boolean
+    server_jira_project_key?: string
   }
 }
 

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -535,9 +535,34 @@ class JJIClient:
 
     # -- Jira Projects --------------------------------------------------------
 
-    def jira_projects(self) -> list[dict]:
-        """List Jira projects. GET /api/jira-projects"""
-        return self._request("GET", "/api/jira-projects")
+    @staticmethod
+    def _with_jira_auth_fields(
+        body: dict, jira_token: str = "", jira_email: str = ""
+    ) -> dict:
+        """Add jira_token/jira_email to *body* when set."""
+        if jira_token and jira_token.strip():
+            body["jira_token"] = jira_token.strip()
+        if jira_email and jira_email.strip():
+            body["jira_email"] = jira_email.strip()
+        return body
+
+    def jira_projects(
+        self, jira_token: str = "", jira_email: str = "", query: str = ""
+    ) -> list[dict]:
+        """List Jira projects. POST /api/jira-projects"""
+        body: dict = {}
+        if query:
+            body["query"] = query
+        body = self._with_jira_auth_fields(body, jira_token, jira_email)
+        return self._request("POST", "/api/jira-projects", json=body)
+
+    def jira_security_levels(
+        self, project_key: str, jira_token: str = "", jira_email: str = ""
+    ) -> list[dict]:
+        """List security levels for a Jira project. POST /api/jira-security-levels"""
+        body: dict = {"project_key": project_key}
+        body = self._with_jira_auth_fields(body, jira_token, jira_email)
+        return self._request("POST", "/api/jira-security-levels", json=body)
 
     # -- AI Configs -----------------------------------------------------------
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -101,6 +101,26 @@ def _run_client_command(
     return data
 
 
+def _resolve_jira_cli_auth(
+    jira_token: str,
+    jira_email: str,
+) -> tuple[str, str]:
+    """Resolve Jira token and email from CLI flags with config fallback.
+
+    Args:
+        jira_token: Value from --jira-token flag (may be empty).
+        jira_email: Value from --jira-email flag (may be empty).
+
+    Returns:
+        (jira_token, jira_email) with config defaults applied.
+    """
+    cfg = _state.get("server_config")
+    return (
+        jira_token.strip() or ((cfg.jira_token or "").strip() if cfg else ""),
+        jira_email.strip() or ((cfg.jira_email or "").strip() if cfg else ""),
+    )
+
+
 def _resolve_server(
     server: str | None,
     username: str,
@@ -1104,12 +1124,22 @@ def capabilities(
 
 @app.command("jira-projects")
 def jira_projects_cmd(
+    query: str = typer.Option("", help="Search query to filter projects."),
+    jira_token: str = typer.Option(
+        "", "--jira-token", help="Jira token (uses config fallback)."
+    ),
+    jira_email: str = typer.Option(
+        "", "--jira-email", help="Jira email (uses config fallback)."
+    ),
     json_output: bool = _JSON_OPTION,
 ) -> None:
     """List available Jira projects."""
+    _jira_token, _jira_email = _resolve_jira_cli_auth(jira_token, jira_email)
     data = _run_client_command(
         json_output,
-        lambda c: c.jira_projects(),
+        lambda c: c.jira_projects(
+            jira_token=_jira_token, jira_email=_jira_email, query=query
+        ),
         emit_output=False,
     )
     if not _state.get("json", False):
@@ -1120,6 +1150,34 @@ def jira_projects_cmd(
                 data,
                 columns=["key", "name"],
                 labels={"key": "KEY", "name": "NAME"},
+                as_json=False,
+            )
+
+
+@app.command("jira-security-levels")
+def jira_security_levels_cmd(
+    project_key: str = typer.Argument(help="Jira project key."),
+    jira_token: str = typer.Option("", "--jira-token", help="Jira token."),
+    jira_email: str = typer.Option("", "--jira-email", help="Jira email."),
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """List security levels for a Jira project."""
+    _jira_token, _jira_email = _resolve_jira_cli_auth(jira_token, jira_email)
+    data = _run_client_command(
+        json_output,
+        lambda c: c.jira_security_levels(
+            project_key=project_key, jira_token=_jira_token, jira_email=_jira_email
+        ),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        if not data:
+            typer.echo("No security levels found.")
+        else:
+            print_output(
+                data,
+                columns=["name", "description"],
+                labels={"name": "NAME", "description": "DESCRIPTION"},
                 as_json=False,
             )
 

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -151,7 +151,7 @@ class Settings(BaseSettings):
     # Explicit Jira issue creation toggle (optional)
     enable_jira_issues: bool | None = Field(
         default=None,
-        description="Enable Jira bug creation. When None, follows jira_enabled.",
+        description="Enable Jira bug creation. When None, defaults to enabled. Independent of enable_jira.",
     )
 
     # AI CLI timeout in minutes
@@ -264,9 +264,9 @@ def _resolve_jira_auth(settings: Settings) -> tuple[bool, str]:
     Determines Cloud vs Server/DC deployment first, then selects the
     appropriate credential.
 
-    Cloud mode is detected only when ``jira_email`` is set together with
-    ``jira_api_token``.  A PAT with email is treated as Server/DC to
-    avoid sending a Bearer token down the Cloud Basic-auth path.
+    Cloud mode (``is_cloud=True``) is detected when ``jira_email`` is
+    set.  The token is selected by preferring ``jira_api_token`` and
+    falling back to ``jira_pat``.
 
     Server/DC mode (no ``jira_email``) prefers ``jira_pat`` and falls
     back to ``jira_api_token`` only when PAT is absent.
@@ -281,13 +281,15 @@ def _resolve_jira_auth(settings: Settings) -> tuple[bool, str]:
     has_pat = bool(settings.jira_pat and settings.jira_pat.get_secret_value())
     has_email = bool(settings.jira_email)
 
-    is_cloud = has_email and has_api_token
+    # email present = Cloud; use api_token first, fall back to pat
+    if has_email:
+        if has_api_token:
+            return True, settings.jira_api_token.get_secret_value()  # type: ignore[union-attr]
+        if has_pat:
+            return True, settings.jira_pat.get_secret_value()  # type: ignore[union-attr]
+        return True, ""
 
-    if is_cloud:
-        # Cloud: jira_api_token only (has_api_token already confirms truthiness)
-        return True, settings.jira_api_token.get_secret_value()  # type: ignore[union-attr]
-
-    # Server/DC: prefer PAT, fall back to API token
+    # No email = Server/DC; prefer PAT, fall back to API token
     if has_pat and settings.jira_pat:
         return False, settings.jira_pat.get_secret_value()
     if has_api_token and settings.jira_api_token:

--- a/src/jenkins_job_insight/jira.py
+++ b/src/jenkins_job_insight/jira.py
@@ -47,12 +47,13 @@ class JiraClient:
     Auto-detects Cloud (email + API token, REST API v3) vs
     Server/DC (PAT or API token, REST API v2) based on provided credentials.
 
-    Cloud detection requires ``jira_email`` together with
-    ``jira_api_token``. ``jira_email`` + ``jira_pat`` stays in
-    Server/DC mode.
+    Cloud detection: ``jira_email`` present → Cloud mode.
+    The token is ``jira_api_token`` (preferred) or ``jira_pat``
+    (fallback).
 
-    Server/DC detection: uses Bearer auth with ``jira_pat``
-    (preferred) or ``jira_api_token`` as fallback.
+    Server/DC detection (no ``jira_email``): uses Bearer auth
+    with ``jira_pat`` (preferred) or ``jira_api_token`` as
+    fallback.
     """
 
     def __init__(self, settings: Settings) -> None:
@@ -65,7 +66,7 @@ class JiraClient:
         # Configure Cloud vs Server/DC auth
         self._auth: tuple[str, str] | None
         if is_cloud and settings.jira_email:
-            # Cloud: _resolve_jira_auth() selected email + jira_api_token.
+            # Cloud: _resolve_jira_auth() selected email + token (api_token or pat).
             self._auth = (settings.jira_email, token_value)
             self._search_path = "/rest/api/3/search/jql"
             self._api_path = "/rest/api/3"
@@ -101,15 +102,109 @@ class JiraClient:
     async def __aexit__(self, *exc) -> None:
         await self.close()
 
-    async def list_projects(self) -> list[dict]:
-        """List all accessible Jira projects."""
-        try:
-            response = await self._client.get(f"{self._api_path}/project")
+    async def list_projects(self, query: str = "") -> list[dict]:
+        """List all accessible Jira projects.
+
+        Tries ``/project/search`` first (returns only projects the caller
+        can see) and falls back to ``/project`` (requires broader
+        permissions).  Paginates ``/project/search`` to fetch all results.
+        """
+        # /project/search returns paginated results scoped to the caller;
+        # /project requires global Browse Projects and may 403 on Cloud.
+        paths_to_try = [
+            f"{self._api_path}/project/search",
+            f"{self._api_path}/project",
+        ]
+
+        for path in paths_to_try:
+            try:
+                if "/project/search" in path:
+                    return await self._list_projects_paginated(path, query=query)
+                response = await self._client.get(path)
+                response.raise_for_status()
+                data = response.json()
+                projects = data if isinstance(data, list) else data.get("values", [])
+                result = [
+                    {"key": p["key"], "name": p.get("name", p["key"])}
+                    for p in projects
+                    if isinstance(p, dict) and "key" in p
+                ]
+                if query:
+                    _q = query.lower()
+                    result = [
+                        p
+                        for p in result
+                        if _q in p["key"].lower() or _q in p["name"].lower()
+                    ]
+                if result:
+                    return result
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.warning(
+                    "Failed to fetch Jira projects from %s: %s",
+                    path,
+                    exc,
+                )
+        return []
+
+    async def _list_projects_paginated(self, path: str, query: str = "") -> list[dict]:
+        """Fetch projects via paginated /project/search endpoint."""
+        all_projects: list[dict] = []
+        start_at = 0
+        page_size = 50
+
+        while True:
+            params: dict = {"startAt": start_at, "maxResults": page_size}
+            if query:
+                params["query"] = query
+            response = await self._client.get(path, params=params)
             response.raise_for_status()
             data = response.json()
-            return [{"key": p["key"], "name": p.get("name", p["key"])} for p in data]
-        except Exception:
-            logger.warning("Failed to fetch Jira projects", exc_info=True)
+            values = data if isinstance(data, list) else data.get("values", [])
+            for p in values:
+                if isinstance(p, dict) and "key" in p:
+                    all_projects.append(
+                        {"key": p["key"], "name": p.get("name", p["key"])}
+                    )
+            # Use Jira pagination metadata when available
+            if isinstance(data, dict) and "isLast" in data:
+                if data["isLast"]:
+                    break
+                start_at = data.get("startAt", start_at) + data.get(
+                    "maxResults", page_size
+                )
+            elif len(values) < page_size:
+                break
+            else:
+                start_at += page_size
+
+        return all_projects
+
+    async def list_security_levels(self, project_key: str) -> list[dict]:
+        """List available security levels for a Jira project."""
+        if not project_key:
+            return []
+        try:
+            response = await self._client.get(
+                f"{self._api_path}/project/{project_key}/securitylevel"
+            )
+            response.raise_for_status()
+            data = response.json()
+            levels = data.get("levels", [])
+            return [
+                {
+                    "id": lv["id"],
+                    "name": lv["name"],
+                    "description": lv.get("description", ""),
+                }
+                for lv in levels
+                if isinstance(lv, dict) and "id" in lv and "name" in lv
+            ]
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.warning(
+                "Failed to fetch security levels for project %s: %s",
+                project_key,
+                exc,
+            )
             return []
 
     async def search(self, keywords: list[str]) -> list[dict]:
@@ -410,6 +505,7 @@ async def enrich_with_jira_matches(
         len(reports),
     )
 
+    total_matches = 0
     async with JiraClient(settings) as client:
         try:
             # Search Jira for each unique keyword set in parallel
@@ -461,11 +557,7 @@ async def enrich_with_jira_matches(
                 for report in keyword_to_reports[kw_tuple]:
                     report.jira_matches = matches
 
-            total_matches = sum(
-                len(r.jira_matches)
-                for reports_list in keyword_to_reports.values()
-                for r in reports_list
-            )
+                total_matches += len(matches)
             logger.info(
                 "Jira search complete: %d relevant match(es) found", total_matches
             )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -593,8 +593,7 @@ def _resolve_enable_jira(body: BaseAnalysisRequest, settings: Settings) -> bool:
 
     Priority order:
     1. Request body field (highest)
-    2. ENABLE_JIRA env var (via settings)
-    3. Auto-detect from Jira credentials (lowest)
+    2. settings.jira_enabled property (env var + auto-detect fallback)
 
     Args:
         body: The analysis request (AnalyzeRequest or AnalyzeFailuresRequest).
@@ -2044,15 +2043,14 @@ def _has_jira_credentials(settings: Settings) -> bool:
 def _jira_issue_creation_enabled(settings: Settings) -> bool:
     """Check whether Jira issue creation is enabled.
 
-    ``ENABLE_JIRA_ISSUES`` takes precedence when explicitly set (True/False).
-    Falls back to ``ENABLE_JIRA`` when ``ENABLE_JIRA_ISSUES`` is None.
+    Controlled only by ``ENABLE_JIRA_ISSUES``.  Defaults to enabled
+    when not explicitly set.  Independent of ``ENABLE_JIRA`` (which
+    controls Jira enrichment during analysis).
     """
-    if settings.enable_jira_issues is not None:
-        return bool(settings.enable_jira_issues)
-    return settings.enable_jira is not False
+    return settings.enable_jira_issues is not False
 
 
-def _build_capabilities(settings: Settings) -> dict[str, bool]:
+def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
     """Build the capabilities dict for API responses."""
     return {
         "github_issues_enabled": settings.enable_github_issues is not False,
@@ -2065,7 +2063,7 @@ def _build_capabilities(settings: Settings) -> dict[str, bool]:
             or (settings.jira_pat and settings.jira_pat.get_secret_value())
         ),
         "server_jira_email": bool(settings.jira_email),
-        "server_jira_project_key": bool(settings.jira_project_key),
+        "server_jira_project_key": settings.jira_project_key or "",
     }
 
 
@@ -2544,18 +2542,100 @@ async def get_capabilities(settings: Settings = Depends(get_settings)) -> dict:
     return _build_capabilities(settings)
 
 
-@app.get("/api/jira-projects")
+class JiraProjectsRequest(BaseModel):
+    """Request body for listing Jira projects with user credentials."""
+
+    jira_token: str = Field(default="", description="User's Jira token")
+    jira_email: str = Field(default="", description="User's Jira email for Cloud auth")
+    query: str = Field(default="", description="Search query to filter projects")
+
+
+def _jira_client_from_body(
+    settings: Settings, jira_token: str, jira_email: str
+) -> tuple[Settings, str] | None:
+    """Normalize user Jira credentials and return effective settings.
+
+    Returns ``(effective_settings, stripped_token)`` when the user supplied a
+    non-empty token, or *None* when no usable token is present.
+    """
+    token = jira_token.strip() if jira_token else ""
+    if not token:
+        return None
+    effective = _build_effective_jira_settings(settings, token, jira_email)
+    return effective, token
+
+
+@app.post("/api/jira-projects")
 async def list_jira_projects(
+    body: JiraProjectsRequest,
     settings: Settings = Depends(get_settings),
 ) -> list[dict]:
-    """List available Jira projects for the project selector."""
+    """List Jira projects accessible to the user.
+
+    Uses the user's Jira token to list projects they can see.
+    Always includes the server's configured project key.
+    """
     if not settings.jira_url:
         return []
 
+    result = _jira_client_from_body(settings, body.jira_token, body.jira_email)
+    if result is None:
+        # No user token — return just the server's configured project
+        if settings.jira_project_key:
+            return [
+                {"key": settings.jira_project_key, "name": settings.jira_project_key}
+            ]
+        return []
+
+    effective_settings, _ = result
+
     from jenkins_job_insight.jira import JiraClient
 
-    async with JiraClient(settings) as client:
-        return await client.list_projects()
+    projects: list[dict] = []
+    try:
+        async with JiraClient(effective_settings) as client:
+            projects = await client.list_projects(query=body.query)
+    except Exception:
+        logger.warning("Failed to list Jira projects", exc_info=True)
+
+    # Ensure the server's configured project is always included
+    if settings.jira_project_key:
+        configured_key = settings.jira_project_key
+        if not any(p["key"] == configured_key for p in projects):
+            projects.insert(0, {"key": configured_key, "name": configured_key})
+
+    return projects
+
+
+class JiraSecurityLevelsRequest(BaseModel):
+    jira_token: str = Field(default="", description="User's Jira token")
+    jira_email: str = Field(default="", description="User's Jira email")
+    project_key: str = Field(description="Jira project key")
+
+
+@app.post("/api/jira-security-levels")
+async def list_jira_security_levels(
+    body: JiraSecurityLevelsRequest,
+    settings: Settings = Depends(get_settings),
+) -> list[dict]:
+    """List available security levels for a Jira project."""
+    if not settings.jira_url or not body.project_key:
+        return []
+
+    result = _jira_client_from_body(settings, body.jira_token, body.jira_email)
+    if result is None:
+        return []
+
+    effective_settings, _ = result
+
+    from jenkins_job_insight.jira import JiraClient
+
+    try:
+        async with JiraClient(effective_settings) as client:
+            return await client.list_security_levels(body.project_key)
+    except Exception:
+        logger.warning("Failed to list Jira security levels", exc_info=True)
+        return []
 
 
 class ValidateTokenRequest(BaseModel):

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1092,7 +1092,7 @@ class TestJJIClientValidateToken:
 class TestJJIClientJiraProjects:
     def test_jira_projects(self):
         def handler(request):
-            assert request.method == "GET"
+            assert request.method == "POST"
             assert "/api/jira-projects" in str(request.url)
             return httpx.Response(200, json=[{"key": "PROJ", "name": "My Project"}])
 
@@ -1100,6 +1100,39 @@ class TestJJIClientJiraProjects:
         result = client.jira_projects()
         assert len(result) == 1
         assert result[0]["key"] == "PROJ"
+
+
+class TestJJIClientJiraSecurityLevels:
+    def test_jira_security_levels(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/api/jira-security-levels" in str(request.url)
+            body = json.loads(request.content)
+            assert body["project_key"] == "PROJ"
+            return httpx.Response(
+                200,
+                json=[{"id": "10", "name": "Internal", "description": "Internal only"}],
+            )
+
+        client = _make_client(handler)
+        result = client.jira_security_levels("PROJ")
+        assert len(result) == 1
+        assert result[0]["name"] == "Internal"
+
+    def test_jira_security_levels_with_token(self):
+        def handler(request):
+            body = json.loads(request.content)
+            assert body["jira_token"] == "tok"  # noqa: S105
+            assert body["jira_email"] == "u@e.com"
+            return httpx.Response(200, json=[])
+
+        client = _make_client(handler)
+        result = client.jira_security_levels(
+            "PROJ",
+            jira_token="tok",  # noqa: S106
+            jira_email="u@e.com",
+        )
+        assert result == []
 
 
 class TestJJIClientReAnalyze:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2238,6 +2238,32 @@ class TestJiraProjectsCommand:
         assert result.exit_code == 0
 
 
+class TestJiraSecurityLevelsCommand:
+    def test_jira_security_levels(self, mock_client):
+        mock_client.jira_security_levels.return_value = [
+            {"id": "10", "name": "Internal", "description": "Internal only"},
+        ]
+        result = runner.invoke(app, ["jira-security-levels", "PROJ"])
+        assert result.exit_code == 0
+        assert "Internal" in result.output
+
+    def test_jira_security_levels_json(self, mock_client):
+        mock_client.jira_security_levels.return_value = [
+            {"id": "10", "name": "Internal", "description": "Internal only"},
+        ]
+        result = runner.invoke(app, ["--json", "jira-security-levels", "PROJ"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
+        assert parsed[0]["name"] == "Internal"
+
+    def test_jira_security_levels_empty(self, mock_client):
+        mock_client.jira_security_levels.return_value = []
+        result = runner.invoke(app, ["jira-security-levels", "PROJ"])
+        assert result.exit_code == 0
+        assert "No security levels found" in result.output
+
+
 class TestReAnalyzeCommand:
     def test_re_analyze(self, mock_client):
         mock_client.re_analyze.return_value = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,13 +215,13 @@ class TestJiraSettings:
 class TestResolveJiraAuth:
     """Tests for _resolve_jira_auth helper."""
 
-    def test_email_plus_pat_is_server_not_cloud(self) -> None:
-        """JIRA_EMAIL + JIRA_PAT must resolve to Server/DC mode, not Cloud.
+    def test_email_plus_pat_is_cloud(self) -> None:
+        """JIRA_EMAIL + JIRA_PAT resolves to Cloud mode.
 
-        Regression: a PAT sent via Cloud Basic-auth path would fail.
+        Email present = Cloud.  PAT is used as the token via Basic auth.
         """
         env = _build_env(
-            JIRA_URL="https://jira-server.example.com",
+            JIRA_URL="https://myorg.atlassian.net",
             JIRA_EMAIL="user@example.com",
             JIRA_PAT="pat-token-456",
             JIRA_PROJECT_KEY="TEST",
@@ -229,7 +229,7 @@ class TestResolveJiraAuth:
         with patch.dict(os.environ, env, clear=True):
             settings = Settings(_env_file=None)
             is_cloud, token = _resolve_jira_auth(settings)
-            assert not is_cloud, "email + PAT must NOT activate Cloud mode"
+            assert is_cloud, "email present must activate Cloud mode"
             assert token == env["JIRA_PAT"]
 
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -65,8 +65,8 @@ def jira_server_settings() -> Generator[Settings, None, None]:
 def jira_cloud_pat_settings() -> Generator[Settings, None, None]:
     """Create Settings with JIRA_PAT + JIRA_EMAIL (no JIRA_API_TOKEN).
 
-    Even when email is present, PAT-only auth should resolve to Server/DC
-    mode to avoid sending a Bearer token down the Cloud Basic-auth path.
+    Email present → Cloud mode.  The PAT is used as the token value
+    for Cloud Basic auth (email, pat).
     """
     yield from _jira_settings_from_env(
         {
@@ -214,18 +214,16 @@ class TestJiraClient:
             assert client._headers.get("Authorization") == "Bearer server-pat-token"
 
     async def test_cloud_pat_auth_detection(self, jira_cloud_pat_settings) -> None:
-        """JIRA_PAT + JIRA_EMAIL resolves to Server/DC auth (Bearer + v2).
-
-        PAT should never promote to Cloud mode; only jira_api_token does.
-        """
+        """JIRA_PAT + JIRA_EMAIL resolves to Cloud auth (email present = Cloud)."""
         async with JiraClient(jira_cloud_pat_settings) as client:
-            assert client._api_path == "/rest/api/2"
-            assert client._search_path == "/rest/api/2/search"
-            assert client._auth is None
-            assert (
-                client._headers.get("Authorization")
-                == "Bearer ATATT3xFfGF0AbM93-cloud-api-token"
+            assert client._api_path == "/rest/api/3"
+            assert client._search_path == "/rest/api/3/search/jql"
+            # Cloud uses Basic auth (email, token) — PAT used as the token
+            assert client._auth == (
+                "user@example.com",
+                "ATATT3xFfGF0AbM93-cloud-api-token",
             )
+            assert "Authorization" not in (client._headers or {})
 
     async def test_list_projects_returns_projects(self, jira_settings) -> None:
         """list_projects returns project key and name."""
@@ -247,14 +245,112 @@ class TestJiraClient:
         assert projects[1] == {"key": "OTHER", "name": "Other Project"}
         await client.close()
 
+    async def test_list_projects_paginated_response(self, jira_settings) -> None:
+        """list_projects handles paginated response format."""
+        mock_response = httpx.Response(
+            200,
+            json={
+                "values": [
+                    {"key": "PROJ", "name": "My Project"},
+                    {"key": "OTHER", "name": "Other Project"},
+                ],
+                "maxResults": 50,
+            },
+            request=httpx.Request("GET", "https://jira.example.com"),
+        )
+        client = JiraClient(jira_settings)
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            projects = await client.list_projects()
+        assert len(projects) == 2
+        assert projects[0] == {"key": "PROJ", "name": "My Project"}
+        await client.close()
+
+    async def test_list_projects_falls_back_to_project_endpoint(
+        self, jira_settings
+    ) -> None:
+        """list_projects falls back to /project when /project/search fails."""
+        client = JiraClient(jira_settings)
+
+        project_response = httpx.Response(
+            200,
+            json=[{"key": "FALL", "name": "Fallback"}],
+            request=httpx.Request("GET", "https://jira.example.com"),
+        )
+
+        async def _side_effect(path: str, **kwargs) -> httpx.Response:
+            if "/project/search" in path:
+                raise httpx.HTTPError("search failed")
+            return project_response
+
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, side_effect=_side_effect
+        ):
+            projects = await client.list_projects()
+        assert len(projects) == 1
+        assert projects[0] == {"key": "FALL", "name": "Fallback"}
+        await client.close()
+
     async def test_list_projects_returns_empty_on_error(self, jira_settings) -> None:
         """list_projects returns empty list on error."""
         client = JiraClient(jira_settings)
         with patch.object(
-            client._client, "get", new_callable=AsyncMock, side_effect=Exception("fail")
+            client._client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=httpx.HTTPError("fail"),
         ):
             projects = await client.list_projects()
         assert projects == []
+        await client.close()
+
+    async def test_list_security_levels_returns_levels(self, jira_settings) -> None:
+        """list_security_levels returns id, name, description."""
+        mock_response = httpx.Response(
+            200,
+            json={
+                "levels": [
+                    {"id": "10", "name": "Internal", "description": "Internal only"},
+                    {"id": "20", "name": "Public"},
+                ]
+            },
+            request=httpx.Request("GET", "https://jira.example.com"),
+        )
+        client = JiraClient(jira_settings)
+        with patch.object(
+            client._client, "get", new_callable=AsyncMock, return_value=mock_response
+        ):
+            levels = await client.list_security_levels("PROJ")
+        assert len(levels) == 2
+        assert levels[0] == {
+            "id": "10",
+            "name": "Internal",
+            "description": "Internal only",
+        }
+        assert levels[1] == {"id": "20", "name": "Public", "description": ""}
+        await client.close()
+
+    async def test_list_security_levels_empty_project_key(self, jira_settings) -> None:
+        """list_security_levels returns empty list for empty project key."""
+        client = JiraClient(jira_settings)
+        levels = await client.list_security_levels("")
+        assert levels == []
+        await client.close()
+
+    async def test_list_security_levels_returns_empty_on_error(
+        self, jira_settings
+    ) -> None:
+        """list_security_levels returns empty list on error."""
+        client = JiraClient(jira_settings)
+        with patch.object(
+            client._client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=httpx.HTTPError("fail"),
+        ):
+            levels = await client.list_security_levels("PROJ")
+        assert levels == []
         await client.close()
 
     async def test_search_returns_candidates(self, jira_settings) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4137,11 +4137,11 @@ class TestValidateToken:
 
 
 class TestJiraProjectsEndpoint:
-    """Tests for GET /api/jira-projects."""
+    """Tests for POST /api/jira-projects."""
 
     def test_no_jira_url_returns_empty(self, test_client):
         """No JIRA_URL configured returns empty list."""
-        response = test_client.get("/api/jira-projects")
+        response = test_client.post("/api/jira-projects", json={})
         assert response.status_code == 200
         assert response.json() == []
 
@@ -4160,8 +4160,69 @@ class TestJiraProjectsEndpoint:
                 mock_client.__aenter__ = AsyncMock(return_value=mock_client)
                 mock_client.__aexit__ = AsyncMock(return_value=False)
                 MockJiraClient.return_value = mock_client
-                response = test_client.get("/api/jira-projects")
+                response = test_client.post(
+                    "/api/jira-projects",
+                    json={"jira_token": "tok", "jira_email": "u@e.com"},  # noqa: S106
+                )
             assert response.status_code == 200
-            assert response.json() == projects
+            data = response.json()
+            assert any(p["key"] == "PROJ" for p in data)
+        finally:
+            app.dependency_overrides.pop(get_settings, None)
+
+
+class TestJiraSecurityLevelsEndpoint:
+    """Tests for POST /api/jira-security-levels."""
+
+    def test_no_jira_url_returns_empty(self, test_client):
+        """No JIRA_URL configured returns empty list."""
+        response = test_client.post(
+            "/api/jira-security-levels", json={"project_key": "PROJ"}
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_no_token_returns_empty(self, test_client):
+        """No jira_token returns empty list."""
+        from jenkins_job_insight.main import app, get_settings
+
+        jira_settings = _build_wait_settings(jira_url="https://jira.example.com")
+        app.dependency_overrides[get_settings] = lambda: jira_settings
+        try:
+            response = test_client.post(
+                "/api/jira-security-levels", json={"project_key": "PROJ"}
+            )
+            assert response.status_code == 200
+            assert response.json() == []
+        finally:
+            app.dependency_overrides.pop(get_settings, None)
+
+    @pytest.mark.asyncio
+    async def test_returns_security_levels(self, test_client):
+        """Returns security levels from JiraClient.list_security_levels."""
+        from jenkins_job_insight.main import app, get_settings
+
+        levels = [{"id": "10", "name": "Internal", "description": "Internal only"}]
+        jira_settings = _build_wait_settings(jira_url="https://jira.example.com")
+        app.dependency_overrides[get_settings] = lambda: jira_settings
+        try:
+            with patch("jenkins_job_insight.jira.JiraClient") as MockJiraClient:
+                mock_client = AsyncMock()
+                mock_client.list_security_levels = AsyncMock(return_value=levels)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockJiraClient.return_value = mock_client
+                response = test_client.post(
+                    "/api/jira-security-levels",
+                    json={
+                        "project_key": "PROJ",
+                        "jira_token": "tok",
+                        "jira_email": "u@e.com",
+                    },  # noqa: S106
+                )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["name"] == "Internal"
         finally:
             app.dependency_overrides.pop(get_settings, None)


### PR DESCRIPTION
## Summary

Adds Jira project selector with fuzzy search, per-project security level dropdown, fixes Jira Cloud auth detection, and makes ENABLE_JIRA/ENABLE_JIRA_ISSUES independent.

Addresses remaining items from #104.

## Changes

### Jira Project Selector
- Server-side fuzzy search via `POST /api/jira-projects` with `query` param
- Uses **user's Jira token** (not server credentials)
- Searchable combobox with debounced input (300ms)
- Paginated fetching via `/project/search` endpoint

### Jira Security Levels
- New `POST /api/jira-security-levels` endpoint, fetches per-project levels
- Searchable combobox dropdown (shows name + description)
- Debounced fetch when project changes
- `JiraClient.list_security_levels()` method

### Auth Fix
- `_resolve_jira_auth`: email present = Cloud (was: email + api_token only)
- Fixes project listing for Cloud instances where PAT was configured alongside email
- Updated docstrings and tests to match

### Independent Toggles
- `ENABLE_JIRA` controls only Jira enrichment during analysis
- `ENABLE_JIRA_ISSUES` controls only issue creation (no fallback to ENABLE_JIRA)

### Bug Fixes
- Fix inflated Jira match log metric (shared list reference caused multiplication)
- Fix `_resolve_enable_jira` docstring accuracy

### CLI Parity
- `jji jira-projects --query MTV --jira-token ...`
- `jji jira-security-levels MTV --jira-token ...`

## Peer Review
Reviewed by Cursor (2 rounds). Key findings addressed:
- NameError in enrich_with_jira_matches (results → accumulate in loop)
- Security level fetch not debounced
- Stale docstrings for auth detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable Jira project suggestions with debounced query and filtered dropdowns when creating issues.
  * Security-level selection in the bug creation dialog (includes “None (public)” option).
  * CLI command to list Jira security levels.

* **Bug Fixes**
  * Report flow now pre-fills the server-configured default Jira project key in the issue dialog.
  * Dialog close/reset behavior improved to clear interim Jira selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->