### PR TITLE
fix(reportportal): log all RP push error paths with full context

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { api, ApiError, userErrorMessage } from '../api'
+import { api, ApiError } from '../api'
 
 describe('api', () => {
   beforeEach(() => {
@@ -47,51 +47,5 @@ describe('api', () => {
     const [, options] = fetchSpy.mock.calls[0]
     expect(options?.method).toBe('POST')
     expect(options?.body).toBe(JSON.stringify({ name: 'test' }))
-  })
-})
-
-describe('userErrorMessage', () => {
-  it('extracts string detail from ApiError body', () => {
-    const err = new ApiError(404, 'Not Found', { detail: 'Job not found' })
-    expect(userErrorMessage(err)).toBe('Job not found')
-  })
-
-  it('summarises array detail from ApiError body (FastAPI validation)', () => {
-    const err = new ApiError(422, 'Unprocessable Entity', {
-      detail: [
-        { loc: ['body', 'name'], msg: 'field required', type: 'value_error.missing' },
-        { loc: ['body', 'age'], msg: 'not a valid integer', type: 'type_error.integer' },
-      ],
-    })
-    expect(userErrorMessage(err)).toBe('field required (and 1 more)')
-  })
-
-  it('shows count for array detail without msg field', () => {
-    const err = new ApiError(422, 'Unprocessable Entity', {
-      detail: ['error1', 'error2'],
-    })
-    expect(userErrorMessage(err)).toBe('Validation failed (2 errors)')
-  })
-
-  it('falls back to ApiError message when no detail', () => {
-    const err = new ApiError(500, 'Internal Server Error', { error: 'something' })
-    expect(userErrorMessage(err)).toBe('API error 500: Internal Server Error')
-  })
-
-  it('uses Error.message for non-ApiError errors', () => {
-    const err = new TypeError('network failure')
-    expect(userErrorMessage(err)).toBe('network failure')
-  })
-
-  it('returns fallback for non-Error values', () => {
-    expect(userErrorMessage('boom')).toBe('An unexpected error occurred')
-    expect(userErrorMessage(null, 'custom fallback')).toBe('custom fallback')
-  })
-
-  it('handles single-item array detail without extra count', () => {
-    const err = new ApiError(422, 'Unprocessable Entity', {
-      detail: [{ msg: 'field required' }],
-    })
-    expect(userErrorMessage(err)).toBe('field required')
   })
 })

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { api, ApiError } from '../api'
+import { api, ApiError, userErrorMessage } from '../api'
 
 describe('api', () => {
   beforeEach(() => {
@@ -47,5 +47,51 @@ describe('api', () => {
     const [, options] = fetchSpy.mock.calls[0]
     expect(options?.method).toBe('POST')
     expect(options?.body).toBe(JSON.stringify({ name: 'test' }))
+  })
+})
+
+describe('userErrorMessage', () => {
+  it('extracts string detail from ApiError body', () => {
+    const err = new ApiError(404, 'Not Found', { detail: 'Job not found' })
+    expect(userErrorMessage(err)).toBe('Job not found')
+  })
+
+  it('summarises array detail from ApiError body (FastAPI validation)', () => {
+    const err = new ApiError(422, 'Unprocessable Entity', {
+      detail: [
+        { loc: ['body', 'name'], msg: 'field required', type: 'value_error.missing' },
+        { loc: ['body', 'age'], msg: 'not a valid integer', type: 'type_error.integer' },
+      ],
+    })
+    expect(userErrorMessage(err)).toBe('field required (and 1 more)')
+  })
+
+  it('shows count for array detail without msg field', () => {
+    const err = new ApiError(422, 'Unprocessable Entity', {
+      detail: ['error1', 'error2'],
+    })
+    expect(userErrorMessage(err)).toBe('Validation failed (2 errors)')
+  })
+
+  it('falls back to ApiError message when no detail', () => {
+    const err = new ApiError(500, 'Internal Server Error', { error: 'something' })
+    expect(userErrorMessage(err)).toBe('API error 500: Internal Server Error')
+  })
+
+  it('uses Error.message for non-ApiError errors', () => {
+    const err = new TypeError('network failure')
+    expect(userErrorMessage(err)).toBe('network failure')
+  })
+
+  it('returns fallback for non-Error values', () => {
+    expect(userErrorMessage('boom')).toBe('An unexpected error occurred')
+    expect(userErrorMessage(null, 'custom fallback')).toBe('custom fallback')
+  })
+
+  it('handles single-item array detail without extra count', () => {
+    const err = new ApiError(422, 'Unprocessable Entity', {
+      detail: [{ msg: 'field required' }],
+    })
+    expect(userErrorMessage(err)).toBe('field required')
   })
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,34 +63,5 @@ export const api = {
     request<T>(path, { method: 'DELETE' }),
 }
 
-/** Extract a short user-facing message from an error.
- *
- *  - ApiError with a string `detail` → use it directly.
- *  - ApiError with an array `detail` (FastAPI validation) → short summary.
- *  - ApiError without detail → "API error {status}: {statusText}".
- *  - Any other Error → its `.message`.
- *  - Non-Error → generic fallback.
- */
-export function userErrorMessage(err: unknown, fallback = 'An unexpected error occurred'): string {
-  if (err instanceof ApiError) {
-    const body = err.body as Record<string, unknown> | null | undefined
-    if (body && typeof body === 'object') {
-      if (typeof body.detail === 'string') return body.detail
-      if (Array.isArray(body.detail) && body.detail.length > 0) {
-        const first = body.detail[0]
-        const msg = typeof first === 'object' && first !== null && 'msg' in first
-          ? String((first as Record<string, unknown>).msg)
-          : undefined
-        const count = body.detail.length
-        return msg
-          ? `${msg}${count > 1 ? ` (and ${count - 1} more)` : ''}`
-          : `Validation failed (${count} error${count !== 1 ? 's' : ''})`
-      }
-    }
-    return err.message
-  }
-  if (err instanceof Error) return err.message
-  return fallback
-}
 
 export { ApiError }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,4 +63,34 @@ export const api = {
     request<T>(path, { method: 'DELETE' }),
 }
 
+/** Extract a short user-facing message from an error.
+ *
+ *  - ApiError with a string `detail` → use it directly.
+ *  - ApiError with an array `detail` (FastAPI validation) → short summary.
+ *  - ApiError without detail → "API error {status}: {statusText}".
+ *  - Any other Error → its `.message`.
+ *  - Non-Error → generic fallback.
+ */
+export function userErrorMessage(err: unknown, fallback = 'An unexpected error occurred'): string {
+  if (err instanceof ApiError) {
+    const body = err.body as Record<string, unknown> | null | undefined
+    if (body && typeof body === 'object') {
+      if (typeof body.detail === 'string') return body.detail
+      if (Array.isArray(body.detail) && body.detail.length > 0) {
+        const first = body.detail[0]
+        const msg = typeof first === 'object' && first !== null && 'msg' in first
+          ? String((first as Record<string, unknown>).msg)
+          : undefined
+        const count = body.detail.length
+        return msg
+          ? `${msg}${count > 1 ? ` (and ${count - 1} more)` : ''}`
+          : `Validation failed (${count} error${count !== 1 ? 's' : ''})`
+      }
+    }
+    return err.message
+  }
+  if (err instanceof Error) return err.message
+  return fallback
+}
+
 export { ApiError }

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -176,6 +176,7 @@ function ReportContent() {
           dispatch({ type: 'SET_GITHUB_ISSUES_ENABLED', payload: resultRes.capabilities?.github_issues_enabled ?? false })
           dispatch({ type: 'SET_JIRA_ISSUES_ENABLED', payload: resultRes.capabilities?.jira_issues_enabled ?? false })
           dispatch({ type: 'SET_REPORTPORTAL_AVAILABLE', payload: resultRes.capabilities?.reportportal ?? false })
+          dispatch({ type: 'SET_REPORTPORTAL_PROJECT', payload: resultRes.capabilities?.reportportal_project ?? '' })
           dispatch({ type: 'SET_SERVER_JIRA_PROJECT_KEY', payload: resultRes.capabilities?.server_jira_project_key ?? '' })
         }
 
@@ -397,7 +398,7 @@ function ReportContent() {
           )}
           <div className="ml-auto flex items-center gap-3">
             {state.reportportalAvailable && (result.child_job_analyses ?? []).length === 0 && (
-              <ReportPortalButton jobId={result.job_id} />
+              <ReportPortalButton jobId={result.job_id} jobName={result.job_name ?? result.job_id} buildNumber={result.build_number} />
             )}
             {result.request_params && (
               <Button

--- a/frontend/src/pages/report/ChildJobSection.tsx
+++ b/frontend/src/pages/report/ChildJobSection.tsx
@@ -103,6 +103,8 @@ export function ChildJobSection({ child, jobId, depth = 0, activeHash, parentHas
         {state.reportportalAvailable && (
           <ReportPortalButton
             jobId={jobId}
+            jobName={child.job_name}
+            buildNumber={child.build_number}
             childJobName={child.job_name}
             childBuildNumber={child.build_number}
           />

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -14,6 +14,7 @@ interface ReportState {
   githubIssuesEnabled: boolean
   jiraIssuesEnabled: boolean
   reportportalAvailable: boolean
+  reportportalProject: string
   serverJiraProjectKey: string
   aiConfigs: AiConfig[]
   loading: boolean
@@ -35,6 +36,7 @@ type ReportAction =
   | { type: 'SET_GITHUB_ISSUES_ENABLED'; payload: boolean }
   | { type: 'SET_JIRA_ISSUES_ENABLED'; payload: boolean }
   | { type: 'SET_REPORTPORTAL_AVAILABLE'; payload: boolean }
+  | { type: 'SET_REPORTPORTAL_PROJECT'; payload: string }
   | { type: 'SET_SERVER_JIRA_PROJECT_KEY'; payload: string }
   | { type: 'SET_AI_CONFIGS'; payload: AiConfig[] }
   | { type: 'SET_ENRICHMENTS'; payload: Record<string, CommentEnrichment[]> }
@@ -67,6 +69,7 @@ const initialState: ReportState = {
   githubIssuesEnabled: false,
   jiraIssuesEnabled: false,
   reportportalAvailable: false,
+  reportportalProject: '',
   serverJiraProjectKey: '',
   aiConfigs: [],
   loading: true,
@@ -94,6 +97,8 @@ function reportReducer(state: ReportState, action: ReportAction): ReportState {
       return { ...state, jiraIssuesEnabled: action.payload }
     case 'SET_REPORTPORTAL_AVAILABLE':
       return { ...state, reportportalAvailable: action.payload }
+    case 'SET_REPORTPORTAL_PROJECT':
+      return { ...state, reportportalProject: action.payload }
     case 'SET_SERVER_JIRA_PROJECT_KEY':
       return { ...state, serverJiraProjectKey: action.payload }
     case 'SET_AI_CONFIGS':

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -13,6 +13,45 @@ import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-re
 import type { ReportPortalPushResult } from '@/types'
 import { useReportState } from './ReportContext'
 
+interface RPPushMetadataProps {
+  project?: string
+  jobName?: string
+  buildNumber?: number
+  launchId?: number
+  className?: string
+}
+
+function RPPushMetadata({ project, jobName, buildNumber, launchId, className }: RPPushMetadataProps) {
+  return (
+    <dl className={className}>
+      {project && (
+        <>
+          <dt className="font-medium">Project</dt>
+          <dd className="font-mono truncate" title={project}>{project}</dd>
+        </>
+      )}
+      {jobName && (
+        <>
+          <dt className="font-medium">Job</dt>
+          <dd className="font-mono truncate" title={jobName}>{jobName}</dd>
+        </>
+      )}
+      {buildNumber != null && (
+        <>
+          <dt className="font-medium">Build</dt>
+          <dd className="font-mono">#{buildNumber}</dd>
+        </>
+      )}
+      {launchId != null && (
+        <>
+          <dt className="font-medium">Launch ID</dt>
+          <dd className="font-mono">{launchId}</dd>
+        </>
+      )}
+    </dl>
+  )
+}
+
 interface ReportPortalButtonProps {
   jobId: string
   jobName: string
@@ -89,18 +128,12 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
             <DialogDescription>
               Push failure classifications to Report Portal?
             </DialogDescription>
-            <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-text-secondary">
-              {reportportalProject && (
-                <>
-                  <dt className="font-medium">Project</dt>
-                  <dd className="font-mono truncate" title={reportportalProject}>{reportportalProject}</dd>
-                </>
-              )}
-              <dt className="font-medium">Job</dt>
-              <dd className="font-mono truncate" title={displayJobName}>{displayJobName}</dd>
-              <dt className="font-medium">Build</dt>
-              <dd className="font-mono">#{displayBuildNumber}</dd>
-            </dl>
+            <RPPushMetadata
+              project={reportportalProject}
+              jobName={displayJobName}
+              buildNumber={displayBuildNumber}
+              className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-text-secondary"
+            />
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>
@@ -125,24 +158,13 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
                 <><CheckCircle2 className="h-5 w-5 text-signal-green" /> Pushed {pushResult?.pushed ?? 0} classification{pushResult?.pushed !== 1 ? 's' : ''} to Report Portal.</>
               )}
             </DialogTitle>
-            <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary">
-              {reportportalProject && (
-                <>
-                  <dt className="font-medium">Project</dt>
-                  <dd className="font-mono truncate" title={reportportalProject}>{reportportalProject}</dd>
-                </>
-              )}
-              <dt className="font-medium">Job</dt>
-              <dd className="font-mono truncate" title={displayJobName}>{displayJobName}</dd>
-              <dt className="font-medium">Build</dt>
-              <dd className="font-mono">#{displayBuildNumber}</dd>
-              {pushResult?.launch_id != null && (
-                <>
-                  <dt className="font-medium">Launch ID</dt>
-                  <dd className="font-mono">{pushResult.launch_id}</dd>
-                </>
-              )}
-            </dl>
+            <RPPushMetadata
+              project={reportportalProject}
+              jobName={displayJobName}
+              buildNumber={displayBuildNumber}
+              launchId={pushResult?.launch_id ?? undefined}
+              className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary"
+            />
           </DialogHeader>
 
           <div className="space-y-3 py-2 min-w-0">

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -11,14 +11,20 @@ import { Button } from '@/components/ui/button'
 import { api } from '@/lib/api'
 import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react'
 import type { ReportPortalPushResult } from '@/types'
+import { useReportState } from './ReportContext'
 
 interface ReportPortalButtonProps {
   jobId: string
+  jobName: string
+  buildNumber: number
   childJobName?: string
   childBuildNumber?: number
 }
 
-export function ReportPortalButton({ jobId, childJobName, childBuildNumber }: ReportPortalButtonProps) {
+export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, childBuildNumber }: ReportPortalButtonProps) {
+  const { reportportalProject } = useReportState()
+  const displayJobName = childJobName ?? jobName
+  const displayBuildNumber = childBuildNumber ?? buildNumber
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [pushing, setPushing] = useState(false)
   const [resultDialogOpen, setResultDialogOpen] = useState(false)
@@ -83,6 +89,18 @@ export function ReportPortalButton({ jobId, childJobName, childBuildNumber }: Re
             <DialogDescription>
               Push failure classifications to Report Portal?
             </DialogDescription>
+            <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-text-secondary">
+              {reportportalProject && (
+                <>
+                  <dt className="font-medium">Project</dt>
+                  <dd className="font-mono truncate" title={reportportalProject}>{reportportalProject}</dd>
+                </>
+              )}
+              <dt className="font-medium">Job</dt>
+              <dd className="font-mono truncate" title={displayJobName}>{displayJobName}</dd>
+              <dt className="font-medium">Build</dt>
+              <dd className="font-mono">#{displayBuildNumber}</dd>
+            </dl>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>
@@ -107,11 +125,24 @@ export function ReportPortalButton({ jobId, childJobName, childBuildNumber }: Re
                 <><CheckCircle2 className="h-5 w-5 text-signal-green" /> Pushed {pushResult?.pushed ?? 0} classification{pushResult?.pushed !== 1 ? 's' : ''} to Report Portal.</>
               )}
             </DialogTitle>
-            {pushResult?.launch_id != null && (
-              <p className="text-xs text-text-tertiary mt-1">
-                Launch ID: <span className="font-mono">{pushResult.launch_id}</span>
-              </p>
-            )}
+            <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary">
+              {reportportalProject && (
+                <>
+                  <dt className="font-medium">Project</dt>
+                  <dd className="font-mono truncate" title={reportportalProject}>{reportportalProject}</dd>
+                </>
+              )}
+              <dt className="font-medium">Job</dt>
+              <dd className="font-mono truncate" title={displayJobName}>{displayJobName}</dd>
+              <dt className="font-medium">Build</dt>
+              <dd className="font-mono">#{displayBuildNumber}</dd>
+              {pushResult?.launch_id != null && (
+                <>
+                  <dt className="font-medium">Launch ID</dt>
+                  <dd className="font-mono">{pushResult.launch_id}</dd>
+                </>
+              )}
+            </dl>
           </DialogHeader>
 
           <div className="space-y-3 py-2 min-w-0">

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -7,7 +7,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { api, userErrorMessage } from '@/lib/api'
+import { api } from '@/lib/api'
 import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react'
 import type { ReportPortalPushResult } from '@/types'
 import { useReportState } from './ReportContext'
@@ -67,12 +67,12 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
   const [pushing, setPushing] = useState(false)
   const [resultDialogOpen, setResultDialogOpen] = useState(false)
   const [pushResult, setPushResult] = useState<ReportPortalPushResult | null>(null)
-  const [pushError, setPushError] = useState('')
+  const [pushFailed, setPushFailed] = useState(false)
 
   const handlePush = useCallback(async () => {
     setConfirmOpen(false)
     setPushing(true)
-    setPushError('')
+    setPushFailed(false)
     setPushResult(null)
     try {
       const params = new URLSearchParams()
@@ -82,8 +82,8 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
       const result = await api.post<ReportPortalPushResult>(`/results/${jobId}/push-reportportal${qs ? `?${qs}` : ''}`)
       setPushResult(result)
       setResultDialogOpen(true)
-    } catch (err) {
-      setPushError(userErrorMessage(err, 'Failed to push to Report Portal'))
+    } catch {
+      setPushFailed(true)
       setResultDialogOpen(true)
     } finally {
       setPushing(false)
@@ -96,7 +96,7 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
 
   const hasResultErrors = !!(pushResult && pushResult.errors.length > 0)
   const hasUnmatched = !!(pushResult && pushResult.unmatched.length > 0)
-  const isFullFailure = pushError || (pushResult && pushResult.pushed === 0 && hasResultErrors)
+  const isFullFailure = pushFailed || (pushResult && pushResult.pushed === 0 && hasResultErrors)
   const isPartialSuccess = pushResult && pushResult.pushed > 0 && (hasResultErrors || hasUnmatched)
   const isNoop = !!(pushResult && pushResult.pushed === 0 && !hasResultErrors && hasUnmatched)
 

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -161,17 +161,7 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
                 className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary"
               />
 
-              {pushError && (
-                <p className="text-sm text-signal-red break-words">{pushError}</p>
-              )}
 
-              {pushResult && pushResult.errors.length > 0 && (
-                <ul className="space-y-1 text-xs text-signal-red/80 max-h-48 overflow-y-auto">
-                  {pushResult.errors.map((err, i) => (
-                    <li key={i} className="break-words" title={err}>{err}</li>
-                  ))}
-                </ul>
-              )}
             </div>
           )}
 

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -4,11 +4,10 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { api } from '@/lib/api'
+import { api, userErrorMessage } from '@/lib/api'
 import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react'
 import type { ReportPortalPushResult } from '@/types'
 import { useReportState } from './ReportContext'
@@ -84,7 +83,7 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
       setPushResult(result)
       setResultDialogOpen(true)
     } catch (err) {
-      setPushError(err instanceof Error ? err.message : 'Failed to push to Report Portal')
+      setPushError(userErrorMessage(err, 'Failed to push to Report Portal'))
       setResultDialogOpen(true)
     } finally {
       setPushing(false)
@@ -125,15 +124,7 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
               <Upload className="h-5 w-5 text-text-secondary" />
               Confirm Push
             </DialogTitle>
-            <DialogDescription>
-              Push failure classifications to Report Portal?
-            </DialogDescription>
-            <RPPushMetadata
-              project={reportportalProject}
-              jobName={displayJobName}
-              buildNumber={displayBuildNumber}
-              className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-text-secondary"
-            />
+
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>
@@ -158,48 +149,31 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
                 <><CheckCircle2 className="h-5 w-5 text-signal-green" /> Pushed {pushResult?.pushed ?? 0} classification{pushResult?.pushed !== 1 ? 's' : ''} to Report Portal.</>
               )}
             </DialogTitle>
-            <RPPushMetadata
-              project={reportportalProject}
-              jobName={displayJobName}
-              buildNumber={displayBuildNumber}
-              launchId={pushResult?.launch_id ?? undefined}
-              className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary"
-            />
           </DialogHeader>
 
-          <div className="space-y-3 py-2 min-w-0">
-            {pushError && (
-              <p className="text-sm text-signal-red break-words">{pushError}</p>
-            )}
+          {(isFullFailure || isPartialSuccess || isNoop) && (
+            <div className="space-y-3 py-2 min-w-0">
+              <RPPushMetadata
+                project={reportportalProject}
+                jobName={displayJobName}
+                buildNumber={displayBuildNumber}
+                launchId={pushResult?.launch_id ?? undefined}
+                className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-text-tertiary"
+              />
 
-            {pushResult && pushResult.unmatched.length > 0 && (
-              <div className="space-y-1.5">
-                <div className="flex items-center gap-1.5 text-sm text-signal-orange">
-                  <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-                  <span>{pushResult.unmatched.length} unmatched test{pushResult.unmatched.length !== 1 ? 's' : ''}</span>
-                </div>
-                <ul className="ml-6 space-y-0.5 text-xs text-text-tertiary max-h-32 overflow-y-auto">
-                  {pushResult.unmatched.map((name, index) => (
-                    <li key={`${name}-${index}`} className="font-mono break-all" title={name}>{name}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+              {pushError && (
+                <p className="text-sm text-signal-red break-words">{pushError}</p>
+              )}
 
-            {pushResult && pushResult.errors.length > 0 && (
-              <div className="space-y-1.5">
-                <div className="flex items-center gap-1.5 text-sm text-signal-red">
-                  <XCircle className="h-4 w-4 flex-shrink-0" />
-                  <span>{pushResult.errors.length} error{pushResult.errors.length !== 1 ? 's' : ''}</span>
-                </div>
-                <ul className="ml-6 space-y-1 text-xs text-signal-red/80 max-h-48 overflow-y-auto">
+              {pushResult && pushResult.errors.length > 0 && (
+                <ul className="space-y-1 text-xs text-signal-red/80 max-h-48 overflow-y-auto">
                   {pushResult.errors.map((err, i) => (
                     <li key={i} className="break-words" title={err}>{err}</li>
                   ))}
                 </ul>
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+          )}
 
           <DialogFooter>
             <Button variant="outline" onClick={handleClose}>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -254,6 +254,7 @@ export interface ResultResponse {
     server_jira_email?: boolean
     server_jira_project_key?: string
     reportportal?: boolean
+    reportportal_project?: string
   }
 }
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2474,6 +2474,10 @@ async def _execute_rp_push(
         )
         report_url = f"{report_url}#{anchor}"
 
+    failures_data = result_data.get("failures", [])
+    if not failures_data:
+        return _rp_push_error_result("No failures to push to Report Portal.")
+
     # Called only when reportportal_enabled is True, which guarantees these
     # fields are set (see Settings.reportportal_enabled property).  Explicit
     # checks narrow the Optional types for mypy and survive python -O.
@@ -2584,7 +2588,6 @@ async def _execute_rp_push(
             )
 
         # Build FailureAnalysis objects from stored result
-        failures_data = result_data.get("failures", [])
         try:
             jji_failures = [FailureAnalysis.model_validate(f) for f in failures_data]
         except ValidationError as exc:
@@ -2592,17 +2595,6 @@ async def _execute_rp_push(
                 status_code=422,
                 detail=f"Stored result contains invalid failure data: {exc.error_count()} validation error(s)",
             ) from exc
-
-        if not jji_failures:
-            logger.debug(
-                "RP push: no JJI failures in stored result for job='%s', launch_id=%d",
-                job_name,
-                launch_id,
-            )
-            return _rp_push_error_result(
-                "No JJI failures found in stored result.",
-                launch_id=launch_id,
-            )
 
         try:
             matched = await asyncio.to_thread(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2068,6 +2068,7 @@ def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
         "server_jira_email": bool(settings.jira_email),
         "server_jira_project_key": settings.jira_project_key or "",
         "reportportal": settings.reportportal_enabled,
+        "reportportal_project": settings.reportportal_project or "",
     }
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2393,47 +2393,111 @@ async def push_to_reportportal(
 def _rp_push_error_result(
     message: str,
     *,
-    job_name: str = "",
-    build_number: int | None = None,
     launch_id: int | None = None,
 ) -> dict:
     """Build a standard RP push failure response."""
-    context = (
-        f" (job='{job_name}' #{build_number})"
-        if job_name and build_number is not None
-        else ""
-    )
     return {
         "pushed": 0,
         "unmatched": [],
-        "errors": [f"{message}{context}"],
+        "errors": [message],
         "launch_id": launch_id,
     }
 
 
-def _rp_error_message(exc: Exception, operation: str) -> str:
-    """Build a user-facing error message from an RP exception."""
+def _log_and_return_rp_error(
+    user_msg: str,
+    *,
+    log_msg: str = "",
+    job_name: str = "",
+    build_number: int | None = None,
+    jenkins_url: str = "",
+    launch_id: int | None = None,
+) -> dict:
+    """Log an RP push error and return the standardised error dict.
+
+    Centralises the repeated log-then-return pattern so each call-site
+    is a single expression instead of a multi-line logger.error + return
+    block.
+
+    Args:
+        user_msg: Short, user-facing error for the API response.
+        log_msg: Detailed message for the server log.  Falls back to
+            *user_msg* when empty.
+    """
+    detail = log_msg or user_msg
+    if launch_id is not None:
+        logger.error(
+            "RP push failed: %s, job='%s' #%s, launch_id=%d",
+            detail,
+            job_name,
+            build_number,
+            launch_id,
+        )
+    elif jenkins_url:
+        logger.error(
+            "RP push failed: %s, job='%s' #%s, jenkins_url='%s'",
+            detail,
+            job_name,
+            build_number,
+            jenkins_url,
+        )
+    elif build_number is not None:
+        logger.error(
+            "RP push failed: %s, job='%s' #%s",
+            detail,
+            job_name,
+            build_number,
+        )
+    else:
+        logger.error("RP push failed: %s", detail)
+    return _rp_push_error_result(
+        user_msg,
+        launch_id=launch_id,
+    )
+
+
+def _rp_error_message(exc: Exception, operation: str) -> tuple[str, str]:
+    """Build a short user-facing message and a detailed log message.
+
+    Returns:
+        Tuple of ``(user_message, log_detail)``.
+        *user_message* is short and suitable for API responses.
+        *log_detail* contains the full exception context for server logs.
+    """
     detail = ""
+    rp_message = ""
     status = ""
     resp = getattr(exc, "response", None)
     if resp is not None:
         status = str(resp.status_code)
         try:
             rp_body = resp.json()
-            detail = (
-                rp_body.get("message", resp.text)
-                if isinstance(rp_body, dict)
-                else resp.text
-            )
+            raw = rp_body.get("message") if isinstance(rp_body, dict) else None
+            # RP JSON "message" field — short, user-friendly
+            rp_message = raw if isinstance(raw, str) else ""
+            # Full response text — log only
+            detail = resp.text or ""
         except Exception:
-            detail = resp.text
+            detail = resp.text or ""
     else:
-        # No HTTP response (ConnectionError, TimeoutError, etc.)
         detail = str(exc) if str(exc) else ""
-    msg = f"{status or type(exc).__name__} error {operation}"
+
+    # User message: short — operation + status + RP message (if any)
+    if status:
+        user_msg = f"Error {operation} (HTTP {status})"
+        if rp_message:
+            user_msg += f": {rp_message}"
+    else:
+        user_msg = f"Error {operation}"
+
+    # Log message: full technical detail
+    log_msg = f"{type(exc).__name__} {operation}"
+    if status:
+        log_msg = f"{status} ({type(exc).__name__}) {operation}"
     if detail:
-        msg += f": {detail}"
-    return msg
+        log_msg += f": {detail}"
+
+    return user_msg, log_msg
 
 
 async def _execute_rp_push(
@@ -2494,8 +2558,6 @@ async def _execute_rp_push(
     if not failures_data:
         return _rp_push_error_result(
             "No failures to push to Report Portal.",
-            job_name=result_data.get("job_name", ""),
-            build_number=result_data.get("build_number"),
         )
 
     # Called only when reportportal_enabled is True, which guarantees these
@@ -2520,12 +2582,14 @@ async def _execute_rp_push(
             verify_ssl=settings.reportportal_verify_ssl,
         )
     except Exception as exc:
-        error_msg = _rp_error_message(
+        user_msg, log_msg = _rp_error_message(
             exc,
-            f"connecting to Report Portal at {settings.reportportal_url}",
+            "connecting to Report Portal",
         )
-        logger.error("RP push failed: %s", error_msg)
-        return _rp_push_error_result(error_msg)
+        # Include the RP URL in the log message (not user-facing) so
+        # operators can identify which RP instance failed.
+        log_msg = f"{log_msg}, reportportal_url='{settings.reportportal_url}'"
+        return _log_and_return_rp_error(user_msg, log_msg=log_msg)
 
     with rp_client_ctx as rp_client:
         jenkins_url = result_data.get("jenkins_url", "")
@@ -2548,41 +2612,25 @@ async def _execute_rp_push(
                 exc,
             )
             return _rp_push_error_result(
-                f"Ambiguous RP launch: found {exc.count} launches"
-                f" for '{job_name}' #{build_number} in project"
-                f" '{settings.reportportal_project}'"
-                f" whose description contains the Jenkins build URL."
+                f"Ambiguous RP launch: found {exc.count} launches."
                 f" Remove duplicate launches to disambiguate."
             )
         except Exception as exc:
-            error_msg = _rp_error_message(
-                exc, f"searching RP launches for job '{job_name}' #{build_number}"
-            )
-            logger.error(
-                "RP push failed: %s, job='%s' #%s, jenkins_url='%s'",
-                error_msg,
-                job_name,
-                build_number,
-                jenkins_url,
-            )
-            return _rp_push_error_result(
-                error_msg, job_name=job_name, build_number=build_number
+            user_msg, log_msg = _rp_error_message(exc, "searching RP launches")
+            return _log_and_return_rp_error(
+                user_msg,
+                log_msg=log_msg,
+                job_name=job_name,
+                build_number=build_number,
+                jenkins_url=jenkins_url,
             )
 
         if launch_id is None:
-            logger.error(
-                "RP push failed: no launch found for job='%s' #%s in project='%s',"
-                " jenkins_url='%s'",
-                job_name,
-                build_number,
-                settings.reportportal_project,
-                jenkins_url,
-            )
-            return _rp_push_error_result(
-                f"No RP launch found for job '{job_name}' #{build_number}"
-                f" in project '{settings.reportportal_project}'",
+            return _log_and_return_rp_error(
+                "No RP launch found.",
                 job_name=job_name,
                 build_number=build_number,
+                jenkins_url=jenkins_url,
             )
 
         try:
@@ -2590,17 +2638,10 @@ async def _execute_rp_push(
                 rp_client.get_failed_items, launch_id
             )
         except Exception as exc:
-            error_msg = _rp_error_message(
-                exc, f"fetching failed items from RP launch {launch_id}"
-            )
-            logger.error(
-                "RP push failed: %s, job='%s' #%s",
-                error_msg,
-                job_name,
-                build_number,
-            )
-            return _rp_push_error_result(
-                error_msg,
+            user_msg, log_msg = _rp_error_message(exc, "fetching failed items from RP")
+            return _log_and_return_rp_error(
+                user_msg,
+                log_msg=log_msg,
                 job_name=job_name,
                 build_number=build_number,
                 launch_id=launch_id,
@@ -2630,18 +2671,10 @@ async def _execute_rp_push(
                 rp_client.match_failures, failed_items, jji_failures
             )
         except Exception as exc:
-            error_msg = _rp_error_message(
-                exc, f"matching RP items to JJI failures for job '{job_name}'"
-            )
-            logger.error(
-                "RP push failed: %s, job='%s' #%s, launch_id=%d",
-                error_msg,
-                job_name,
-                build_number,
-                launch_id,
-            )
-            return _rp_push_error_result(
-                error_msg,
+            user_msg, log_msg = _rp_error_message(exc, "matching RP items to failures")
+            return _log_and_return_rp_error(
+                user_msg,
+                log_msg=log_msg,
                 job_name=job_name,
                 build_number=build_number,
                 launch_id=launch_id,
@@ -2650,20 +2683,17 @@ async def _execute_rp_push(
         if not matched and failed_items and jji_failures:
             rp_names = [item.get("name", "") for item in failed_items]
             jji_names = [f.test_name for f in jji_failures]
-            overlap_error = (
+            # Full diagnostic detail for server logs only
+            log_detail = (
                 f"No overlap between {len(failed_items)} RP item(s)"
                 f" and {len(jji_failures)} JJI failure(s)."
                 f" RP items: {', '.join(rp_names)}."
                 f" JJI tests: {', '.join(jji_names)}."
             )
-            logger.error(
-                "RP push failed for job='%s', launch_id=%d: %s",
-                job_name,
-                launch_id,
-                overlap_error,
-            )
-            return _rp_push_error_result(
-                overlap_error,
+            return _log_and_return_rp_error(
+                f"No overlap between {len(failed_items)} RP item(s)"
+                f" and {len(jji_failures)} JJI failure(s).",
+                log_msg=log_detail,
                 job_name=job_name,
                 build_number=build_number,
                 launch_id=launch_id,
@@ -2702,19 +2732,13 @@ async def _execute_rp_push(
                 history_classifications,
             )
         except Exception as exc:
-            error_msg = _rp_error_message(
+            user_msg, log_msg = _rp_error_message(
                 exc,
-                f"pushing classifications to RP for job '{job_name}'",
+                "pushing classifications to RP",
             )
-            logger.error(
-                "RP push failed: %s, job='%s' #%s, launch_id=%d",
-                error_msg,
-                job_name,
-                build_number,
-                launch_id,
-            )
-            return _rp_push_error_result(
-                error_msg,
+            return _log_and_return_rp_error(
+                user_msg,
+                log_msg=log_msg,
                 job_name=job_name,
                 build_number=build_number,
                 launch_id=launch_id,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2390,12 +2390,23 @@ async def push_to_reportportal(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-def _rp_push_error_result(message: str, *, launch_id: int | None = None) -> dict:
+def _rp_push_error_result(
+    message: str,
+    *,
+    job_name: str = "",
+    build_number: int | None = None,
+    launch_id: int | None = None,
+) -> dict:
     """Build a standard RP push failure response."""
+    context = (
+        f" (job='{job_name}' #{build_number})"
+        if job_name and build_number is not None
+        else ""
+    )
     return {
         "pushed": 0,
         "unmatched": [],
-        "errors": [message],
+        "errors": [f"{message}{context}"],
         "launch_id": launch_id,
     }
 
@@ -2481,7 +2492,11 @@ async def _execute_rp_push(
 
     failures_data = result_data.get("failures", [])
     if not failures_data:
-        return _rp_push_error_result("No failures to push to Report Portal.")
+        return _rp_push_error_result(
+            "No failures to push to Report Portal.",
+            job_name=result_data.get("job_name", ""),
+            build_number=result_data.get("build_number"),
+        )
 
     # Called only when reportportal_enabled is True, which guarantees these
     # fields are set (see Settings.reportportal_enabled property).  Explicit
@@ -2550,7 +2565,9 @@ async def _execute_rp_push(
                 build_number,
                 jenkins_url,
             )
-            return _rp_push_error_result(error_msg)
+            return _rp_push_error_result(
+                error_msg, job_name=job_name, build_number=build_number
+            )
 
         if launch_id is None:
             logger.error(
@@ -2563,7 +2580,9 @@ async def _execute_rp_push(
             )
             return _rp_push_error_result(
                 f"No RP launch found for job '{job_name}' #{build_number}"
-                f" in project '{settings.reportportal_project}'"
+                f" in project '{settings.reportportal_project}'",
+                job_name=job_name,
+                build_number=build_number,
             )
 
         try:
@@ -2580,7 +2599,12 @@ async def _execute_rp_push(
                 job_name,
                 build_number,
             )
-            return _rp_push_error_result(error_msg, launch_id=launch_id)
+            return _rp_push_error_result(
+                error_msg,
+                job_name=job_name,
+                build_number=build_number,
+                launch_id=launch_id,
+            )
         if not failed_items:
             logger.debug(
                 "RP push: no failed items in launch_id=%d for job='%s'",
@@ -2616,7 +2640,12 @@ async def _execute_rp_push(
                 build_number,
                 launch_id,
             )
-            return _rp_push_error_result(error_msg, launch_id=launch_id)
+            return _rp_push_error_result(
+                error_msg,
+                job_name=job_name,
+                build_number=build_number,
+                launch_id=launch_id,
+            )
 
         if not matched and failed_items and jji_failures:
             rp_names = [item.get("name", "") for item in failed_items]
@@ -2633,7 +2662,12 @@ async def _execute_rp_push(
                 launch_id,
                 overlap_error,
             )
-            return _rp_push_error_result(overlap_error, launch_id=launch_id)
+            return _rp_push_error_result(
+                overlap_error,
+                job_name=job_name,
+                build_number=build_number,
+                launch_id=launch_id,
+            )
 
         # Get history classifications for matched tests (concurrent queries)
         unique_test_names = list(
@@ -2679,7 +2713,12 @@ async def _execute_rp_push(
                 build_number,
                 launch_id,
             )
-            return _rp_push_error_result(error_msg, launch_id=launch_id)
+            return _rp_push_error_result(
+                error_msg,
+                job_name=job_name,
+                build_number=build_number,
+                launch_id=launch_id,
+            )
 
         push_result["launch_id"] = launch_id
         return push_result

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2506,10 +2506,12 @@ async def _execute_rp_push(
     with rp_client_ctx as rp_client:
         jenkins_url = result_data.get("jenkins_url", "")
         job_name = result_data.get("job_name", "")
+        build_number = result_data.get("build_number", 0)
 
         logger.debug(
-            "RP push: searching for launch name='%s', jenkins_url='%s'",
+            "RP push: searching for launch job='%s' #%s, jenkins_url='%s'",
             job_name,
+            build_number,
             jenkins_url,
         )
         try:
@@ -2523,33 +2525,35 @@ async def _execute_rp_push(
             )
             return _rp_push_error_result(
                 f"Ambiguous RP launch: found {exc.count} launches"
-                f" named '{job_name}' in project"
+                f" for '{job_name}' #{build_number} in project"
                 f" '{settings.reportportal_project}'"
-                f" but none matched the Jenkins build URL."
-                f" Add the Jenkins URL to the RP launch description"
-                f" to disambiguate."
+                f" whose description contains the Jenkins build URL."
+                f" Remove duplicate launches to disambiguate."
             )
         except Exception as exc:
             error_msg = _rp_error_message(
-                exc, f"searching RP launches for job '{job_name}'"
+                exc, f"searching RP launches for job '{job_name}' #{build_number}"
             )
             logger.error(
-                "RP push failed: %s, jenkins_url='%s'",
+                "RP push failed: %s, job='%s' #%s, jenkins_url='%s'",
                 error_msg,
+                job_name,
+                build_number,
                 jenkins_url,
             )
             return _rp_push_error_result(error_msg)
 
         if launch_id is None:
             logger.error(
-                "RP push failed: no launch found for job='%s' in project='%s',"
+                "RP push failed: no launch found for job='%s' #%s in project='%s',"
                 " jenkins_url='%s'",
                 job_name,
+                build_number,
                 settings.reportportal_project,
                 jenkins_url,
             )
             return _rp_push_error_result(
-                f"No RP launch found for job '{job_name}'"
+                f"No RP launch found for job '{job_name}' #{build_number}"
                 f" in project '{settings.reportportal_project}'"
             )
 
@@ -2562,9 +2566,10 @@ async def _execute_rp_push(
                 exc, f"fetching failed items from RP launch {launch_id}"
             )
             logger.error(
-                "RP push failed: %s, job='%s'",
+                "RP push failed: %s, job='%s' #%s",
                 error_msg,
                 job_name,
+                build_number,
             )
             return _rp_push_error_result(error_msg, launch_id=launch_id)
         if not failed_items:
@@ -2608,8 +2613,10 @@ async def _execute_rp_push(
                 exc, f"matching RP items to JJI failures for job '{job_name}'"
             )
             logger.error(
-                "RP push failed: %s, launch_id=%d",
+                "RP push failed: %s, job='%s' #%s, launch_id=%d",
                 error_msg,
+                job_name,
+                build_number,
                 launch_id,
             )
             return _rp_push_error_result(error_msg, launch_id=launch_id)
@@ -2669,8 +2676,10 @@ async def _execute_rp_push(
                 f"pushing classifications to RP for job '{job_name}'",
             )
             logger.error(
-                "RP push failed: %s, launch_id=%d",
+                "RP push failed: %s, job='%s' #%s, launch_id=%d",
                 error_msg,
+                job_name,
+                build_number,
                 launch_id,
             )
             return _rp_push_error_result(error_msg, launch_id=launch_id)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -40,7 +40,7 @@ from jenkins_job_insight.encryption import (
     encrypt_sensitive_fields,
 )
 from jenkins_job_insight.jira import enrich_with_jira_matches
-from jenkins_job_insight.reportportal import ReportPortalClient
+from jenkins_job_insight.reportportal import AmbiguousLaunchError, ReportPortalClient
 from jenkins_job_insight.bug_creation import (
     _parse_github_repo_url,
     create_github_issue,
@@ -2389,6 +2389,36 @@ async def push_to_reportportal(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _rp_push_error_result(message: str, *, launch_id: int | None = None) -> dict:
+    """Build a standard RP push failure response."""
+    return {
+        "pushed": 0,
+        "unmatched": [],
+        "errors": [message],
+        "launch_id": launch_id,
+    }
+
+
+def _rp_error_message(exc: Exception, operation: str) -> str:
+    """Build a user-facing error message from an RP exception."""
+    detail = ""
+    status = ""
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        status = str(resp.status_code)
+        try:
+            detail = resp.json().get("message", resp.text)
+        except Exception:
+            detail = resp.text
+    else:
+        # No HTTP response (ConnectionError, TimeoutError, etc.)
+        detail = str(exc) if str(exc) else ""
+    msg = f"{status or type(exc).__name__} error {operation}"
+    if detail:
+        msg += f": {detail}"
+    return msg
+
+
 async def _execute_rp_push(
     job_id: str,
     result_data: dict,
@@ -2457,34 +2487,95 @@ async def _execute_rp_push(
             "reportportal_project is required when Report Portal is enabled"
         )
 
-    with ReportPortalClient(
-        url=settings.reportportal_url,
-        token=settings.reportportal_api_token.get_secret_value(),
-        project=settings.reportportal_project,
-        verify_ssl=settings.reportportal_verify_ssl,
-    ) as rp_client:
+    try:
+        rp_client_ctx = ReportPortalClient(
+            url=settings.reportportal_url,
+            token=settings.reportportal_api_token.get_secret_value(),
+            project=settings.reportportal_project,
+            verify_ssl=settings.reportportal_verify_ssl,
+        )
+    except Exception as exc:
+        error_msg = _rp_error_message(
+            exc,
+            f"connecting to Report Portal at {settings.reportportal_url}",
+        )
+        logger.error("RP push failed: %s", error_msg)
+        return _rp_push_error_result(error_msg)
+
+    with rp_client_ctx as rp_client:
         jenkins_url = result_data.get("jenkins_url", "")
         job_name = result_data.get("job_name", "")
 
-        launch_id = await asyncio.to_thread(
-            rp_client.find_launch, job_name, jenkins_url
+        logger.debug(
+            "RP push: searching for launch name='%s', jenkins_url='%s'",
+            job_name,
+            jenkins_url,
         )
-        if launch_id is None:
-            return {
-                "pushed": 0,
-                "unmatched": [],
-                "errors": [f"No RP launch found for job '{job_name}'"],
-                "launch_id": None,
-            }
+        try:
+            launch_id = await asyncio.to_thread(
+                rp_client.find_launch, job_name, jenkins_url
+            )
+        except AmbiguousLaunchError as exc:
+            logger.warning(
+                "RP push: %s",
+                exc,
+            )
+            return _rp_push_error_result(
+                f"Ambiguous RP launch: found {exc.count} launches"
+                f" named '{job_name}' in project"
+                f" '{settings.reportportal_project}'"
+                f" but none matched the Jenkins build URL."
+                f" Add the Jenkins URL to the RP launch description"
+                f" to disambiguate."
+            )
+        except Exception as exc:
+            error_msg = _rp_error_message(
+                exc, f"searching RP launches for job '{job_name}'"
+            )
+            logger.error(
+                "RP push failed: %s, jenkins_url='%s'",
+                error_msg,
+                jenkins_url,
+            )
+            return _rp_push_error_result(error_msg)
 
-        failed_items = await asyncio.to_thread(rp_client.get_failed_items, launch_id)
+        if launch_id is None:
+            logger.error(
+                "RP push failed: no launch found for job='%s' in project='%s',"
+                " jenkins_url='%s'",
+                job_name,
+                settings.reportportal_project,
+                jenkins_url,
+            )
+            return _rp_push_error_result(
+                f"No RP launch found for job '{job_name}'"
+                f" in project '{settings.reportportal_project}'"
+            )
+
+        try:
+            failed_items = await asyncio.to_thread(
+                rp_client.get_failed_items, launch_id
+            )
+        except Exception as exc:
+            error_msg = _rp_error_message(
+                exc, f"fetching failed items from RP launch {launch_id}"
+            )
+            logger.error(
+                "RP push failed: %s, job='%s'",
+                error_msg,
+                job_name,
+            )
+            return _rp_push_error_result(error_msg, launch_id=launch_id)
         if not failed_items:
-            return {
-                "pushed": 0,
-                "unmatched": [],
-                "errors": ["No failed test items found in RP launch."],
-                "launch_id": launch_id,
-            }
+            logger.debug(
+                "RP push: no failed items in launch_id=%d for job='%s'",
+                launch_id,
+                job_name,
+            )
+            return _rp_push_error_result(
+                "No failed test items found in RP launch.",
+                launch_id=launch_id,
+            )
 
         # Build FailureAnalysis objects from stored result
         failures_data = result_data.get("failures", [])
@@ -2497,31 +2588,47 @@ async def _execute_rp_push(
             ) from exc
 
         if not jji_failures:
-            return {
-                "pushed": 0,
-                "unmatched": [],
-                "errors": ["No JJI failures found in stored result."],
-                "launch_id": launch_id,
-            }
+            logger.debug(
+                "RP push: no JJI failures in stored result for job='%s', launch_id=%d",
+                job_name,
+                launch_id,
+            )
+            return _rp_push_error_result(
+                "No JJI failures found in stored result.",
+                launch_id=launch_id,
+            )
 
-        matched = await asyncio.to_thread(
-            rp_client.match_failures, failed_items, jji_failures
-        )
+        try:
+            matched = await asyncio.to_thread(
+                rp_client.match_failures, failed_items, jji_failures
+            )
+        except Exception as exc:
+            error_msg = _rp_error_message(
+                exc, f"matching RP items to JJI failures for job '{job_name}'"
+            )
+            logger.error(
+                "RP push failed: %s, launch_id=%d",
+                error_msg,
+                launch_id,
+            )
+            return _rp_push_error_result(error_msg, launch_id=launch_id)
 
         if not matched and failed_items and jji_failures:
             rp_names = [item.get("name", "") for item in failed_items]
             jji_names = [f.test_name for f in jji_failures]
-            return {
-                "pushed": 0,
-                "unmatched": [],
-                "errors": [
-                    f"No overlap between {len(failed_items)} RP item(s)"
-                    f" and {len(jji_failures)} JJI failure(s)."
-                    f" RP items: {', '.join(rp_names)}."
-                    f" JJI tests: {', '.join(jji_names)}."
-                ],
-                "launch_id": launch_id,
-            }
+            overlap_error = (
+                f"No overlap between {len(failed_items)} RP item(s)"
+                f" and {len(jji_failures)} JJI failure(s)."
+                f" RP items: {', '.join(rp_names)}."
+                f" JJI tests: {', '.join(jji_names)}."
+            )
+            logger.error(
+                "RP push failed for job='%s', launch_id=%d: %s",
+                job_name,
+                launch_id,
+                overlap_error,
+            )
+            return _rp_push_error_result(overlap_error, launch_id=launch_id)
 
         # Get history classifications for matched tests (concurrent queries)
         unique_test_names = list(
@@ -2529,19 +2636,44 @@ async def _execute_rp_push(
         )
         scope_name = child_job_name or ""
         scope_build = child_build_number or 0
-        classifications = await asyncio.gather(
-            *(
+        classification_results = await run_parallel_with_limit(
+            [
                 get_history_classification(job_id, name, scope_name, scope_build)
                 for name in unique_test_names
-            )
+            ]
         )
-        history_classifications: dict[str, str] = {
-            name: cls for name, cls in zip(unique_test_names, classifications) if cls
-        }
+        history_classifications: dict[str, str] = {}
+        for name, result in zip(unique_test_names, classification_results, strict=True):
+            if isinstance(result, BaseException):
+                logger.debug(
+                    "RP push: failed to fetch history classification"
+                    " for test='%s', job='%s'",
+                    name,
+                    job_name,
+                )
+                continue
+            if result:
+                history_classifications[name] = result
 
-        push_result = await asyncio.to_thread(
-            rp_client.push_classifications, matched, report_url, history_classifications
-        )
+        try:
+            push_result = await asyncio.to_thread(
+                rp_client.push_classifications,
+                matched,
+                report_url,
+                history_classifications,
+            )
+        except Exception as exc:
+            error_msg = _rp_error_message(
+                exc,
+                f"pushing classifications to RP for job '{job_name}'",
+            )
+            logger.error(
+                "RP push failed: %s, launch_id=%d",
+                error_msg,
+                launch_id,
+            )
+            return _rp_push_error_result(error_msg, launch_id=launch_id)
+
         push_result["launch_id"] = launch_id
         return push_result
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2408,7 +2408,12 @@ def _rp_error_message(exc: Exception, operation: str) -> str:
     if resp is not None:
         status = str(resp.status_code)
         try:
-            detail = resp.json().get("message", resp.text)
+            rp_body = resp.json()
+            detail = (
+                rp_body.get("message", resp.text)
+                if isinstance(rp_body, dict)
+                else resp.text
+            )
         except Exception:
             detail = resp.text
     else:

--- a/src/jenkins_job_insight/reportportal.py
+++ b/src/jenkins_job_insight/reportportal.py
@@ -31,8 +31,8 @@ class AmbiguousLaunchError(Exception):
         self.job_name = job_name
         self.jenkins_url = jenkins_url
         super().__init__(
-            f"Found {count} launches named '{job_name}'"
-            f" but none matched jenkins_url '{jenkins_url}'"
+            f"Found {count} launches matching jenkins_url='{jenkins_url}'"
+            f" for job '{job_name}'. Cannot disambiguate."
         )
 
 
@@ -182,48 +182,43 @@ class ReportPortalClient:
         return result
 
     def find_launch(self, job_name: str, jenkins_url: str) -> int | None:
-        """Find an RP launch matching the given Jenkins job.
+        """Find an RP launch matching the given Jenkins build.
 
-        Searches by exact match on launch name. If multiple launches share
-        the same name, disambiguates by checking whether the launch description
-        contains *jenkins_url*.
+        Searches recent launches in the project and matches by checking
+        whether the launch **description** contains *jenkins_url*.  The
+        Jenkins URL is unique per build and is a reliable identifier
+        regardless of launch naming conventions.
 
         Args:
-            job_name: Jenkins job name to search for.
-            jenkins_url: Full Jenkins build URL for disambiguation.
+            job_name: Jenkins job name (used for error context).
+            jenkins_url: Full Jenkins build URL used as identifier.
 
         Returns:
             Numeric launch ID, or ``None`` if no match found.
 
         Raises:
-            AmbiguousLaunchError: Multiple launches share the same name
-                and none could be disambiguated by *jenkins_url*.
+            AmbiguousLaunchError: Multiple launches matched by
+                description (URL query) and cannot be disambiguated.
         """
         base = self._rp_client.base_url_v1
         url = f"{base}/launch"
-        all_launches = self._paginate_get(
+
+        url_matches = self._paginate_get(
             url,
             {
-                "filter.eq.name": job_name,
+                "filter.cnt.description": jenkins_url,
                 "page.size": 50,
                 "page.sort": "startTime,desc",
             },
         )
 
-        if not all_launches:
-            return None
+        if len(url_matches) == 1:
+            return url_matches[0]["id"]
 
-        if len(all_launches) == 1:
-            return all_launches[0]["id"]
+        if len(url_matches) > 1:
+            raise AmbiguousLaunchError(len(url_matches), job_name, jenkins_url)
 
-        # Multiple launches with the same name -- match by Jenkins URL in description
-        for launch in all_launches:
-            desc = launch.get("description", "") or ""
-            if jenkins_url in desc:
-                return launch["id"]
-
-        # Ambiguous: multiple launches, none matched by URL — refuse to guess
-        raise AmbiguousLaunchError(len(all_launches), job_name, jenkins_url)
+        return None
 
     def get_failed_items(self, launch_id: int) -> list[dict]:
         """Get all failed test items from a launch.

--- a/src/jenkins_job_insight/reportportal.py
+++ b/src/jenkins_job_insight/reportportal.py
@@ -6,6 +6,8 @@ classification results, analysis text, and Jira matches into RP launches.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import warnings
 from typing import TYPE_CHECKING, Literal
@@ -19,6 +21,20 @@ if TYPE_CHECKING:
     from jenkins_job_insight.models import FailureAnalysis
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+class AmbiguousLaunchError(Exception):
+    """Multiple RP launches matched but none could be disambiguated."""
+
+    def __init__(self, count: int, job_name: str, jenkins_url: str) -> None:
+        self.count = count
+        self.job_name = job_name
+        self.jenkins_url = jenkins_url
+        super().__init__(
+            f"Found {count} launches named '{job_name}'"
+            f" but none matched jenkins_url '{jenkins_url}'"
+        )
+
 
 # JJI classification -> RP defect type category
 _CLASSIFICATION_MAP: dict[str, str] = {
@@ -61,12 +77,20 @@ class ReportPortalClient:
         self._session.headers["Authorization"] = f"Bearer {token}"
         self._session.verify = verify_ssl
         self._suppress_ssl_warnings = not verify_ssl
-        self._rp_client = RPClient(
-            endpoint=url.rstrip("/"),
-            project=project,
-            api_key=token,
-            verify_ssl=verify_ssl,
-        )
+        # Suppress RPClient's own traceback output from get_api_info().
+        # The library prints to sys.stderr on connection failure before
+        # raising; we catch the exception ourselves and log a clean error.
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self._rp_client = RPClient(
+                    endpoint=url.rstrip("/"),
+                    project=project,
+                    api_key=token,
+                    verify_ssl=verify_ssl,
+                )
+        except Exception:
+            self._session.close()
+            raise
 
     def __enter__(self) -> ReportPortalClient:
         return self
@@ -170,6 +194,10 @@ class ReportPortalClient:
 
         Returns:
             Numeric launch ID, or ``None`` if no match found.
+
+        Raises:
+            AmbiguousLaunchError: Multiple launches share the same name
+                and none could be disambiguated by *jenkins_url*.
         """
         base = self._rp_client.base_url_v1
         url = f"{base}/launch"
@@ -195,13 +223,7 @@ class ReportPortalClient:
                 return launch["id"]
 
         # Ambiguous: multiple launches, none matched by URL — refuse to guess
-        logger.warning(
-            "Found %d launches named '%s' but none matched jenkins_url '%s'",
-            len(all_launches),
-            job_name,
-            jenkins_url,
-        )
-        return None
+        raise AmbiguousLaunchError(len(all_launches), job_name, jenkins_url)
 
     def get_failed_items(self, launch_id: int) -> list[dict]:
         """Get all failed test items from a launch.
@@ -238,10 +260,12 @@ class ReportPortalClient:
 
         Matching strategy (in order):
         1. Exact match on ``name`` or ``codeRef``
-        2. Dotted-suffix match in either direction: JJI FQN ends with
-           ``.{rp_name}`` *or* RP name ends with ``.{jji_name}``.  This
-           handles both cases where JJI stores the fully-qualified name
-           and RP stores the short name, and vice-versa.
+        2. Dotted-suffix match on ``name`` in either direction: JJI FQN
+           ends with ``.{rp_name}`` *or* RP name ends with
+           ``.{jji_name}``.
+        3. Dotted-suffix match on ``codeRef`` in either direction: JJI
+           FQN ends with ``.{rp_codeRef}`` *or* RP codeRef ends with
+           ``.{jji_name}``.
 
         Args:
             rp_items: List of RP item dicts.
@@ -398,27 +422,53 @@ class ReportPortalClient:
             except _requests.exceptions.HTTPError as exc:
                 status = exc.response.status_code if exc.response is not None else None
                 detail = ""
+                response_body = ""
                 if exc.response is not None:
+                    response_body = exc.response.text
                     try:
                         rp_body = exc.response.json()
-                        detail = rp_body.get("message", "")
+                        raw_detail = (
+                            rp_body.get("message", response_body)
+                            if isinstance(rp_body, dict)
+                            else response_body
+                        )
+                        detail = (
+                            raw_detail
+                            if isinstance(raw_detail, str)
+                            else response_body
+                            if raw_detail is None
+                            else str(raw_detail)
+                        )
                     except Exception:
-                        detail = ""
-                logger.debug("RP batch update failed: %s", exc)
+                        detail = response_body
+                log_detail = detail.replace("\r", "\\r").replace("\n", "\\n")
+                log_body = response_body.replace("\r", "\\r").replace("\n", "\\n")
+                logger.error(
+                    "RP batch update failed: status=%s, url=%s,"
+                    " items=%d, detail=%s, response_body=%s",
+                    status,
+                    url,
+                    len(bulk_issues),
+                    log_detail or "(no detail)",
+                    log_body,
+                )
                 suffix = f": {detail}" if detail else ""
                 error_msg = (
                     f"{status or 'HTTP'} error updating"
                     f" {len(bulk_issues)} item(s){suffix}"
                 )
-                logger.warning(error_msg)
                 errors.append(error_msg)
             except Exception as exc:
-                logger.debug("RP batch update failed: %s", exc)
+                logger.error(
+                    "RP batch update failed: url=%s, items=%d, error=%s",
+                    url,
+                    len(bulk_issues),
+                    exc,
+                )
                 error_msg = (
                     f"Failed to update {len(bulk_issues)} RP item(s):"
                     f" {type(exc).__name__}"
                 )
-                logger.warning(error_msg)
                 errors.append(error_msg)
 
         return {

--- a/src/jenkins_job_insight/reportportal.py
+++ b/src/jenkins_job_insight/reportportal.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import io
 import os
+import threading
 import warnings
 from typing import TYPE_CHECKING, Literal
 
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from jenkins_job_insight.models import FailureAnalysis
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+_RPCLIENT_INIT_LOCK = threading.Lock()
 
 
 class AmbiguousLaunchError(Exception):
@@ -81,7 +83,7 @@ class ReportPortalClient:
         # The library prints to sys.stderr on connection failure before
         # raising; we catch the exception ourselves and log a clean error.
         try:
-            with contextlib.redirect_stderr(io.StringIO()):
+            with _RPCLIENT_INIT_LOCK, contextlib.redirect_stderr(io.StringIO()):
                 self._rp_client = RPClient(
                     endpoint=url.rstrip("/"),
                     project=project,
@@ -460,9 +462,11 @@ class ReportPortalClient:
                     len(bulk_issues),
                     exc,
                 )
+                detail = str(exc).strip()
                 error_msg = (
                     f"Failed to update {len(bulk_issues)} RP item(s):"
                     f" {type(exc).__name__}"
+                    f"{f': {detail}' if detail else ''}"
                 )
                 errors.append(error_msg)
 

--- a/src/jenkins_job_insight/reportportal.py
+++ b/src/jenkins_job_insight/reportportal.py
@@ -30,7 +30,7 @@ _RPCLIENT_INIT_LOCK = threading.Lock()
 # so any internal wait on it returns instantly.
 #
 # This patches a name-mangled private method; if a future library upgrade
-# removes it, the AttributeError here will surface immediately at import
+# removes it, the ImportError here will surface immediately at import
 # time rather than silently reverting to noisy behaviour.
 _PREFETCH_ATTR = "_RPClient__init_api_info_prefetch"
 if not hasattr(RPClient, _PREFETCH_ATTR):

--- a/src/jenkins_job_insight/reportportal.py
+++ b/src/jenkins_job_insight/reportportal.py
@@ -6,8 +6,6 @@ classification results, analysis text, and Jira matches into RP launches.
 
 from __future__ import annotations
 
-import contextlib
-import io
 import os
 import threading
 import warnings
@@ -23,6 +21,31 @@ if TYPE_CHECKING:
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 _RPCLIENT_INIT_LOCK = threading.Lock()
+
+# Disable RPClient's background "RP-API-Info-Prefetch" thread.  RPClient
+# spawns a daemon thread during __init__ that calls get_api_info(); when
+# RP is unreachable the library dumps full exception tracebacks to logs.
+# We never use api_info (all API calls go through our own Session), so
+# prevent the thread from starting and set the prefetch event immediately
+# so any internal wait on it returns instantly.
+#
+# This patches a name-mangled private method; if a future library upgrade
+# removes it, the AttributeError here will surface immediately at import
+# time rather than silently reverting to noisy behaviour.
+_PREFETCH_ATTR = "_RPClient__init_api_info_prefetch"
+if not hasattr(RPClient, _PREFETCH_ATTR):
+    raise ImportError(
+        f"reportportal_client.RPClient no longer has '{_PREFETCH_ATTR}'; "
+        "update the prefetch suppression patch in reportportal.py"
+    )
+
+
+def _noop_prefetch(self: RPClient) -> None:  # type: ignore[no-untyped-def]
+    """No-op replacement: skip the background thread, mark event done."""
+    self._api_info_prefetched.set()
+
+
+setattr(RPClient, _PREFETCH_ATTR, _noop_prefetch)
 
 
 class AmbiguousLaunchError(Exception):
@@ -79,20 +102,21 @@ class ReportPortalClient:
         self._session.headers["Authorization"] = f"Bearer {token}"
         self._session.verify = verify_ssl
         self._suppress_ssl_warnings = not verify_ssl
-        # Suppress RPClient's own traceback output from get_api_info().
-        # The library prints to sys.stderr on connection failure before
-        # raising; we catch the exception ourselves and log a clean error.
+        if not _RPCLIENT_INIT_LOCK.acquire(timeout=30):
+            self._session.close()
+            raise TimeoutError("Timed out waiting for RPClient initialisation lock")
         try:
-            with _RPCLIENT_INIT_LOCK, contextlib.redirect_stderr(io.StringIO()):
-                self._rp_client = RPClient(
-                    endpoint=url.rstrip("/"),
-                    project=project,
-                    api_key=token,
-                    verify_ssl=verify_ssl,
-                )
+            self._rp_client = RPClient(
+                endpoint=url.rstrip("/"),
+                project=project,
+                api_key=token,
+                verify_ssl=verify_ssl,
+            )
         except Exception:
             self._session.close()
             raise
+        finally:
+            _RPCLIENT_INIT_LOCK.release()
 
     def __enter__(self) -> ReportPortalClient:
         return self
@@ -418,27 +442,20 @@ class ReportPortalClient:
                 logger.info("Pushed %d classification(s) to RP in one batch", pushed)
             except _requests.exceptions.HTTPError as exc:
                 status = exc.response.status_code if exc.response is not None else None
-                detail = ""
+                rp_message = ""
                 response_body = ""
                 if exc.response is not None:
                     response_body = exc.response.text
                     try:
                         rp_body = exc.response.json()
-                        raw_detail = (
-                            rp_body.get("message", response_body)
+                        raw = (
+                            rp_body.get("message")
                             if isinstance(rp_body, dict)
-                            else response_body
+                            else None
                         )
-                        detail = (
-                            raw_detail
-                            if isinstance(raw_detail, str)
-                            else response_body
-                            if raw_detail is None
-                            else str(raw_detail)
-                        )
+                        rp_message = raw if isinstance(raw, str) else ""
                     except Exception:
-                        detail = response_body
-                log_detail = detail.replace("\r", "\\r").replace("\n", "\\n")
+                        pass
                 log_body = response_body.replace("\r", "\\r").replace("\n", "\\n")
                 logger.error(
                     "RP batch update failed: status=%s, url=%s,"
@@ -446,13 +463,13 @@ class ReportPortalClient:
                     status,
                     url,
                     len(bulk_issues),
-                    log_detail or "(no detail)",
+                    rp_message or "(no detail)",
                     log_body,
                 )
-                suffix = f": {detail}" if detail else ""
+                suffix = f": {rp_message}" if rp_message else ""
                 error_msg = (
-                    f"{status or 'HTTP'} error updating"
-                    f" {len(bulk_issues)} item(s){suffix}"
+                    f"Error updating {len(bulk_issues)} item(s)"
+                    f" (HTTP {status or '?'}){suffix}"
                 )
                 errors.append(error_msg)
             except Exception as exc:
@@ -462,13 +479,7 @@ class ReportPortalClient:
                     len(bulk_issues),
                     exc,
                 )
-                detail = str(exc).strip()
-                error_msg = (
-                    f"Failed to update {len(bulk_issues)} RP item(s):"
-                    f" {type(exc).__name__}"
-                    f"{f': {detail}' if detail else ''}"
-                )
-                errors.append(error_msg)
+                errors.append(f"Error updating {len(bulk_issues)} RP item(s)")
 
         return {
             "pushed": pushed,

--- a/tests/test_reportportal.py
+++ b/tests/test_reportportal.py
@@ -1,7 +1,8 @@
 """Tests for Report Portal integration module."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 import requests as _requests
 
 from jenkins_job_insight.reportportal import ReportPortalClient
@@ -57,6 +58,27 @@ class TestClassificationMapping:
         )
         locator = client._map_classification("")
         assert locator is None
+
+    def test_custom_locators_override_defaults(self):
+        client = ReportPortalClient(
+            url="http://rp.example.com",
+            token="tok",
+            project="proj",
+        )
+        custom = {"PRODUCT_BUG": "pb_custom_123"}
+        locator = client._map_classification("PRODUCT BUG", locators=custom)
+        assert locator == "pb_custom_123"
+
+    def test_custom_locators_falls_back_to_defaults_for_missing_key(self):
+        client = ReportPortalClient(
+            url="http://rp.example.com",
+            token="tok",
+            project="proj",
+        )
+        # Custom locators without PRODUCT_BUG — falls back to default
+        custom = {"SYSTEM_ISSUE": "si_custom"}
+        locator = client._map_classification("PRODUCT BUG", locators=custom)
+        assert locator == "pb001"  # default locator
 
 
 # -- Constructor tests -------------------------------------------------------
@@ -218,6 +240,33 @@ class TestFindLaunch:
             "my-job", "http://jenkins.example.com/job/my-job/5/"
         )
         assert result == 20
+
+    def test_raises_ambiguous_launch_error(self):
+        from jenkins_job_insight.reportportal import AmbiguousLaunchError
+
+        client = ReportPortalClient(
+            url="http://rp.example.com", token="tok", project="proj"
+        )
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "content": [
+                {"id": 10, "name": "my-job", "description": "run A"},
+                {"id": 20, "name": "my-job", "description": "run B"},
+            ],
+            "page": {"totalPages": 1},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_rp = MagicMock()
+        mock_rp.base_url_v1 = "http://rp.example.com/api/v1/proj"
+        client._rp_client = mock_rp
+        client._session = mock_session
+
+        with pytest.raises(AmbiguousLaunchError) as exc_info:
+            client.find_launch("my-job", "http://jenkins/job/my-job/99/")
+        assert exc_info.value.count == 2
+        assert exc_info.value.job_name == "my-job"
 
     def test_paginates_across_multiple_pages(self):
         client = ReportPortalClient(
@@ -396,6 +445,12 @@ def _extract_put_json(mock_session):
 class TestPushClassifications:
     """Test pushing classifications to RP."""
 
+    _DEFAULT_LOCATORS = {
+        "PRODUCT_BUG": "pb001",
+        "AUTOMATION_BUG": "ab001",
+        "SYSTEM_ISSUE": "si001",
+    }
+
     def _make_failure(self, classification="PRODUCT BUG", details="Analysis text"):
         failure = MagicMock()
         failure.analysis = MagicMock()
@@ -404,6 +459,27 @@ class TestPushClassifications:
         failure.analysis.product_bug_report = None
         failure.analysis.code_fix = None
         return failure
+
+    def _setup_push_client(self, *, locators=None, put_side_effect=None):
+        """Create a ReportPortalClient with mocked session for push tests."""
+        client = ReportPortalClient(
+            url="http://rp.example.com", token="tok", project="proj"
+        )
+        client.get_defect_type_locators = MagicMock(
+            return_value=self._DEFAULT_LOCATORS if locators is None else locators
+        )
+        mock_session = MagicMock()
+        if put_side_effect is not None:
+            mock_session.put.side_effect = put_side_effect
+        else:
+            mock_put_response = MagicMock()
+            mock_put_response.raise_for_status = MagicMock()
+            mock_session.put.return_value = mock_put_response
+        mock_rp = MagicMock()
+        mock_rp.base_url_v1 = "http://rp.example.com/api/v1/proj"
+        client._rp_client = mock_rp
+        client._session = mock_session
+        return client, mock_session
 
     def test_push_product_bug(self):
         client = ReportPortalClient(
@@ -627,27 +703,22 @@ class TestPushClassifications:
         assert result["errors"] == []
         assert result["unmatched"] == []
 
-    def test_http_error_extracts_rp_message(self):
+    @patch("jenkins_job_insight.reportportal.logger")
+    def test_http_error_extracts_rp_message(self, mock_logger):
         """HTTPError responses extract the RP JSON message field into errors."""
-        client = ReportPortalClient(
-            url="http://rp.example.com", token="tok", project="proj"
-        )
-        client.get_defect_type_locators = MagicMock(
-            return_value={"PRODUCT_BUG": "pb001"},
-        )
-        mock_session = MagicMock()
         mock_error_response = MagicMock()
         mock_error_response.status_code = 403
+        mock_error_response.text = '{"message": "Not a launch owner"}'
         mock_error_response.json.return_value = {"message": "Not a launch owner"}
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = _requests.exceptions.HTTPError(
+        mock_put_response = MagicMock()
+        mock_put_response.raise_for_status.side_effect = _requests.exceptions.HTTPError(
             response=mock_error_response
         )
-        mock_session.put.return_value = mock_response
-        mock_rp = MagicMock()
-        mock_rp.base_url_v1 = "http://rp.example.com/api/v1/proj"
-        client._rp_client = mock_rp
-        client._session = mock_session
+
+        client, _mock_session = self._setup_push_client(
+            locators={"PRODUCT_BUG": "pb001"}
+        )
+        _mock_session.put.return_value = mock_put_response
 
         failure = self._make_failure("PRODUCT BUG", "Bug")
         matched = [({"id": 200, "name": "test_x"}, failure)]
@@ -659,20 +730,26 @@ class TestPushClassifications:
         assert "403" in result["errors"][0]
         assert "Not a launch owner" in result["errors"][0]
 
-    def test_generic_exception_uses_type_name(self):
+        # Verify error logged with status, detail, and response body
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "batch update failed" in str(c).lower()
+        ]
+        assert error_calls, "Expected error log for HTTP error"
+        log_msg = str(error_calls[0])
+        assert "403" in log_msg
+        assert "Not a launch owner" in log_msg
+        # Response body included in ERROR log (not separate DEBUG)
+        assert '{"message": "Not a launch owner"}' in log_msg
+
+    @patch("jenkins_job_insight.reportportal.logger")
+    def test_generic_exception_uses_type_name(self, mock_logger):
         """Non-HTTP exceptions use type(exc).__name__ in the error."""
-        client = ReportPortalClient(
-            url="http://rp.example.com", token="tok", project="proj"
+        client, _ = self._setup_push_client(
+            locators={"PRODUCT_BUG": "pb001"},
+            put_side_effect=ConnectionError("connection refused"),
         )
-        client.get_defect_type_locators = MagicMock(
-            return_value={"PRODUCT_BUG": "pb001"},
-        )
-        mock_session = MagicMock()
-        mock_session.put.side_effect = ConnectionError("connection refused")
-        mock_rp = MagicMock()
-        mock_rp.base_url_v1 = "http://rp.example.com/api/v1/proj"
-        client._rp_client = mock_rp
-        client._session = mock_session
 
         failure = self._make_failure("PRODUCT BUG", "Bug")
         matched = [({"id": 201, "name": "test_y"}, failure)]
@@ -682,6 +759,16 @@ class TestPushClassifications:
         assert result["pushed"] == 0
         assert len(result["errors"]) == 1
         assert "ConnectionError" in result["errors"][0]
+
+        # Verify error logged with error details
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "batch update failed" in str(c).lower()
+        ]
+        assert error_calls, "Expected error log for generic exception"
+        log_msg = str(error_calls[0])
+        assert "connection refused" in log_msg
 
 
 # -- close tests --------------------------------------------------------------

--- a/tests/test_reportportal.py
+++ b/tests/test_reportportal.py
@@ -768,8 +768,7 @@ class TestPushClassifications:
         )
         assert result["pushed"] == 0
         assert len(result["errors"]) == 1
-        assert "ConnectionError" in result["errors"][0]
-        assert "connection refused" in result["errors"][0]
+        assert "Error updating" in result["errors"][0]
 
         # Verify error logged with error details
         error_calls = [
@@ -813,8 +812,8 @@ class TestRPClientInitLock:
         assert callable(getattr(lock, "acquire", None))
         assert callable(getattr(lock, "release", None))
 
-    def test_init_acquires_lock_around_redirect_stderr(self):
-        """Constructor must acquire _RPCLIENT_INIT_LOCK while redirecting stderr."""
+    def test_init_acquires_lock_during_rpclient_creation(self):
+        """Constructor must hold _RPCLIENT_INIT_LOCK while creating RPClient."""
         acquired_during_init = []
 
         original_rpclient = rp_module.RPClient
@@ -833,3 +832,18 @@ class TestRPClientInitLock:
         assert acquired_during_init[0] is True, (
             "_RPCLIENT_INIT_LOCK was NOT held when RPClient was initialised"
         )
+
+    def test_init_timeout_when_lock_held(self):
+        """TimeoutError raised when lock cannot be acquired within timeout."""
+        mock_lock = MagicMock()
+        mock_lock.acquire.return_value = False  # Simulate timeout
+        with patch.object(rp_module, "_RPCLIENT_INIT_LOCK", mock_lock):
+            with pytest.raises(TimeoutError, match="Timed out waiting"):
+                ReportPortalClient(
+                    url="http://rp.example.com",
+                    token="tok",
+                    project="proj",
+                )
+        mock_lock.acquire.assert_called_once_with(timeout=30)
+        # Lock release should NOT be called since acquire failed
+        mock_lock.release.assert_not_called()

--- a/tests/test_reportportal.py
+++ b/tests/test_reportportal.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests as _requests
 
+import jenkins_job_insight.reportportal as rp_module
 from jenkins_job_insight.reportportal import ReportPortalClient
 
 
@@ -768,6 +769,7 @@ class TestPushClassifications:
         assert result["pushed"] == 0
         assert len(result["errors"]) == 1
         assert "ConnectionError" in result["errors"][0]
+        assert "connection refused" in result["errors"][0]
 
         # Verify error logged with error details
         error_calls = [
@@ -795,3 +797,39 @@ class TestClose:
         client.close()
         mock_sess.close.assert_called_once()
         mock_rp.close.assert_called_once()
+
+
+# -- thread-safety tests ----------------------------------------------------
+
+
+class TestRPClientInitLock:
+    """Verify RPClient init is serialised via a module-level threading lock."""
+
+    def test_module_level_lock_exists_and_is_threading_lock(self):
+        """_RPCLIENT_INIT_LOCK must be a threading.Lock at module scope."""
+        assert hasattr(rp_module, "_RPCLIENT_INIT_LOCK")
+        # threading.Lock() returns _thread.lock; check it has acquire/release
+        lock = rp_module._RPCLIENT_INIT_LOCK
+        assert callable(getattr(lock, "acquire", None))
+        assert callable(getattr(lock, "release", None))
+
+    def test_init_acquires_lock_around_redirect_stderr(self):
+        """Constructor must acquire _RPCLIENT_INIT_LOCK while redirecting stderr."""
+        acquired_during_init = []
+
+        original_rpclient = rp_module.RPClient
+
+        def spy_rpclient(*args, **kwargs):
+            """Record whether the lock is held when RPClient.__init__ runs."""
+            lock = rp_module._RPCLIENT_INIT_LOCK
+            # locked() returns True when the lock is held by any thread
+            acquired_during_init.append(lock.locked())
+            return original_rpclient(*args, **kwargs)
+
+        with patch.object(rp_module, "RPClient", side_effect=spy_rpclient):
+            ReportPortalClient(url="http://rp.example.com", token="tok", project="proj")
+
+        assert acquired_during_init, "RPClient was never called"
+        assert acquired_during_init[0] is True, (
+            "_RPCLIENT_INIT_LOCK was NOT held when RPClient was initialised"
+        )

--- a/tests/test_reportportal.py
+++ b/tests/test_reportportal.py
@@ -175,7 +175,13 @@ class TestFindLaunch:
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "content": [{"id": 42, "name": "my-job", "description": ""}],
+            "content": [
+                {
+                    "id": 42,
+                    "name": "my-job",
+                    "description": "http://jenkins.example.com/job/my-job/1/",
+                }
+            ],
             "page": {"totalPages": 1},
         }
         mock_response.raise_for_status = MagicMock()
@@ -217,10 +223,10 @@ class TestFindLaunch:
             url="http://rp.example.com", token="tok", project="proj"
         )
         mock_session = MagicMock()
+        # URL filter returns exactly the one launch whose description contains the URL
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "content": [
-                {"id": 10, "name": "my-job", "description": "old run"},
                 {
                     "id": 20,
                     "name": "my-job",
@@ -247,12 +253,13 @@ class TestFindLaunch:
         client = ReportPortalClient(
             url="http://rp.example.com", token="tok", project="proj"
         )
+        jenkins_url = "http://jenkins/job/my-job/99/"
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "content": [
-                {"id": 10, "name": "my-job", "description": "run A"},
-                {"id": 20, "name": "my-job", "description": "run B"},
+                {"id": 10, "name": "my-job", "description": jenkins_url},
+                {"id": 20, "name": "my-job", "description": jenkins_url},
             ],
             "page": {"totalPages": 1},
         }
@@ -264,17 +271,19 @@ class TestFindLaunch:
         client._session = mock_session
 
         with pytest.raises(AmbiguousLaunchError) as exc_info:
-            client.find_launch("my-job", "http://jenkins/job/my-job/99/")
+            client.find_launch("my-job", jenkins_url)
         assert exc_info.value.count == 2
         assert exc_info.value.job_name == "my-job"
+        assert exc_info.value.jenkins_url == jenkins_url
 
     def test_paginates_across_multiple_pages(self):
         client = ReportPortalClient(
             url="http://rp.example.com", token="tok", project="proj"
         )
+        # URL filter query paginates across 2 pages; match is on page 2
         page1_response = MagicMock()
         page1_response.json.return_value = {
-            "content": [{"id": 10, "name": "my-job", "description": "old run"}],
+            "content": [],
             "page": {"totalPages": 2},
         }
         page1_response.raise_for_status = MagicMock()

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -278,7 +278,16 @@ class TestPushReportPortalEndpoint:
                 "result": {
                     "job_name": "test-job",
                     "jenkins_url": "https://jenkins.example.com/job/test/1/",
-                    "failures": [],
+                    "failures": [
+                        {
+                            "test_name": "test_a",
+                            "error": "err",
+                            "analysis": {
+                                "classification": "PRODUCT BUG",
+                                "details": "d",
+                            },
+                        }
+                    ],
                 }
             }
             mock_rp = MagicMock()
@@ -971,6 +980,107 @@ class TestRPPushHTTPErrors:
         assert error_calls, "Expected ERROR log for constructor failure"
 
 
+class TestRPPushEarlyGuard:
+    """Verify early exit when there are no failures to push."""
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_empty_failures_skips_rp_calls(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """When failures list is empty, return early without connecting to RP."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [],
+            }
+        }
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "No failures to push" in body["errors"][0]
+        mock_rp_class.assert_not_called()
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_missing_failures_key_skips_rp_calls(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """When failures key is absent, return early without connecting to RP."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+            }
+        }
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "No failures to push" in body["errors"][0]
+        mock_rp_class.assert_not_called()
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_child_job_empty_failures_skips_rp_calls(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """When scoped child job has empty failures, return early."""
+        mock_get_result.return_value = {
+            "status": "completed",
+            "result": {
+                "job_name": "parent-pipeline",
+                "build_number": 1,
+                "jenkins_url": "https://jenkins.example.com/job/parent/1/",
+                "failures": [
+                    {
+                        "test_name": "test_parent",
+                        "error": "err",
+                        "analysis": {
+                            "classification": "PRODUCT BUG",
+                            "details": "d",
+                        },
+                    }
+                ],
+                "child_job_analyses": [
+                    {
+                        "job_name": "child-job",
+                        "build_number": 42,
+                        "jenkins_url": "https://jenkins.example.com/job/child-job/42/",
+                        "failures": [],
+                        "failed_children": [],
+                    }
+                ],
+            },
+        }
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            "/results/some-job-id/push-reportportal",
+            params={"child_job_name": "child-job", "child_build_number": 42},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "No failures to push" in body["errors"][0]
+        mock_rp_class.assert_not_called()
+
+
 class TestRPPushDebugLogging:
     """Verify normal-state RP paths log at DEBUG, not ERROR."""
 
@@ -984,7 +1094,13 @@ class TestRPPushDebugLogging:
             "result": {
                 "job_name": "my-job",
                 "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
-                "failures": [],
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
             }
         }
         mock_rp = MagicMock()
@@ -1018,9 +1134,10 @@ class TestRPPushDebugLogging:
     @patch("jenkins_job_insight.main.logger")
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_no_jji_failures_logs_debug(
+    def test_empty_failures_early_guard_does_not_log_error(
         self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
     ):
+        """Empty failures triggers early guard without ERROR logs."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "my-job",
@@ -1028,14 +1145,6 @@ class TestRPPushDebugLogging:
                 "failures": [],
             }
         }
-        mock_rp = MagicMock()
-        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
-        mock_rp.__exit__ = MagicMock(return_value=False)
-        mock_rp.find_launch.return_value = 42
-        mock_rp.get_failed_items.return_value = [
-            {"id": 1, "name": "test_a", "status": "FAILED"}
-        ]
-        mock_rp_class.return_value = mock_rp
 
         from jenkins_job_insight.main import app
 
@@ -1044,19 +1153,11 @@ class TestRPPushDebugLogging:
         assert response.status_code == 200
         assert response.json()["pushed"] == 0
 
-        # Normal state: logged at DEBUG, not ERROR
-        debug_calls = [
-            c
-            for c in mock_logger.debug.call_args_list
-            if "no jji failures" in str(c).lower()
-        ]
-        assert debug_calls, "Expected DEBUG log for 'no JJI failures'"
-        error_calls = [
-            c
-            for c in mock_logger.error.call_args_list
-            if "no jji failures" in str(c).lower()
-        ]
-        assert not error_calls, "Should NOT log 'no JJI failures' at ERROR"
+        error_calls = mock_logger.error.call_args_list
+        assert not error_calls, (
+            "Early guard for empty failures should not produce ERROR logs"
+        )
+        mock_rp_class.assert_not_called()
 
 
 class TestCapabilitiesEndpoint:

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -1262,3 +1262,329 @@ class TestRPErrorMessage:
         result = _rp_error_message(exc, "connecting")
         assert "ConnectionError" in result
         assert "connection refused" in result
+
+
+class TestRpPushErrorResultContext:
+    """Unit tests for _rp_push_error_result job/build context in error messages."""
+
+    def test_no_context_when_args_omitted(self, _rp_enabled_env):
+        """Without job_name/build_number, error message has no context suffix."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result("Some error")
+        assert result["errors"] == ["Some error"]
+
+    def test_context_appended_when_both_provided(self, _rp_enabled_env):
+        """With job_name and build_number, context suffix is appended."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result("Some error", job_name="my-job", build_number=42)
+        assert len(result["errors"]) == 1
+        assert "Some error" in result["errors"][0]
+        assert "(job='my-job' #42)" in result["errors"][0]
+
+    def test_no_context_when_job_name_empty(self, _rp_enabled_env):
+        """Empty job_name means no context suffix."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result("Some error", job_name="", build_number=42)
+        assert result["errors"] == ["Some error"]
+
+    def test_no_context_when_build_number_none(self, _rp_enabled_env):
+        """None build_number means no context suffix."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result(
+            "Some error", job_name="my-job", build_number=None
+        )
+        assert result["errors"] == ["Some error"]
+
+    def test_context_with_build_number_zero(self, _rp_enabled_env):
+        """build_number=0 is valid (not None) and should produce context."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result("Some error", job_name="my-job", build_number=0)
+        assert "(job='my-job' #0)" in result["errors"][0]
+
+    def test_launch_id_preserved_with_context(self, _rp_enabled_env):
+        """launch_id is still set correctly when context is also provided."""
+        from jenkins_job_insight.main import _rp_push_error_result
+
+        result = _rp_push_error_result(
+            "Some error", job_name="my-job", build_number=5, launch_id=99
+        )
+        assert result["launch_id"] == 99
+        assert "(job='my-job' #5)" in result["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_early_guard_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """Early guard (no failures) includes job/build context in error."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "context-job",
+                "build_number": 77,
+                "jenkins_url": "https://jenkins.example.com/job/context-job/77/",
+                "failures": [],
+            }
+        }
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert "No failures to push" in body["errors"][0]
+        assert "(job='context-job' #77)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_find_launch_error_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """find_launch exception error includes job/build context."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 55,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/55/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.side_effect = ConnectionError("refused")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #55)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_no_launch_found_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """No launch found error includes job/build context."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 33,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/33/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = None
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #33)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_get_failed_items_error_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """get_failed_items error includes job/build context."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 44,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/44/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.side_effect = RuntimeError("network err")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #44)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_match_failures_error_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """match_failures error includes job/build context."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 66,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/66/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [{"id": 1, "name": "test_a"}]
+        mock_rp.match_failures.side_effect = TypeError("boom")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #66)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_no_overlap_error_includes_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """No overlap error includes job/build context."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 22,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/22/",
+                "failures": [
+                    {
+                        "test_name": "test_alpha",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [
+            {"id": 1, "name": "test_beta", "status": "FAILED"}
+        ]
+        mock_rp.match_failures.return_value = []
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #22)" in body["errors"][0]
+
+    @patch(
+        "jenkins_job_insight.main.get_history_classification", new_callable=AsyncMock
+    )
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_push_classifications_error_includes_context(
+        self, mock_get_result, mock_rp_class, mock_get_cls, _rp_enabled_env
+    ):
+        """push_classifications error includes job/build context."""
+        mock_get_cls.return_value = ""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 11,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/11/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [
+            {"id": 1, "name": "test_a", "status": "FAILED"}
+        ]
+        mock_failure = MagicMock()
+        mock_failure.test_name = "test_a"
+        mock_rp.match_failures.return_value = [
+            ({"id": 1, "name": "test_a"}, mock_failure)
+        ]
+        mock_rp.push_classifications.side_effect = RuntimeError("timeout")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        assert "(job='ctx-job' #11)" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_constructor_failure_has_no_context(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """Constructor failure should NOT have job/build context (not in scope)."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "ctx-job",
+                "build_number": 88,
+                "jenkins_url": "https://jenkins.example.com/job/ctx-job/88/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp_class.side_effect = ConnectionError("DNS failed")
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        body = response.json()
+        # Constructor failure has no job/build context
+        assert "(job=" not in body["errors"][0]

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -261,8 +261,8 @@ class TestPushReportPortalEndpoint:
         assert data["pushed"] == 0
         assert len(data["errors"]) == 1
         assert "No overlap" in data["errors"][0]
-        assert "test_beta" in data["errors"][0]
-        assert "test_alpha" in data["errors"][0]
+        # Test names are in server logs only, not user-facing
+        assert "test_beta" not in data["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
@@ -641,8 +641,8 @@ class TestRPPushHTTPErrors:
         body = response.json()
         assert body["pushed"] == 0
         assert len(body["errors"]) == 1
-        assert "ConnectionError" in body["errors"][0]
-        assert "connection refused" in body["errors"][0]
+        assert "Error" in body["errors"][0]
+        assert "searching RP launches" in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
@@ -727,7 +727,7 @@ class TestRPPushHTTPErrors:
         assert body["pushed"] == 0
         assert body["launch_id"] == 42
         assert len(body["errors"]) == 1
-        assert "TypeError" in body["errors"][0]
+        assert "Error" in body["errors"][0]
         assert "matching RP items" in body["errors"][0]
 
     @patch("jenkins_job_insight.main.logger")
@@ -924,7 +924,7 @@ class TestRPPushHTTPErrors:
         assert body["pushed"] == 0
         assert len(body["errors"]) == 1
         assert "Ambiguous" in body["errors"][0]
-        assert "my-project" in body["errors"][0]
+        assert "Remove duplicate" in body["errors"][0]
 
         # Ambiguous launch is logged at WARNING, not ERROR
         warning_calls = [
@@ -968,8 +968,8 @@ class TestRPPushHTTPErrors:
         body = response.json()
         assert body["pushed"] == 0
         assert len(body["errors"]) == 1
-        assert "ConnectionError" in body["errors"][0]
-        assert "Name resolution failed" in body["errors"][0]
+        assert "Error" in body["errors"][0]
+        assert "connecting to Report Portal" in body["errors"][0]
 
         # Constructor failure is logged at ERROR
         error_calls = [
@@ -978,6 +978,10 @@ class TestRPPushHTTPErrors:
             if "name resolution" in str(c).lower()
         ]
         assert error_calls, "Expected ERROR log for constructor failure"
+        # RP URL must appear in log (not in user-facing error)
+        assert "reportportal_url=" in str(error_calls[0]), (
+            "Log should include reportportal_url for operator debugging"
+        )
 
 
 class TestRPPushEarlyGuard:
@@ -1200,49 +1204,59 @@ class TestRPErrorMessage:
         return exc
 
     def test_dict_body_extracts_message_field(self, _rp_enabled_env):
-        """When RP returns a JSON dict with 'message', extract it."""
+        """When RP returns a JSON dict with 'message', extract it for user."""
         from jenkins_job_insight.main import _rp_error_message
 
         exc = self._make_exc_with_response(json_return={"message": "Token expired"})
-        result = _rp_error_message(exc, "finding launch")
-        assert "Token expired" in result
+        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        assert "Token expired" in user_msg
+        assert "500" in user_msg
+        assert "finding launch" in user_msg
 
-    def test_dict_body_without_message_falls_back_to_text(self, _rp_enabled_env):
-        """When RP returns a JSON dict without 'message', fall back to resp.text."""
+    def test_dict_body_without_message_shows_status_only(self, _rp_enabled_env):
+        """When RP returns a JSON dict without 'message', user sees status only."""
         from jenkins_job_insight.main import _rp_error_message
 
         exc = self._make_exc_with_response(
             json_return={"error": "something else"},
             text="raw response text",
         )
-        result = _rp_error_message(exc, "finding launch")
-        assert "raw response text" in result
+        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        # User sees status + operation, no raw text
+        assert "500" in user_msg
+        assert "finding launch" in user_msg
+        # Raw text only in log
+        assert "raw response text" in log_msg
 
-    def test_list_body_falls_back_to_text(self, _rp_enabled_env):
-        """When RP returns a JSON array, fall back to resp.text (not AttributeError)."""
+    def test_list_body_shows_status_only(self, _rp_enabled_env):
+        """When RP returns a JSON array, user sees status only (no crash)."""
         from jenkins_job_insight.main import _rp_error_message
 
         exc = self._make_exc_with_response(
             json_return=["error1", "error2"],
             text="the raw text",
         )
-        result = _rp_error_message(exc, "finding launch")
-        # Must contain the fallback text, not crash with AttributeError
-        assert "the raw text" in result
+        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        assert "500" in user_msg
+        assert "finding launch" in user_msg
+        # Raw text only in log
+        assert "the raw text" in log_msg
 
-    def test_string_body_falls_back_to_text(self, _rp_enabled_env):
-        """When RP returns a plain JSON string, fall back to resp.text."""
+    def test_string_body_shows_status_only(self, _rp_enabled_env):
+        """When RP returns a plain JSON string, user sees status only."""
         from jenkins_job_insight.main import _rp_error_message
 
         exc = self._make_exc_with_response(
             json_return="just a string",
             text="the raw text",
         )
-        result = _rp_error_message(exc, "finding launch")
-        assert "the raw text" in result
+        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        assert "500" in user_msg
+        # Raw text only in log
+        assert "the raw text" in log_msg
 
-    def test_json_parse_failure_falls_back_to_text(self, _rp_enabled_env):
-        """When resp.json() raises, fall back to resp.text."""
+    def test_json_parse_failure_shows_status_only(self, _rp_enabled_env):
+        """When resp.json() raises, user sees status only, log has raw text."""
         from jenkins_job_insight.main import _rp_error_message
 
         resp = MagicMock()
@@ -1251,77 +1265,62 @@ class TestRPErrorMessage:
         resp.json.side_effect = ValueError("No JSON")
         exc = Exception("boom")
         exc.response = resp
-        result = _rp_error_message(exc, "finding launch")
-        assert "Bad Gateway" in result
+        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        assert "502" in user_msg
+        assert "finding launch" in user_msg
+        # Full text only in log
+        assert "Bad Gateway" in log_msg
 
-    def test_no_response_uses_exc_str(self, _rp_enabled_env):
-        """When exc has no .response, use str(exc) as detail."""
+    def test_no_response_shows_operation_only(self, _rp_enabled_env):
+        """When exc has no .response, user sees operation only; log has detail."""
         from jenkins_job_insight.main import _rp_error_message
 
         exc = ConnectionError("connection refused")
-        result = _rp_error_message(exc, "connecting")
-        assert "ConnectionError" in result
-        assert "connection refused" in result
+        user_msg, log_msg = _rp_error_message(exc, "connecting")
+        # User sees short message
+        assert user_msg == "Error connecting"
+        # Log has full detail
+        assert "ConnectionError" in log_msg
+        assert "connection refused" in log_msg
+
+    def test_rp_message_shown_to_user_but_raw_body_only_in_log(self, _rp_enabled_env):
+        """RP JSON message goes to user; full response body only in log."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = self._make_exc_with_response(
+            json_return={"message": "Access denied"},
+            text='{"message": "Access denied", "debug": "lots of internal detail"}',
+        )
+        user_msg, log_msg = _rp_error_message(exc, "pushing classifications")
+        assert "Access denied" in user_msg
+        assert "internal detail" not in user_msg
+        assert "internal detail" in log_msg
 
 
-class TestRpPushErrorResultContext:
-    """Unit tests for _rp_push_error_result job/build context in error messages."""
+class TestRpPushErrorResult:
+    """Unit tests for _rp_push_error_result."""
 
-    def test_no_context_when_args_omitted(self, _rp_enabled_env):
-        """Without job_name/build_number, error message has no context suffix."""
+    def test_message_preserved_as_is(self, _rp_enabled_env):
+        """Error message is returned verbatim — no context suffix."""
         from jenkins_job_insight.main import _rp_push_error_result
 
         result = _rp_push_error_result("Some error")
         assert result["errors"] == ["Some error"]
 
-    def test_context_appended_when_both_provided(self, _rp_enabled_env):
-        """With job_name and build_number, context suffix is appended."""
+    def test_launch_id_preserved(self, _rp_enabled_env):
+        """launch_id is set correctly."""
         from jenkins_job_insight.main import _rp_push_error_result
 
-        result = _rp_push_error_result("Some error", job_name="my-job", build_number=42)
-        assert len(result["errors"]) == 1
-        assert "Some error" in result["errors"][0]
-        assert "(job='my-job' #42)" in result["errors"][0]
-
-    def test_no_context_when_job_name_empty(self, _rp_enabled_env):
-        """Empty job_name means no context suffix."""
-        from jenkins_job_insight.main import _rp_push_error_result
-
-        result = _rp_push_error_result("Some error", job_name="", build_number=42)
-        assert result["errors"] == ["Some error"]
-
-    def test_no_context_when_build_number_none(self, _rp_enabled_env):
-        """None build_number means no context suffix."""
-        from jenkins_job_insight.main import _rp_push_error_result
-
-        result = _rp_push_error_result(
-            "Some error", job_name="my-job", build_number=None
-        )
-        assert result["errors"] == ["Some error"]
-
-    def test_context_with_build_number_zero(self, _rp_enabled_env):
-        """build_number=0 is valid (not None) and should produce context."""
-        from jenkins_job_insight.main import _rp_push_error_result
-
-        result = _rp_push_error_result("Some error", job_name="my-job", build_number=0)
-        assert "(job='my-job' #0)" in result["errors"][0]
-
-    def test_launch_id_preserved_with_context(self, _rp_enabled_env):
-        """launch_id is still set correctly when context is also provided."""
-        from jenkins_job_insight.main import _rp_push_error_result
-
-        result = _rp_push_error_result(
-            "Some error", job_name="my-job", build_number=5, launch_id=99
-        )
+        result = _rp_push_error_result("Some error", launch_id=99)
         assert result["launch_id"] == 99
-        assert "(job='my-job' #5)" in result["errors"][0]
+        assert result["errors"] == ["Some error"]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_early_guard_includes_context(
+    def test_early_guard_error_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """Early guard (no failures) includes job/build context in error."""
+        """Early guard (no failures) returns a short error without context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "context-job",
@@ -1339,14 +1338,14 @@ class TestRpPushErrorResultContext:
         body = response.json()
         assert body["pushed"] == 0
         assert "No failures to push" in body["errors"][0]
-        assert "(job='context-job' #77)" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_find_launch_error_includes_context(
+    def test_find_launch_error_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """find_launch exception error includes job/build context."""
+        """find_launch exception error has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1372,14 +1371,15 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #55)" in body["errors"][0]
+        assert "searching RP launches" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_no_launch_found_includes_context(
+    def test_no_launch_found_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """No launch found error includes job/build context."""
+        """No launch found error is short and has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1405,14 +1405,15 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #33)" in body["errors"][0]
+        assert "No RP launch found" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_get_failed_items_error_includes_context(
+    def test_get_failed_items_error_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """get_failed_items error includes job/build context."""
+        """get_failed_items error has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1439,14 +1440,15 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #44)" in body["errors"][0]
+        assert "fetching failed items" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_match_failures_error_includes_context(
+    def test_match_failures_error_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """match_failures error includes job/build context."""
+        """match_failures error has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1474,14 +1476,15 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #66)" in body["errors"][0]
+        assert "matching RP items" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_no_overlap_error_includes_context(
+    def test_no_overlap_error_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """No overlap error includes job/build context."""
+        """No overlap error has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1511,17 +1514,18 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #22)" in body["errors"][0]
+        assert "No overlap" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch(
         "jenkins_job_insight.main.get_history_classification", new_callable=AsyncMock
     )
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_push_classifications_error_includes_context(
+    def test_push_classifications_error_is_clean(
         self, mock_get_result, mock_rp_class, mock_get_cls, _rp_enabled_env
     ):
-        """push_classifications error includes job/build context."""
+        """push_classifications error has no context suffix."""
         mock_get_cls.return_value = ""
         mock_get_result.return_value = {
             "result": {
@@ -1557,14 +1561,15 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "(job='ctx-job' #11)" in body["errors"][0]
+        assert "pushing classifications" in body["errors"][0]
+        assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
-    def test_constructor_failure_has_no_context(
+    def test_constructor_failure_is_clean(
         self, mock_get_result, mock_rp_class, _rp_enabled_env
     ):
-        """Constructor failure should NOT have job/build context (not in scope)."""
+        """Constructor failure has no context suffix."""
         mock_get_result.return_value = {
             "result": {
                 "job_name": "ctx-job",
@@ -1586,5 +1591,5 @@ class TestRpPushErrorResultContext:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        # Constructor failure has no job/build context
+        assert "connecting to Report Portal" in body["errors"][0]
         assert "(job=" not in body["errors"][0]

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -724,6 +724,159 @@ class TestRPPushHTTPErrors:
     @patch("jenkins_job_insight.main.logger")
     @patch("jenkins_job_insight.main.ReportPortalClient")
     @patch("jenkins_job_insight.main.get_result")
+    def test_get_failed_items_error_log_includes_build_number(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        """get_failed_items error log must include build_number for debugging."""
+        import requests as _requests
+
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "build_number": 77,
+                "jenkins_url": "https://jenkins.example.com/job/my-job/77/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = '{"message": "Access denied"}'
+        mock_response.json.return_value = {"message": "Access denied"}
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.side_effect = _requests.exceptions.HTTPError(
+            response=mock_response
+        )
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+
+        # Verify error log includes build_number
+        error_calls = [
+            c for c in mock_logger.error.call_args_list if "RP push failed" in str(c)
+        ]
+        assert error_calls, "Expected ERROR log for get_failed_items failure"
+        log_fmt = error_calls[0][0][0]  # format string
+        log_args = error_calls[0][0][1:]  # positional args
+        rendered = log_fmt % log_args
+        assert "77" in rendered, f"build_number (77) missing from error log: {rendered}"
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_match_failures_error_log_includes_build_number(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        """match_failures error log must include build_number for debugging."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "build_number": 88,
+                "jenkins_url": "https://jenkins.example.com/job/my-job/88/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [{"id": 1, "name": "test_a"}]
+        mock_rp.match_failures.side_effect = TypeError("unexpected None")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job2/push-reportportal")
+        assert response.status_code == 200
+
+        # Verify error log includes build_number
+        error_calls = [
+            c for c in mock_logger.error.call_args_list if "RP push failed" in str(c)
+        ]
+        assert error_calls, "Expected ERROR log for match_failures failure"
+        log_fmt = error_calls[0][0][0]
+        log_args = error_calls[0][0][1:]
+        rendered = log_fmt % log_args
+        assert "88" in rendered, f"build_number (88) missing from error log: {rendered}"
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch(
+        "jenkins_job_insight.main.get_history_classification", new_callable=AsyncMock
+    )
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_push_classifications_error_log_includes_build_number(
+        self, mock_get_result, mock_rp_class, mock_get_cls, mock_logger, _rp_enabled_env
+    ):
+        """push_classifications error log must include build_number for debugging."""
+        mock_get_cls.return_value = ""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "build_number": 99,
+                "jenkins_url": "https://jenkins.example.com/job/my-job/99/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [
+            {"id": 1, "name": "test_a", "status": "FAILED"}
+        ]
+        mock_failure = MagicMock()
+        mock_failure.test_name = "test_a"
+        mock_rp.match_failures.return_value = [
+            ({"id": 1, "name": "test_a"}, mock_failure)
+        ]
+        mock_rp.push_classifications.side_effect = RuntimeError("network timeout")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job3/push-reportportal")
+        assert response.status_code == 200
+
+        # Verify error log includes build_number
+        error_calls = [
+            c for c in mock_logger.error.call_args_list if "RP push failed" in str(c)
+        ]
+        assert error_calls, "Expected ERROR log for push_classifications failure"
+        log_fmt = error_calls[0][0][0]
+        log_args = error_calls[0][0][1:]
+        rendered = log_fmt % log_args
+        assert "99" in rendered, f"build_number (99) missing from error log: {rendered}"
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
     def test_ambiguous_launch_returns_200_with_error(
         self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
     ):

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -918,6 +918,7 @@ class TestCapabilitiesEndpoint:
         data = response.json()
         assert "reportportal" in data
         assert data["reportportal"] is False
+        assert data["reportportal_project"] == ""
 
     def test_capabilities_includes_rp_enabled(self, _rp_enabled_env):
         from jenkins_job_insight.main import app
@@ -928,3 +929,4 @@ class TestCapabilitiesEndpoint:
         data = response.json()
         assert "reportportal" in data
         assert data["reportportal"] is True
+        assert data["reportportal_project"] == "my-project"

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -721,6 +721,102 @@ class TestRPPushHTTPErrors:
         assert "TypeError" in body["errors"][0]
         assert "matching RP items" in body["errors"][0]
 
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_ambiguous_launch_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        """AmbiguousLaunchError from find_launch returns errors and logs WARNING."""
+        from jenkins_job_insight.reportportal import AmbiguousLaunchError
+
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.side_effect = AmbiguousLaunchError(
+            count=3,
+            job_name="my-job",
+            jenkins_url="https://jenkins.example.com/job/my-job/1/",
+        )
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "Ambiguous" in body["errors"][0]
+        assert "my-project" in body["errors"][0]
+
+        # Ambiguous launch is logged at WARNING, not ERROR
+        warning_calls = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if "ambiguous" in str(c).lower()
+        ]
+        assert warning_calls, "Expected WARNING log for ambiguous launch"
+        error_calls = [
+            c for c in mock_logger.error.call_args_list if "ambiguous" in str(c).lower()
+        ]
+        assert not error_calls, "Should NOT log ambiguous launch at ERROR"
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_rp_client_constructor_failure_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        """RPClient constructor failure returns errors and logs ERROR."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp_class.side_effect = ConnectionError("Name resolution failed")
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job3/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "ConnectionError" in body["errors"][0]
+        assert "Name resolution failed" in body["errors"][0]
+
+        # Constructor failure is logged at ERROR
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "name resolution" in str(c).lower()
+        ]
+        assert error_calls, "Expected ERROR log for constructor failure"
+
 
 class TestRPPushDebugLogging:
     """Verify normal-state RP paths log at DEBUG, not ERROR."""

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -1184,3 +1184,81 @@ class TestCapabilitiesEndpoint:
         assert "reportportal" in data
         assert data["reportportal"] is True
         assert data["reportportal_project"] == "my-project"
+
+
+class TestRPErrorMessage:
+    """Unit tests for _rp_error_message helper."""
+
+    def _make_exc_with_response(self, *, json_return, text="fallback text"):
+        """Build an exception whose .response mimics an httpx/requests Response."""
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = text
+        resp.json.return_value = json_return
+        exc = Exception("boom")
+        exc.response = resp
+        return exc
+
+    def test_dict_body_extracts_message_field(self, _rp_enabled_env):
+        """When RP returns a JSON dict with 'message', extract it."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = self._make_exc_with_response(json_return={"message": "Token expired"})
+        result = _rp_error_message(exc, "finding launch")
+        assert "Token expired" in result
+
+    def test_dict_body_without_message_falls_back_to_text(self, _rp_enabled_env):
+        """When RP returns a JSON dict without 'message', fall back to resp.text."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = self._make_exc_with_response(
+            json_return={"error": "something else"},
+            text="raw response text",
+        )
+        result = _rp_error_message(exc, "finding launch")
+        assert "raw response text" in result
+
+    def test_list_body_falls_back_to_text(self, _rp_enabled_env):
+        """When RP returns a JSON array, fall back to resp.text (not AttributeError)."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = self._make_exc_with_response(
+            json_return=["error1", "error2"],
+            text="the raw text",
+        )
+        result = _rp_error_message(exc, "finding launch")
+        # Must contain the fallback text, not crash with AttributeError
+        assert "the raw text" in result
+
+    def test_string_body_falls_back_to_text(self, _rp_enabled_env):
+        """When RP returns a plain JSON string, fall back to resp.text."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = self._make_exc_with_response(
+            json_return="just a string",
+            text="the raw text",
+        )
+        result = _rp_error_message(exc, "finding launch")
+        assert "the raw text" in result
+
+    def test_json_parse_failure_falls_back_to_text(self, _rp_enabled_env):
+        """When resp.json() raises, fall back to resp.text."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        resp = MagicMock()
+        resp.status_code = 502
+        resp.text = "Bad Gateway"
+        resp.json.side_effect = ValueError("No JSON")
+        exc = Exception("boom")
+        exc.response = resp
+        result = _rp_error_message(exc, "finding launch")
+        assert "Bad Gateway" in result
+
+    def test_no_response_uses_exc_str(self, _rp_enabled_env):
+        """When exc has no .response, use str(exc) as detail."""
+        from jenkins_job_insight.main import _rp_error_message
+
+        exc = ConnectionError("connection refused")
+        result = _rp_error_message(exc, "connecting")
+        assert "ConnectionError" in result
+        assert "connection refused" in result

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -1208,7 +1208,7 @@ class TestRPErrorMessage:
         from jenkins_job_insight.main import _rp_error_message
 
         exc = self._make_exc_with_response(json_return={"message": "Token expired"})
-        user_msg, log_msg = _rp_error_message(exc, "finding launch")
+        user_msg, _log_msg = _rp_error_message(exc, "finding launch")
         assert "Token expired" in user_msg
         assert "500" in user_msg
         assert "finding launch" in user_msg

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -552,6 +552,264 @@ class TestPushReportPortalEndpoint:
         )
 
 
+class TestRPPushHTTPErrors:
+    """Verify HTTP errors from RP API return proper error responses, not 500."""
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_find_launch_401_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """A 401 from RP find_launch returns a push result with errors, not 500."""
+        import requests as _requests
+
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = '{"message": "Full authentication is required"}'
+        mock_response.json.return_value = {"message": "Full authentication is required"}
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.side_effect = _requests.exceptions.HTTPError(
+            response=mock_response
+        )
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "401" in body["errors"][0]
+        assert "Full authentication is required" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_find_launch_connection_error_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """A ConnectionError from find_launch returns a push result with errors."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.side_effect = ConnectionError("connection refused")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job2/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert len(body["errors"]) == 1
+        assert "ConnectionError" in body["errors"][0]
+        assert "connection refused" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_get_failed_items_error_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """An HTTPError from get_failed_items returns errors, not 500."""
+        import requests as _requests
+
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = '{"message": "Access denied"}'
+        mock_response.json.return_value = {"message": "Access denied"}
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.side_effect = _requests.exceptions.HTTPError(
+            response=mock_response
+        )
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert body["launch_id"] == 42
+        assert len(body["errors"]) == 1
+        assert "403" in body["errors"][0]
+        assert "Access denied" in body["errors"][0]
+        assert "fetching failed items" in body["errors"][0]
+
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_match_failures_error_returns_200_with_error(
+        self, mock_get_result, mock_rp_class, _rp_enabled_env
+    ):
+        """An exception from match_failures returns errors, not 500."""
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [
+                    {
+                        "test_name": "test_a",
+                        "error": "err",
+                        "analysis": {"classification": "PRODUCT BUG", "details": "d"},
+                    }
+                ],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [{"id": 1, "name": "test_a"}]
+        mock_rp.match_failures.side_effect = TypeError("unexpected None")
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job2/push-reportportal")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pushed"] == 0
+        assert body["launch_id"] == 42
+        assert len(body["errors"]) == 1
+        assert "TypeError" in body["errors"][0]
+        assert "matching RP items" in body["errors"][0]
+
+
+class TestRPPushDebugLogging:
+    """Verify normal-state RP paths log at DEBUG, not ERROR."""
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_no_failed_items_logs_debug(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = []
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job1/push-reportportal")
+        assert response.status_code == 200
+        assert response.json()["pushed"] == 0
+
+        # Normal state: logged at DEBUG, not ERROR
+        debug_calls = [
+            c
+            for c in mock_logger.debug.call_args_list
+            if "no failed items" in str(c).lower()
+        ]
+        assert debug_calls, "Expected DEBUG log for 'no failed items'"
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "no failed items" in str(c).lower()
+        ]
+        assert not error_calls, "Should NOT log 'no failed items' at ERROR"
+
+    @patch("jenkins_job_insight.main.logger")
+    @patch("jenkins_job_insight.main.ReportPortalClient")
+    @patch("jenkins_job_insight.main.get_result")
+    def test_no_jji_failures_logs_debug(
+        self, mock_get_result, mock_rp_class, mock_logger, _rp_enabled_env
+    ):
+        mock_get_result.return_value = {
+            "result": {
+                "job_name": "my-job",
+                "jenkins_url": "https://jenkins.example.com/job/my-job/1/",
+                "failures": [],
+            }
+        }
+        mock_rp = MagicMock()
+        mock_rp.__enter__ = MagicMock(return_value=mock_rp)
+        mock_rp.__exit__ = MagicMock(return_value=False)
+        mock_rp.find_launch.return_value = 42
+        mock_rp.get_failed_items.return_value = [
+            {"id": 1, "name": "test_a", "status": "FAILED"}
+        ]
+        mock_rp_class.return_value = mock_rp
+
+        from jenkins_job_insight.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/results/job2/push-reportportal")
+        assert response.status_code == 200
+        assert response.json()["pushed"] == 0
+
+        # Normal state: logged at DEBUG, not ERROR
+        debug_calls = [
+            c
+            for c in mock_logger.debug.call_args_list
+            if "no jji failures" in str(c).lower()
+        ]
+        assert debug_calls, "Expected DEBUG log for 'no JJI failures'"
+        error_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if "no jji failures" in str(c).lower()
+        ]
+        assert not error_calls, "Should NOT log 'no JJI failures' at ERROR"
+
+
 class TestCapabilitiesEndpoint:
     """Test that capabilities includes reportportal."""
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/myk-org/jenkins-job-insight/issues/114

Ensures every RP push failure path is logged exactly once at the appropriate level with full context, and returns a clear user-facing error message instead of a raw 500.

## Changes

### Error handling (`main.py`)

- **`_rp_error_message()` helper** — single function that extracts status code, RP JSON `message`, or `str(exc)` from any exception type (HTTPError, ConnectionError, generic)
- **All RP client calls wrapped in try/except** — `find_launch`, `get_failed_items`, `match_failures`, `push_classifications`, and `asyncio.gather` for history classifications
- **RPClient constructor failure** caught — DNS/connection errors during `__init__` return a proper error response
- **No-overlap error** built once via `overlap_error` variable and reused for both log and response (no duplication)
- **"No launch" error** now includes project name: `"No RP launch found for job 'x' in project 'CNV'"`

### Logging levels (`main.py`, `reportportal.py`)

| Path | Level | Rationale |
|---|---|---|
| find_launch HTTP/connection error | ERROR | Actual failure |
| No launch found | ERROR | Actual failure |
| get_failed_items error | ERROR | Actual failure |
| match_failures error | ERROR | Actual failure |
| No overlap | ERROR | Actual failure |
| Batch PUT HTTP error | ERROR | Actual failure |
| Batch PUT generic error | ERROR | Actual failure |
| No failed items in RP launch | DEBUG | Normal state |
| No JJI failures in stored result | DEBUG | Normal state |
| History classification fetch failure | DEBUG | Non-fatal, proceeds without history |
| Ambiguous launches (multiple, none matched URL) | WARNING | Diagnostic detail |

### Cleanup (`reportportal.py`)

- **Removed duplicate log** from `find_launch` for "no launches found" — caller logs with more context
- **Suppressed RPClient stderr traceback** during construction — the `reportportal_client` library prints to `sys.stderr` on connection failure; redirected during init so only our clean error log appears
- **Response body included in ERROR log** for batch PUT failures (single line, not separate DEBUG)

### Tests

- **6 new endpoint tests**: 401/ConnectionError from find_launch, 403 from get_failed_items, TypeError from match_failures, DEBUG-level logging for no-failed-items and no-JJI-failures
- **Updated existing tests**: removed assertions on removed logs, added response_body assertion to HTTP error test, added ambiguous-launches warning assertion
- All 1075 backend + 80 frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report Portal pushes now fail gracefully with consistent, user-facing error messages and preserved launch info when available.
  * Ambiguous launch matches are reported explicitly and surfaced as a clear failure.

* **Behavior**
  * Partial history fetches are tolerated; pushes proceed with available classifications.
  * Error cases (no overlap, lookup, or downstream RP errors) produce standardized, readable responses and operator logs.

* **UI Changes**
  * Capabilities expose a ReportPortal project field; report UI and push dialog show Project/Job/Build metadata and pass job+build to the push button.

* **Tests**
  * Expanded coverage for push error paths, logging, launch lookup, concurrency, and capability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->