### PR TITLE
fix: peer response parsing and failed job UX improvements

### DIFF
--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom'
+import { Bug } from 'lucide-react'
 import { UserBadge } from './UserBadge'
 import { cn } from '@/lib/utils'
 
@@ -37,7 +38,19 @@ export function NavBar() {
             ))}
           </nav>
         </div>
-        <UserBadge />
+        <div className="flex items-center gap-3">
+          <a
+            href="https://github.com/myk-org/jenkins-job-insight/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Report a bug on GitHub"
+            className="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
+          >
+            <Bug className="h-4 w-4 shrink-0" />
+            Report Bug
+          </a>
+          <UserBadge />
+        </div>
       </div>
     </header>
   )

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -198,7 +198,7 @@ export function DashboardPage() {
   }
 
   function getJobRoute(job: DashboardJob): string {
-    return ['waiting', 'pending', 'running'].includes(job.status)
+    return ['waiting', 'pending', 'running', 'failed'].includes(job.status)
       ? `/status/${job.job_id}`
       : `/results/${job.job_id}`
   }

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -159,8 +159,7 @@ function ReportContent() {
         }
 
         if (resultRes.status === 'failed') {
-          const errorMsg = resultRes.result?.error ?? 'Analysis failed'
-          dispatch({ type: 'SET_ERROR', payload: String(errorMsg) })
+          navigate(`/status/${jobId}`, { replace: true })
           return
         }
 

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -5,7 +5,10 @@ import { formatTimestamp, isAnalysisTimeout, INVALID_DATE_FALLBACK } from '@/lib
 import type { ResultResponse } from '@/types'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Clock, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Clock, ExternalLink, Loader2, RotateCw } from 'lucide-react'
+import { StatusChip } from '@/components/shared/StatusChip'
+import { ReAnalyzeDialog } from './report/ReAnalyzeDialog'
 
 const POLL_MS = 10_000
 
@@ -77,6 +80,7 @@ export function StatusPage() {
   const [data, setData] = useState<ResultResponse | null>(null)
   const [error, setError] = useState('')
   const [terminalErrorKind, setTerminalErrorKind] = useState<'not_found' | 'unauthorized' | 'failed' | null>(null)
+  const [reAnalyzeOpen, setReAnalyzeOpen] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval>>(null)
   const prevLogLenRef = useRef(0)
   const logEndRef = useRef<HTMLDivElement>(null)
@@ -96,6 +100,7 @@ export function StatusPage() {
     setData(null)
     setError('')
     setTerminalErrorKind(null)
+    setReAnalyzeOpen(false)
     prevLogLenRef.current = 0
 
     async function poll() {
@@ -174,7 +179,7 @@ export function StatusPage() {
   }, [stepLog.length])
 
   const status = data?.status ?? terminalErrorKind ?? 'pending'
-  const isTimeout = isAnalysisTimeout(status, error)
+  const isTimeout = isAnalysisTimeout(status, error, data?.result?.summary)
   const displayStatus = isTimeout ? 'timeout' : status
   const queuedAtDisplay = data?.created_at ? formatTimestamp(data.created_at) : null
 
@@ -192,17 +197,69 @@ export function StatusPage() {
   const statusBadgeLabel = displayStatus.replace(/_/g, ' ').toUpperCase()
 
   return (
-    <div className="relative flex min-h-screen items-start justify-center overflow-x-hidden overflow-y-auto bg-surface-page py-8 sm:items-center">
-      {/* Scan-line overlay */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.015]"
-        style={{
-          backgroundImage:
-            'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(56,139,253,.3) 2px, rgba(56,139,253,.3) 4px)',
-        }}
-      />
+    <>
+      {/* Sticky header for failed jobs — matches report page layout */}
+      {terminalErrorKind === 'failed' && data?.result && (
+        <div className="sticky top-14 z-40 w-full bg-surface-page/95 backdrop-blur-sm border-b border-border-muted">
+          <div className="mx-auto max-w-[1400px] px-4 py-3 sm:px-6 lg:px-8">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="font-display text-lg font-bold text-text-primary truncate">
+                {data.result.job_name || jobId}
+              </h1>
+              {data.result.build_number > 0 && (
+                data.jenkins_url ? (
+                  <a href={String(data.jenkins_url)} target="_blank" rel="noopener noreferrer" className="font-mono text-sm text-text-link hover:underline">
+                    #{data.result.build_number}
+                  </a>
+                ) : (
+                  <span className="font-mono text-sm text-text-tertiary">#{data.result.build_number}</span>
+                )
+              )}
+              <StatusChip status={displayStatus} />
+              {data.result.request_params?.ai_provider && (
+                <Badge variant="outline" className="text-[10px]">
+                  {data.result.request_params.ai_provider}{data.result.request_params.ai_model ? ` / ${data.result.request_params.ai_model}` : ''}
+                </Badge>
+              )}
+              <div className="ml-auto flex items-center gap-3">
+                {data.result.request_params && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 text-xs"
+                    onClick={() => setReAnalyzeOpen(true)}
+                  >
+                    <RotateCw className="h-3.5 w-3.5" />
+                    Re-Analyze
+                  </Button>
+                )}
+                {data.jenkins_url && (
+                  <a
+                    href={String(data.jenkins_url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-text-link hover:underline"
+                  >
+                    Jenkins <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
-      <div className="relative z-10 w-full max-w-xl px-4">
+      <div className="relative flex min-h-screen items-start justify-center overflow-x-hidden overflow-y-auto bg-surface-page py-8 sm:items-center">
+        {/* Scan-line overlay */}
+        <div
+          className="pointer-events-none absolute inset-0 opacity-[0.015]"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(56,139,253,.3) 2px, rgba(56,139,253,.3) 4px)',
+          }}
+        />
+
+        <div className="relative z-10 w-full max-w-xl px-4">
         <Card className="animate-slide-up border-border-muted">
           <CardContent className="flex flex-col items-center gap-6 p-8">
             {/* Pulsing / spinning indicator */}
@@ -255,7 +312,7 @@ export function StatusPage() {
                       </h2>
                     </div>
                     <p className="mt-2 text-sm text-signal-orange/80 bg-signal-orange/10 rounded-md px-3 py-2">
-                      {error}
+                      The AI analysis timed out. You can re-analyze with a longer timeout.
                     </p>
                   </>
                 ) : (
@@ -264,8 +321,9 @@ export function StatusPage() {
                       {terminalErrorTitles[terminalErrorKind] ?? terminalErrorTitles.failed}
                     </h2>
                     <p className="mt-2 text-sm text-signal-red/80 bg-signal-red/10 rounded-md px-3 py-2">
-                      {error}
+                      Analysis failed. You can re-analyze or check server logs for details.
                     </p>
+
                   </>
                 )
               ) : (
@@ -304,7 +362,7 @@ export function StatusPage() {
               <Row
                 label="STATUS"
                 value={
-                  <Badge variant={isRunning || isWaiting ? 'default' : 'outline'}>
+                  <Badge variant={isRunning || isWaiting ? 'default' : displayStatus === 'timeout' ? 'warning' : displayStatus === 'failed' ? 'destructive' : 'outline'}>
                     {statusBadgeLabel}
                   </Badge>
                 }
@@ -381,7 +439,18 @@ export function StatusPage() {
           </CardContent>
         </Card>
       </div>
-    </div>
+
+      </div>
+
+      {jobId && terminalErrorKind === 'failed' && data?.result?.request_params && (
+        <ReAnalyzeDialog
+          open={reAnalyzeOpen}
+          onOpenChange={setReAnalyzeOpen}
+          result={data.result}
+          jobId={jobId}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1590,6 +1590,12 @@ async def analyze_job(
                 ai_provider, ai_model, cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, [])
             )
             if not ok:
+                logger.error(
+                    "AI CLI sanity check failed for job %s (%s/%s)",
+                    job_id,
+                    ai_provider,
+                    ai_model,
+                )
                 return AnalysisResult(
                     job_id=job_id,
                     job_name=request.job_name,

--- a/src/jenkins_job_insight/logging_context.py
+++ b/src/jenkins_job_insight/logging_context.py
@@ -1,0 +1,28 @@
+"""Request-scoped logging context using contextvars.
+
+Provides a ``job_id`` context variable and a logging filter that
+automatically prepends ``[job_id=<value>]`` to log messages during
+request processing.
+"""
+
+import contextvars
+import logging
+
+job_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("job_id", default="")
+
+
+class JobIdFilter(logging.Filter):
+    """Logging filter that prepends ``[job_id=<value>]`` to log messages.
+
+    When ``job_id`` is set in the current context, prepends the prefix.
+    When empty (e.g. startup, health checks), the message is unchanged.
+    Guards against duplicate prefixes when multiple handlers share this filter.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        jid = job_id_var.get("")
+        if jid:
+            prefix = f"[job_id={jid}] "
+            if not isinstance(record.msg, str) or not record.msg.startswith(prefix):
+                record.msg = f"{prefix}{record.msg}"
+        return True

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import math
 import os
 import time as _time
@@ -18,6 +19,8 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from pydantic import BaseModel, Field, SecretStr, ValidationError
 from simple_logger.logger import get_logger
+
+from jenkins_job_insight.logging_context import JobIdFilter, job_id_var
 
 from ai_cli_runner import VALID_AI_PROVIDERS, run_parallel_with_limit
 from jenkins_job_insight.analyzer import (
@@ -90,6 +93,28 @@ from jenkins_job_insight.storage import (
 FAVICON_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="0.9em" font-size="90">\xf0\x9f\x94\x8d</text></svg>'
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+# Install job_id filter on ALL logger handlers so module loggers
+# (which use propagate=False via python-simple-logger) get the prefix.
+_job_id_filter = JobIdFilter()
+
+
+def _install_job_id_filter() -> None:
+    """Attach JobIdFilter to every handler on every known logger."""
+    for name in [None, *list(logging.Logger.manager.loggerDict)]:
+        _logger = logging.getLogger(name)
+        for handler in getattr(_logger, "handlers", []):
+            if _job_id_filter not in handler.filters:
+                handler.addFilter(_job_id_filter)
+
+
+_install_job_id_filter()
+
+
+async def _bind_job_id(job_id: str) -> None:
+    """FastAPI dependency that binds job_id to the logging context."""
+    job_id_var.set(job_id)
+
 
 # Statuses that indicate the analysis is still in progress.
 IN_PROGRESS_STATUSES = ("pending", "running", "waiting")
@@ -454,6 +479,7 @@ async def _deferred_resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _install_job_id_filter()
     await init_db()
     waiting_jobs = await storage.mark_stale_results_failed()
     if waiting_jobs:
@@ -827,6 +853,7 @@ async def process_analysis_with_id(
         body: The analysis request.
         settings: Application settings.
     """
+    job_id_var.set(job_id)
     logger.info(
         f"Analysis request received for {body.job_name} #{body.build_number} "
         f"(job_id: {job_id})"
@@ -1094,6 +1121,7 @@ async def _enqueue_analysis_job(
     job setup, persistence, and response shaping.
     """
     job_id = str(uuid.uuid4())
+    job_id_var.set(job_id)
     jenkins_url = build_jenkins_url(
         merged.jenkins_url, body.job_name, body.build_number
     )
@@ -1182,6 +1210,7 @@ async def analyze_failures(
 
         if not test_failures:
             job_id = str(uuid.uuid4())
+            job_id_var.set(job_id)
             analysis_result = FailureAnalysisResult(
                 job_id=job_id,
                 status="completed",
@@ -1211,6 +1240,7 @@ async def analyze_failures(
     additional_repos_list = resolve_additional_repos(body, merged)
 
     job_id = str(uuid.uuid4())
+    job_id_var.set(job_id)
     logger.info(
         f"Direct failure analysis request received with {len(test_failures)} failures (job_id: {job_id})"
     )
@@ -1375,6 +1405,7 @@ async def re_analyze(
     request: Request,
     body: BaseAnalysisRequest,
     background_tasks: BackgroundTasks,
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Re-analyze a previously analyzed job with the same (or overridden) settings.
 
@@ -1428,7 +1459,9 @@ async def re_analyze(
 
 
 @app.get("/results/{job_id}", response_model=None)
-async def get_job_result(request: Request, job_id: str, response: Response):
+async def get_job_result(
+    request: Request, job_id: str, response: Response, _: None = Depends(_bind_job_id)
+):
     """Retrieve stored result by job_id, or serve SPA for browser requests."""
     # Content negotiation: browsers requesting HTML get the SPA
     accept = request.headers.get("accept", "")
@@ -1614,7 +1647,7 @@ async def _resolve_effective_failure(
 
 
 @app.get("/results/{job_id}/comments")
-async def get_comments(job_id: str) -> dict:
+async def get_comments(job_id: str, _: None = Depends(_bind_job_id)) -> dict:
     """Get all comments and review states for a job."""
     logger.debug(f"GET /results/{job_id}/comments")
     comments = await storage.get_comments_for_job(job_id)
@@ -1623,7 +1656,12 @@ async def get_comments(job_id: str) -> dict:
 
 
 @app.post("/results/{job_id}/comments", status_code=201)
-async def add_comment(job_id: str, body: AddCommentRequest, request: Request) -> dict:
+async def add_comment(
+    job_id: str,
+    body: AddCommentRequest,
+    request: Request,
+    _: None = Depends(_bind_job_id),
+) -> dict:
     """Add a comment to a test failure."""
     logger.debug(f"POST /results/{job_id}/comments: test_name={body.test_name}")
     await _validate_test_name_in_result(
@@ -1652,7 +1690,7 @@ async def add_comment(job_id: str, body: AddCommentRequest, request: Request) ->
 
 @app.delete("/results/{job_id}/comments/{comment_id}")
 async def delete_comment_endpoint(
-    job_id: str, comment_id: int, request: Request
+    job_id: str, comment_id: int, request: Request, _: None = Depends(_bind_job_id)
 ) -> dict:
     """Delete a comment. Username check is a UI courtesy, not security.
 
@@ -1674,7 +1712,12 @@ async def delete_comment_endpoint(
 
 
 @app.put("/results/{job_id}/reviewed")
-async def set_reviewed(job_id: str, body: SetReviewedRequest, request: Request) -> dict:
+async def set_reviewed(
+    job_id: str,
+    body: SetReviewedRequest,
+    request: Request,
+    _: None = Depends(_bind_job_id),
+) -> dict:
     """Toggle the reviewed state for a test failure."""
     logger.debug(
         f"PUT /results/{job_id}/reviewed: test_name={body.test_name}, reviewed={body.reviewed}"
@@ -1702,7 +1745,9 @@ async def set_reviewed(job_id: str, body: SetReviewedRequest, request: Request) 
 
 @app.post("/results/{job_id}/enrich-comments")
 async def enrich_comments(
-    job_id: str, settings: Settings = Depends(get_settings)
+    job_id: str,
+    settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Fetch live statuses for GitHub PRs and Jira tickets found in comments."""
     logger.debug(f"POST /results/{job_id}/enrich-comments")
@@ -1898,6 +1943,7 @@ async def preview_github_issue(
     body: PreviewIssueRequest,
     request: Request,
     settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Generate preview content for a GitHub issue from a failure analysis."""
     logger.debug(
@@ -1968,6 +2014,7 @@ async def preview_jira_bug(
     body: PreviewIssueRequest,
     request: Request,
     settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Generate preview content for a Jira bug from a failure analysis."""
     logger.debug(f"POST /results/{job_id}/preview-jira-bug: test_name={body.test_name}")
@@ -2180,6 +2227,7 @@ async def create_github_issue_endpoint(
     body: CreateIssueRequest,
     request: Request,
     settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Create a GitHub issue from a failure analysis."""
     logger.debug(
@@ -2271,6 +2319,7 @@ async def create_jira_bug_endpoint(
     body: CreateIssueRequest,
     request: Request,
     settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Create a Jira bug from a failure analysis."""
     logger.debug(f"POST /results/{job_id}/create-jira-bug: test_name={body.test_name}")
@@ -2359,6 +2408,7 @@ async def push_to_reportportal(
         default=None, description="Child build number for pipeline child push"
     ),
     settings: Settings = Depends(get_settings),
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Push JJI classifications into Report Portal test items.
 
@@ -2427,29 +2477,16 @@ def _log_and_return_rp_error(
     detail = log_msg or user_msg
     if launch_id is not None:
         logger.error(
-            "RP push failed: %s, job='%s' #%s, launch_id=%d",
-            detail,
-            job_name,
-            build_number,
-            launch_id,
+            f"RP push failed: {detail}, job='{job_name}' #{build_number}, launch_id={launch_id}"
         )
     elif jenkins_url:
         logger.error(
-            "RP push failed: %s, job='%s' #%s, jenkins_url='%s'",
-            detail,
-            job_name,
-            build_number,
-            jenkins_url,
+            f"RP push failed: {detail}, job='{job_name}' #{build_number}, jenkins_url='{jenkins_url}'"
         )
     elif build_number is not None:
-        logger.error(
-            "RP push failed: %s, job='%s' #%s",
-            detail,
-            job_name,
-            build_number,
-        )
+        logger.error(f"RP push failed: {detail}, job='{job_name}' #{build_number}")
     else:
-        logger.error("RP push failed: %s", detail)
+        logger.error(f"RP push failed: {detail}")
     return _rp_push_error_result(
         user_msg,
         launch_id=launch_id,
@@ -2627,7 +2664,8 @@ async def _execute_rp_push(
 
         if launch_id is None:
             return _log_and_return_rp_error(
-                "No RP launch found.",
+                "No Report Portal launch found. "
+                "Ensure the Jenkins build URL is in the RP launch description.",
                 job_name=job_name,
                 build_number=build_number,
                 jenkins_url=jenkins_url,
@@ -2865,6 +2903,7 @@ async def override_classification_endpoint(
     job_id: str,
     body: OverrideClassificationRequest,
     request: Request,
+    _: None = Depends(_bind_job_id),
 ) -> dict:
     """Override the classification of a failure (CODE ISSUE, PRODUCT BUG, or INFRASTRUCTURE)."""
     logger.debug(
@@ -2919,7 +2958,7 @@ async def override_classification_endpoint(
 
 
 @app.get("/results/{job_id}/review-status")
-async def get_review_status(job_id: str) -> dict:
+async def get_review_status(job_id: str, _: None = Depends(_bind_job_id)) -> dict:
     """Get review summary for a job (used by dashboard)."""
     logger.debug(f"GET /results/{job_id}/review-status")
     return await storage.get_review_status(job_id)
@@ -2933,7 +2972,9 @@ async def list_job_results(limit: int = Query(50, le=100)) -> list[dict]:
 
 
 @app.delete("/results/{job_id}")
-async def delete_job_endpoint(job_id: str, request: Request) -> dict:
+async def delete_job_endpoint(
+    job_id: str, request: Request, _: None = Depends(_bind_job_id)
+) -> dict:
     """Delete an analyzed job and all related data.
 
     This project operates on a trusted network with no authentication.

--- a/src/jenkins_job_insight/peer_analysis.py
+++ b/src/jenkins_job_insight/peer_analysis.py
@@ -59,6 +59,19 @@ _PEER_RESPONSE_SCHEMA = """CRITICAL: Your response must be ONLY a valid JSON obj
 }"""
 
 _VALID_CLASSIFICATIONS = frozenset({"CODE ISSUE", "PRODUCT BUG"})
+_PEER_RESPONSE_KEYS = frozenset({"agrees", "classification", "reasoning"})
+
+
+def _is_peer_response_dict(data: object) -> bool:
+    """Check whether *data* contains ALL core peer-response keys with correct types."""
+    if not isinstance(data, dict):
+        return False
+    return (
+        _PEER_RESPONSE_KEYS.issubset(data)
+        and isinstance(data.get("agrees"), bool)
+        and isinstance(data.get("classification"), str)
+        and isinstance(data.get("reasoning"), str)
+    )
 
 
 def _normalize_classification(cls: str) -> str:
@@ -119,6 +132,13 @@ def _check_consensus(
 def _parse_peer_response(raw: str) -> dict:
     """Parse a peer's JSON response with fallback extraction.
 
+    Three strategies are tried in order (direct parse, fenced code blocks,
+    brace-delimited substrings). Each strategy only accepts a dict that
+    contains ALL core peer response keys (``agrees``, ``classification``,
+    and ``reasoning``) with correct types (bool, str, str respectively);
+    dicts missing any of these keys or with wrong types are skipped so
+    later strategies can try.
+
     On parse failure returns ``{"_failed": True, "raw": raw}`` so the peer
     is excluded from consensus.
 
@@ -133,9 +153,8 @@ def _parse_peer_response(raw: str) -> dict:
     # Strategy 1: direct JSON parse
     try:
         data = json.loads(raw)
-        if not isinstance(data, dict):
-            return _failed
-        return data
+        if _is_peer_response_dict(data):
+            return data
     except (json.JSONDecodeError, TypeError):
         pass
 
@@ -143,21 +162,24 @@ def _parse_peer_response(raw: str) -> dict:
     for block in re.findall(r"```(?:json)?\s*\n?(.*?)\n?```", raw, re.DOTALL):
         try:
             data = json.loads(block.strip())
-            if isinstance(data, dict):
+            if _is_peer_response_dict(data):
                 return data
         except (json.JSONDecodeError, TypeError):
             continue
 
-    # Strategy 3: brace matching
-    brace_match = re.search(r"\{.*\}", raw, re.DOTALL)
-    if brace_match:
+    # Strategy 3: try brace-delimited substrings, starting from the last '{'.
+    # AI responses typically put the JSON object at the end, after prefatory text.
+    # Starting from the end avoids false starts from shell variables like ${VAR}.
+    # Use raw_decode() to tolerate trailing text after the JSON object.
+    # Require ALL core keys with correct types to skip inner nested objects.
+    decoder = json.JSONDecoder()
+    for match in reversed(list(re.finditer(r"\{", raw))):
         try:
-            data = json.loads(brace_match.group(0))
-            if not isinstance(data, dict):
-                return _failed
-            return data
-        except (json.JSONDecodeError, TypeError):
-            pass
+            data, _ = decoder.raw_decode(raw, match.start())
+            if _is_peer_response_dict(data):
+                return data
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
 
     return _failed
 

--- a/tests/test_logging_context.py
+++ b/tests/test_logging_context.py
@@ -1,0 +1,82 @@
+"""Tests for job_id logging context."""
+
+import logging
+
+from jenkins_job_insight.logging_context import JobIdFilter, job_id_var
+
+
+class TestJobIdFilter:
+    def test_filter_prepends_job_id_when_set(self) -> None:
+        """Filter prepends [job_id=...] to log messages when job_id is set."""
+        filt = JobIdFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="hello world",
+            args=(),
+            exc_info=None,
+        )
+        job_id_var.set("abc-123")
+        try:
+            filt.filter(record)
+            assert record.msg == "[job_id=abc-123] hello world"
+        finally:
+            job_id_var.set("")
+
+    def test_filter_no_prefix_when_empty(self) -> None:
+        """Filter does not modify messages when job_id is not set."""
+        filt = JobIdFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="hello world",
+            args=(),
+            exc_info=None,
+        )
+        job_id_var.set("")
+        filt.filter(record)
+        assert record.msg == "hello world"
+
+    def test_filter_always_returns_true(self) -> None:
+        """Filter never suppresses records."""
+        filt = JobIdFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test",
+            args=(),
+            exc_info=None,
+        )
+        assert filt.filter(record) is True
+        job_id_var.set("xyz")
+        try:
+            assert filt.filter(record) is True
+        finally:
+            job_id_var.set("")
+
+    def test_filter_on_handler_works_with_named_logger(self, capfd) -> None:
+        """When filter is on a handler, named loggers with propagate=False get the prefix."""
+        filt = JobIdFilter()
+        test_logger = logging.getLogger("test_jid_handler")
+        test_logger.setLevel(logging.DEBUG)
+        test_logger.propagate = False
+
+        handler = logging.StreamHandler()
+        handler.addFilter(filt)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        test_logger.addHandler(handler)
+
+        try:
+            job_id_var.set("job-42")
+            test_logger.info("test message")
+            captured = capfd.readouterr()
+            assert "[job_id=job-42] test message" in captured.err
+        finally:
+            job_id_var.set("")
+            test_logger.removeHandler(handler)

--- a/tests/test_peer_analysis.py
+++ b/tests/test_peer_analysis.py
@@ -417,11 +417,8 @@ class TestParsePeerResponse:
             agrees=False, classification="PRODUCT BUG"
         )
         # First code block contains valid JSON but not a dict (an array).
-        # Strategy 2 currently only tries the first block, so this fails
-        # even though the second block has the valid dict.
-        # Strategy 3 (brace matching) won't help because the greedy regex
-        # matches from the first `{` in the array element to the last `}`
-        # in the valid JSON, producing invalid JSON.
+        # Strategy 2 tries each fenced block in order, skipping non-dict
+        # blocks, so the valid dict in the second block is found.
         raw = (
             "Here is my thinking:\n"
             '```json\n[{"step": "analysis"}, {"step": "review"}]\n```\n'
@@ -432,6 +429,147 @@ class TestParsePeerResponse:
         assert "_failed" not in result
         assert result["agrees"] is False
         assert result["classification"] == "PRODUCT BUG"
+
+    @pytest.mark.parametrize(
+        "preamble,agrees,classification,reasoning,suggested_changes",
+        [
+            pytest.param(
+                (
+                    "I've verified the key claims in the source code:\n"
+                    "1. `infraUtils.groovy` line 39: `cp -fv ${JIRA_CFG_FILE} "
+                    "${WORKSPACE}/mtv-api-tests/jira.cfg` -- confirmed\n"
+                    "2. `pyproject.toml` line 59: `pytest-jira>=0.3.23` is a "
+                    "dependency -- confirmed\n\n"
+                ),
+                True,
+                "CODE ISSUE",
+                "The analysis is correct",
+                "",
+                id="shell_variables_in_preamble",
+            ),
+            pytest.param(
+                (
+                    "Checking the pipeline script:\n"
+                    "- Line 12: `echo ${BUILD_NUMBER}`\n"
+                    "- Line 45: `def config = ${env.CONFIG_MAP}`\n"
+                    '- Line 78: `sh "curl -X POST ${API_URL}/v2/results"`\n\n'
+                    "All references verified.\n\n"
+                ),
+                False,
+                "PRODUCT BUG",
+                "The root cause is in the product",
+                "Fix the API endpoint",
+                id="multiple_braces_in_preamble",
+            ),
+            pytest.param(
+                (
+                    "I've carefully reviewed the orchestrator's analysis and the "
+                    "relevant source code.\n\n"
+                    "Key observations:\n"
+                    "1. The test `test_network_timeout` asserts a 30s timeout\n"
+                    "2. The config in `${PROJECT_ROOT}/settings.yaml` sets it to 60s\n"
+                    '3. The Jenkinsfile runs: `sh "export TIMEOUT=${DEFAULT_TIMEOUT}"` '
+                    "on line 142\n"
+                    "4. The `Makefile` target uses `${CURDIR}/bin/run-tests`\n\n"
+                    "Given these findings, the classification is accurate.\n\n"
+                ),
+                True,
+                "CODE ISSUE",
+                "Timeout mismatch between config and test assertion",
+                "Update the test to expect 60s",
+                id="json_at_end_after_text",
+            ),
+        ],
+    )
+    def test_parse_peer_response_preamble_with_braces(
+        self, preamble, agrees, classification, reasoning, suggested_changes
+    ) -> None:
+        """JSON is correctly extracted when prefatory text contains curly braces."""
+        from jenkins_job_insight.peer_analysis import _parse_peer_response
+
+        raw = preamble + _make_peer_json_response(
+            agrees=agrees,
+            classification=classification,
+            reasoning=reasoning,
+            suggested_changes=suggested_changes,
+        )
+        result = _parse_peer_response(raw)
+        assert "_failed" not in result
+        assert result["agrees"] is agrees
+        assert result["classification"] == classification
+        assert result["reasoning"] == reasoning
+
+    def test_parse_peer_response_trailing_text_after_json(self) -> None:
+        """JSON followed by trailing text is still parsed correctly."""
+        from jenkins_job_insight.peer_analysis import _parse_peer_response
+
+        raw = (
+            _make_peer_json_response(
+                agrees=True,
+                classification="CODE ISSUE",
+                reasoning="Test is broken",
+            )
+            + "\n\nHope this helps! Let me know if you need more details."
+        )
+        result = _parse_peer_response(raw)
+        assert "_failed" not in result
+        assert result["agrees"] is True
+        assert result["classification"] == "CODE ISSUE"
+
+    def test_parse_peer_response_nested_object_not_returned(self) -> None:
+        """Inner nested objects are skipped; the root peer response is returned."""
+        from jenkins_job_insight.peer_analysis import _parse_peer_response
+
+        # JSON with a nested object — iterating from last '{' should NOT
+        # return the inner {"nested": true} dict.
+        raw = (
+            "Some preamble text\n"
+            '{"agrees": true, "classification": "CODE ISSUE", '
+            '"reasoning": "Valid analysis", "extra": {"nested": true}}'
+        )
+        result = _parse_peer_response(raw)
+        assert "_failed" not in result
+        assert result["agrees"] is True
+        assert result["classification"] == "CODE ISSUE"
+        assert result["reasoning"] == "Valid analysis"
+
+    def test_parse_peer_response_wrong_shape_dict_falls_through(self) -> None:
+        """Top-level JSON dict without peer keys falls through to later strategies."""
+        from jenkins_job_insight.peer_analysis import _parse_peer_response
+
+        # The AI wraps its response in extra metadata — Strategy 1 should
+        # reject the top-level dict (no peer keys) and Strategy 3 should
+        # recover the actual peer response embedded inside.
+        inner = _make_peer_json_response(
+            agrees=True,
+            classification="CODE ISSUE",
+            reasoning="Correct analysis",
+        )
+        raw = f'{{"metadata": "wrapper", "response": {inner}}}'
+        result = _parse_peer_response(raw)
+        assert "_failed" not in result
+        assert result["agrees"] is True
+        assert result["classification"] == "CODE ISSUE"
+
+    def test_parse_peer_response_wrapper_with_peer_key_falls_through(self) -> None:
+        """Wrapper dict with a top-level peer key does not short-circuit parsing."""
+        from jenkins_job_insight.peer_analysis import _parse_peer_response
+
+        # A wrapper that has 'classification' at top level but the real peer
+        # payload is nested under 'response'. Strategy 1 should reject the
+        # outer dict (missing agrees/reasoning) and Strategy 3 should recover
+        # the inner peer response.
+        inner = _make_peer_json_response(
+            agrees=True,
+            classification="CODE ISSUE",
+            reasoning="Correct analysis",
+        )
+        raw = f'{{"classification": "CODE ISSUE", "response": {inner}}}'
+        result = _parse_peer_response(raw)
+        assert "_failed" not in result
+        assert result["agrees"] is True
+        assert result["classification"] == "CODE ISSUE"
+        assert result["reasoning"] == "Correct analysis"
 
 
 # ===========================================================================

--- a/tests/test_reportportal_endpoint.py
+++ b/tests/test_reportportal_endpoint.py
@@ -1405,7 +1405,11 @@ class TestRpPushErrorResult:
         client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/results/job1/push-reportportal")
         body = response.json()
-        assert "No RP launch found" in body["errors"][0]
+        assert "No Report Portal launch found." in body["errors"][0]
+        assert (
+            "Ensure the Jenkins build URL is in the RP launch description"
+            in body["errors"][0]
+        )
         assert "(job=" not in body["errors"][0]
 
     @patch("jenkins_job_insight.main.ReportPortalClient")


### PR DESCRIPTION
Fixes #121

## Changes

### Peer response parsing (`peer_analysis.py`)
- Replace greedy brace-matching regex with iterative `JSONDecoder.raw_decode()` approach that handles `${VAR}` shell variables in AI prefatory text
- Add `_is_peer_response_dict()` helper to validate extracted dicts have peer response keys (`agrees`/`classification`/`reasoning`)
- Apply key validation consistently across all 3 parsing strategies

### Failed job UX (`StatusPage.tsx`, `DashboardPage.tsx`, `ReportPage.tsx`)
- Add sticky header bar to StatusPage for failed jobs (job name, build#, status, AI provider, Re-Analyze button, Jenkins link)
- Route failed jobs to StatusPage instead of ReportPage
- Redirect `/results/` URLs for failed jobs to `/status/`
- Fix `isAnalysisTimeout` to include `summary` for consistent timeout detection

### Other
- Add `logger.error` for AI CLI sanity check failures (`analyzer.py`)
- Add Report Bug link to navbar header (`NavBar.tsx`)

## Testing
- All 1,149 tests pass (1,069 backend + 80 frontend)
- Peer reviewed by Cursor (2 rounds, converged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Report Bug" nav link; sticky header and Re‑Analyze action for failed jobs; report view now redirects failed results to the status page

* **Bug Fixes**
  * Route failed jobs to the status page
  * More robust peer-response JSON parsing and improved timeout/error messaging
  * Clarified Report Portal "No Report Portal launch found." guidance

* **Tests**
  * Expanded peer-response tests; added logging-context tests; updated Report Portal test

* **Chores**
  * Emit diagnostics when AI CLI is unavailable; install job-scoped log filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->