### PR TITLE
feat(auth): add admin authentication and user tracking

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,4 +11,7 @@ paths = [
     '''tests/test_config\.py''',
     '''tests/test_main\.py''',
     '''tests/conftest\.py''',
+    '''tests/test_cli_main\.py''',
+    '''tests/test_cli_client\.py''',
+    '''tests/test_auth\.py''',
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,13 +182,15 @@ When adding a new analysis setting:
 5. Add the field to `ServerConfig` in `cli/config.py`
 
 Exceptions (server-level only, no payload equivalent):
+- `ADMIN_KEY` — server-only bootstrap secret for admin superuser authentication; never expose via request payloads, CLI flags, or shared config files
 - `DEBUG` — server reload toggle
-- `LOG_LEVEL` — server log verbosity
-- `PUBLIC_BASE_URL` — trusted server-only origin for building absolute links; never derive from request headers to prevent host-header injection
 - `ENABLE_GITHUB_ISSUES` — server capability toggle for GitHub issue creation
 - `ENABLE_REPORTPORTAL` — server capability toggle for Report Portal integration
 - `JJI_ENCRYPTION_KEY` — server-only secret for at-rest encryption; never expose via request payloads, CLI flags, or shared config files
-- Security-sensitive credentials for preview/create-issue endpoints (`GITHUB_TOKEN`, `TESTS_REPO_URL`, Jira credentials, `REPORTPORTAL_URL`, `REPORTPORTAL_API_TOKEN`, `REPORTPORTAL_PROJECT`) — these use deployment config, not per-request overrides
+- `LOG_LEVEL` — server log verbosity
+- `PUBLIC_BASE_URL` — trusted server-only origin for building absolute links; never derive from request headers to prevent host-header injection
+- `SECURE_COOKIES` — server-only deployment toggle for HTTPS cookie flags (default: True, set False for local HTTP dev)
+- Security-sensitive credentials for preview/create-issue endpoints (`ADMIN_KEY`, `GITHUB_TOKEN`, `TESTS_REPO_URL`, Jira credentials, `REPORTPORTAL_URL`, `REPORTPORTAL_API_TOKEN`, `REPORTPORTAL_PROJECT`) — these use deployment config, not per-request overrides
 
 ### Sensitive Data Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ When adding a new analysis setting:
 5. Add the field to `ServerConfig` in `cli/config.py`
 
 Exceptions (server-level only, no payload equivalent):
-- `ADMIN_KEY` — server-only bootstrap secret for admin superuser authentication; never expose via request payloads, CLI flags, or shared config files
+- `ADMIN_KEY` — server-only bootstrap secret for admin superuser authentication; never expose via request payloads, CLI flags, or shared config files. Rotating `ADMIN_KEY` only affects the bootstrap admin login — delegated admin API keys use `JJI_ENCRYPTION_KEY` for HMAC hashing and are not affected by `ADMIN_KEY` rotation.
 - `DEBUG` — server reload toggle
 - `ENABLE_GITHUB_ISSUES` — server capability toggle for GitHub issue creation
 - `ENABLE_REPORTPORTAL` — server capability toggle for Report Portal integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Exceptions (server-level only, no payload equivalent):
 - `LOG_LEVEL` — server log verbosity
 - `PUBLIC_BASE_URL` — trusted server-only origin for building absolute links; never derive from request headers to prevent host-header injection
 - `SECURE_COOKIES` — server-only deployment toggle for HTTPS cookie flags (default: True, set False for local HTTP dev)
-- Security-sensitive credentials for preview/create-issue endpoints (`ADMIN_KEY`, `GITHUB_TOKEN`, `TESTS_REPO_URL`, Jira credentials, `REPORTPORTAL_URL`, `REPORTPORTAL_API_TOKEN`, `REPORTPORTAL_PROJECT`) — these use deployment config, not per-request overrides
+- Security-sensitive credentials for preview/create-issue endpoints (`GITHUB_TOKEN`, `TESTS_REPO_URL`, Jira credentials, `REPORTPORTAL_URL`, `REPORTPORTAL_API_TOKEN`, `REPORTPORTAL_PROJECT`) — these use deployment config, not per-request overrides
 
 ### Sensitive Data Handling
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 
+import { AuthProvider } from '@/lib/auth'
 import { Layout } from '@/components/layout/Layout'
 import { ProtectedRoute } from '@/components/shared/ProtectedRoute'
 
@@ -10,22 +11,26 @@ import { SettingsPage } from '@/pages/SettingsPage'
 import { HistoryPage } from '@/pages/HistoryPage'
 import { ReportPage } from '@/pages/ReportPage'
 import { TestHistoryPage } from '@/pages/TestHistoryPage'
+import { UsersPage } from '@/pages/UsersPage'
 
 export default function App() {
   return (
-    <BrowserRouter basename="/">
-      <Routes>
-        <Route path="/register" element={<RegisterPage />} />
-        <Route element={<Layout />}>
-          <Route index element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
-          <Route path="/dashboard" element={<Navigate to="/" replace />} />
-          <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
-          <Route path="/history/test/:testName" element={<ProtectedRoute><TestHistoryPage /></ProtectedRoute>} />
-          <Route path="/results/:jobId" element={<ProtectedRoute><ReportPage /></ProtectedRoute>} />
-          <Route path="/status/:jobId" element={<ProtectedRoute><StatusPage /></ProtectedRoute>} />
-          <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter basename="/">
+        <Routes>
+          <Route path="/register" element={<RegisterPage />} />
+          <Route element={<Layout />}>
+            <Route index element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
+            <Route path="/dashboard" element={<Navigate to="/" replace />} />
+            <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
+            <Route path="/history/test/:testName" element={<ProtectedRoute><TestHistoryPage /></ProtectedRoute>} />
+            <Route path="/results/:jobId" element={<ProtectedRoute><ReportPage /></ProtectedRoute>} />
+            <Route path="/status/:jobId" element={<ProtectedRoute><StatusPage /></ProtectedRoute>} />
+            <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+            <Route path="/admin/users" element={<ProtectedRoute adminOnly><UsersPage /></ProtectedRoute>} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,15 +1,21 @@
 import { Link, useLocation } from 'react-router-dom'
 import { Bug } from 'lucide-react'
 import { UserBadge } from './UserBadge'
+import { useAuth } from '@/lib/auth'
 import { cn } from '@/lib/utils'
 
-const NAV_LINKS = [
+const BASE_NAV_LINKS = [
   { to: '/', label: 'Dashboard' },
   { to: '/history', label: 'History' },
 ]
 
 export function NavBar() {
   const location = useLocation()
+  const { isAdmin } = useAuth()
+
+  const navLinks = isAdmin
+    ? [...BASE_NAV_LINKS, { to: '/admin/users', label: 'Users' }]
+    : BASE_NAV_LINKS
 
   return (
     <header className="sticky top-0 z-50 border-b border-border-default bg-surface-card/95 backdrop-blur-sm">
@@ -22,7 +28,7 @@ export function NavBar() {
             JJI
           </Link>
           <nav className="flex items-center gap-1">
-            {NAV_LINKS.map(({ to, label }) => (
+            {navLinks.map(({ to, label }) => (
               <Link
                 key={to}
                 to={to}

--- a/frontend/src/components/layout/UserBadge.tsx
+++ b/frontend/src/components/layout/UserBadge.tsx
@@ -1,22 +1,30 @@
 import { useNavigate } from 'react-router-dom'
-import { getUsername, clearUsername, clearTokens } from '@/lib/cookies'
-import { LogOut, Settings } from 'lucide-react'
+import { useAuth } from '@/lib/auth'
+import { LogOut, Settings, Shield } from 'lucide-react'
 
 export function UserBadge() {
-  const username = getUsername()
+  const { username, isAdmin, logout } = useAuth()
   const navigate = useNavigate()
   if (!username) return null
 
-  function handleLogout() {
-    clearUsername()
-    clearTokens()
+  async function handleLogout() {
+    await logout()
     navigate('/register')
   }
 
   return (
     <div className="flex items-center gap-2 rounded-full bg-surface-elevated px-3 py-1 text-sm text-text-secondary">
-      <div className="h-2 w-2 rounded-full bg-signal-green" />
+      {isAdmin ? (
+        <Shield className="h-3 w-3 text-signal-amber" />
+      ) : (
+        <div className="h-2 w-2 rounded-full bg-signal-green" />
+      )}
       <span className="font-mono text-xs">{username}</span>
+      {isAdmin && (
+        <span className="rounded bg-signal-amber/10 px-1 py-px text-[10px] font-medium text-signal-amber">
+          Admin
+        </span>
+      )}
       <button type="button" aria-label="Settings" onClick={() => navigate('/settings')}
         className="ml-1 rounded-sm p-0.5 text-text-tertiary transition-colors hover:text-signal-blue" title="Settings">
         <Settings className="h-3 w-3" />

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -61,6 +61,16 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
   )
 }
 
+function persistTokensToServer(gh: string, je: string, jt: string) {
+  api.put('/api/user/tokens', {
+    github_token: gh,
+    jira_email: je,
+    jira_token: jt,
+  }).catch((err) => {
+    console.error('Failed to sync tokens to server:', err)
+  })
+}
+
 export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [username, setUsernameValue] = useState(getUsername())
   const [apiKey, setApiKey] = useState('')
@@ -95,14 +105,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         setGithubToken(githubToken.trim())
         setJiraEmail(jiraEmail.trim())
         setJiraToken(jiraToken.trim())
-        // Persist tokens server-side (fire and forget)
-        api.put('/api/user/tokens', {
-          github_token: githubToken.trim(),
-          jira_email: jiraEmail.trim(),
-          jira_token: jiraToken.trim(),
-        }).catch(() => {
-          // Server save failed — tokens still in localStorage
-        })
+        persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
         setSaving(false)
         onSaved()
         return
@@ -136,14 +139,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     setGithubToken(githubToken.trim())
     setJiraEmail(jiraEmail.trim())
     setJiraToken(jiraToken.trim())
-    // Persist tokens server-side (fire and forget)
-    api.put('/api/user/tokens', {
-      github_token: githubToken.trim(),
-      jira_email: jiraEmail.trim(),
-      jira_token: jiraToken.trim(),
-    }).catch(() => {
-      // Server save failed — tokens still in localStorage
-    })
+    persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
     setSaving(false)
     onSaved()
   }
@@ -204,31 +200,35 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
             />
           </div>
 
-          {/* Admin Authentication Divider */}
-          <div className="flex items-center gap-3 py-1">
-            <div className="h-px flex-1 bg-border-muted" />
-            <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
-              Admin Authentication
-            </span>
-            <div className="h-px flex-1 bg-border-muted" />
-          </div>
-          <p className="text-xs text-text-tertiary">
-            Provide your API key for admin access. Leave empty for regular user access.
-          </p>
+          {onAdminLogin && (
+            <>
+              {/* Admin Authentication Divider */}
+              <div className="flex items-center gap-3 py-1">
+                <div className="h-px flex-1 bg-border-muted" />
+                <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
+                  Admin Authentication
+                </span>
+                <div className="h-px flex-1 bg-border-muted" />
+              </div>
+              <p className="text-xs text-text-tertiary">
+                Provide your API key for admin access. Leave empty for regular user access.
+              </p>
 
-          {/* API Key field */}
-          <TokenField
-            id="api-key"
-            label="API Key"
-            value={apiKey}
-            onChange={(v) => { setApiKey(v); setApiKeyError(null) }}
-            show={showApiKey}
-            onToggleShow={() => setShowApiKey(!showApiKey)}
-            validation={null}
-            error={apiKeyError}
-            placeholder="Enter API key..."
-            helpContent={<>Admin API key provided by your server administrator.</>}
-          />
+              {/* API Key field */}
+              <TokenField
+                id="api-key"
+                label="API Key"
+                value={apiKey}
+                onChange={(v) => { setApiKey(v); setApiKeyError(null) }}
+                show={showApiKey}
+                onToggleShow={() => setShowApiKey(!showApiKey)}
+                validation={null}
+                error={apiKeyError}
+                placeholder="Enter API key..."
+                helpContent={<>Admin API key provided by your server administrator.</>}
+              />
+            </>
+          )}
 
           {/* Tracker Tokens Divider */}
           <div className="flex items-center gap-3 py-1">

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -61,15 +61,16 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
   )
 }
 
-function persistTokensToServer(gh: string, je: string, jt: string) {
-  const body: Record<string, string> = {}
-  if (gh) body.github_token = gh
-  if (je) body.jira_email = je
-  if (jt) body.jira_token = jt
-  if (Object.keys(body).length === 0) return
-  api.put('/api/user/tokens', body).catch((err) => {
+async function persistTokensToServer(gh: string, je: string, jt: string) {
+  try {
+    await api.put('/api/user/tokens', {
+      github_token: gh,
+      jira_email: je,
+      jira_token: jt,
+    })
+  } catch (err) {
     console.error('Failed to sync tokens to server:', err)
-  })
+  }
 }
 
 export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
@@ -106,7 +107,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         setGithubToken(githubToken.trim())
         setJiraEmail(jiraEmail.trim())
         setJiraToken(jiraToken.trim())
-        persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+        await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
         setSaving(false)
         onSaved()
         return
@@ -140,7 +141,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     setGithubToken(githubToken.trim())
     setJiraEmail(jiraEmail.trim())
     setJiraToken(jiraToken.trim())
-    persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+    await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
     setSaving(false)
     onSaved()
   }

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -62,11 +62,12 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
 }
 
 function persistTokensToServer(gh: string, je: string, jt: string) {
-  api.put('/api/user/tokens', {
-    github_token: gh,
-    jira_email: je,
-    jira_token: jt,
-  }).catch((err) => {
+  const body: Record<string, string> = {}
+  if (gh) body.github_token = gh
+  if (je) body.jira_email = je
+  if (jt) body.jira_token = jt
+  if (Object.keys(body).length === 0) return
+  api.put('/api/user/tokens', body).catch((err) => {
     console.error('Failed to sync tokens to server:', err)
   })
 }

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent, type ReactNode } from 'react'
-import { api } from '@/lib/api'
+import { api, ApiError } from '@/lib/api'
 import {
   setUsername,
   setGithubToken,
@@ -16,7 +16,8 @@ import { Button } from '@/components/ui/button'
 import { Eye, EyeOff } from 'lucide-react'
 
 interface ProfileFormProps {
-  onSaved: () => void
+  onSaved: () => void | Promise<void>
+  onAdminLogin?: (username: string, apiKey: string) => Promise<void>
 }
 
 interface TokenValidationResult {
@@ -25,7 +26,7 @@ interface TokenValidationResult {
   message: string
 }
 
-function TokenField({ id, label, value, onChange, show, onToggleShow, validation, placeholder, helpContent }: {
+function TokenField({ id, label, value, onChange, show, onToggleShow, validation, error, placeholder, helpContent, optionalLabel = true }: {
   id: string
   label: string
   value: string
@@ -33,13 +34,15 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
   show: boolean
   onToggleShow: () => void
   validation: TokenValidationResult | null
+  error?: string | null
   placeholder: string
   helpContent: ReactNode
+  optionalLabel?: boolean
 }) {
   return (
     <div className="space-y-1.5">
       <label htmlFor={id} className="block font-display text-xs font-medium uppercase tracking-widest text-text-secondary">
-        {label} <span className="text-text-tertiary font-normal normal-case tracking-normal">(optional)</span>
+        {label} {optionalLabel && <span className="text-text-tertiary font-normal normal-case tracking-normal">(optional)</span>}
       </label>
       <div className="relative">
         <Input id={id} type={show ? 'text' : 'password'} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} autoComplete="off" className="h-10 pr-10 font-mono" />
@@ -50,13 +53,19 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
       {validation && (
         <p className={`text-xs ${validation.valid ? 'text-signal-green' : 'text-signal-red'}`}>{validation.message}</p>
       )}
+      {error && (
+        <p className="text-xs text-signal-red">{error}</p>
+      )}
       <p className="text-xs text-text-tertiary">{helpContent}</p>
     </div>
   )
 }
 
-export function ProfileForm({ onSaved }: ProfileFormProps) {
+export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [username, setUsernameValue] = useState(getUsername())
+  const [apiKey, setApiKey] = useState('')
+  const [showApiKey, setShowApiKey] = useState(false)
+  const [apiKeyError, setApiKeyError] = useState<string | null>(null)
   const [githubToken, setGithubTokenValue] = useState(getGithubToken())
   const [jiraEmail, setJiraEmailValue] = useState(getJiraEmail())
   const [jiraToken, setJiraTokenValue] = useState(getJiraToken())
@@ -74,20 +83,51 @@ export function ProfileForm({ onSaved }: ProfileFormProps) {
     const trimmed = username.trim()
     if (!trimmed) return
 
+    setSaving(true)
+    setApiKeyError(null)
+
+    // Try admin login if API key is provided
+    if (apiKey.trim() && onAdminLogin) {
+      try {
+        await onAdminLogin(trimmed, apiKey.trim())
+        // Admin login succeeded — also save the username cookie
+        setUsername(trimmed)
+        setGithubToken(githubToken.trim())
+        setJiraEmail(jiraEmail.trim())
+        setJiraToken(jiraToken.trim())
+        // Persist tokens server-side (fire and forget)
+        api.put('/api/user/tokens', {
+          github_token: githubToken.trim(),
+          jira_email: jiraEmail.trim(),
+          jira_token: jiraToken.trim(),
+        }).catch(() => {
+          // Server save failed — tokens still in localStorage
+        })
+        setSaving(false)
+        onSaved()
+        return
+      } catch (err) {
+        setSaving(false)
+        if (err instanceof ApiError && err.status === 401) {
+          setApiKeyError('Invalid username or API key')
+        } else {
+          setApiKeyError('Login failed — please try again')
+        }
+        return
+      }
+    }
+
     const needsGithubValidation = githubToken.trim() && (!githubValidation || !githubValidation.valid)
     const needsJiraValidation = jiraToken.trim() && (!jiraValidation || !jiraValidation.valid)
 
     if (needsGithubValidation || needsJiraValidation) {
-      setSaving(true)
       const validations = await Promise.allSettled([
         needsGithubValidation ? validateGithub() : Promise.resolve(),
         needsJiraValidation ? validateJira() : Promise.resolve(),
       ])
       setSaving(false)
 
-      // Check if any validation failed — block save
       const results = validations.map((r) => r.status === 'fulfilled' ? r.value : false)
-      // validateGithub/validateJira return true if valid, false if invalid
       if (needsGithubValidation && results[0] === false) return
       if (needsJiraValidation && results[1] === false) return
     }
@@ -96,6 +136,15 @@ export function ProfileForm({ onSaved }: ProfileFormProps) {
     setGithubToken(githubToken.trim())
     setJiraEmail(jiraEmail.trim())
     setJiraToken(jiraToken.trim())
+    // Persist tokens server-side (fire and forget)
+    api.put('/api/user/tokens', {
+      github_token: githubToken.trim(),
+      jira_email: jiraEmail.trim(),
+      jira_token: jiraToken.trim(),
+    }).catch(() => {
+      // Server save failed — tokens still in localStorage
+    })
+    setSaving(false)
     onSaved()
   }
 
@@ -155,7 +204,33 @@ export function ProfileForm({ onSaved }: ProfileFormProps) {
             />
           </div>
 
-          {/* Divider */}
+          {/* Admin Authentication Divider */}
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-px flex-1 bg-border-muted" />
+            <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
+              Admin Authentication
+            </span>
+            <div className="h-px flex-1 bg-border-muted" />
+          </div>
+          <p className="text-xs text-text-tertiary">
+            Provide your API key for admin access. Leave empty for regular user access.
+          </p>
+
+          {/* API Key field */}
+          <TokenField
+            id="api-key"
+            label="API Key"
+            value={apiKey}
+            onChange={(v) => { setApiKey(v); setApiKeyError(null) }}
+            show={showApiKey}
+            onToggleShow={() => setShowApiKey(!showApiKey)}
+            validation={null}
+            error={apiKeyError}
+            placeholder="Enter API key..."
+            helpContent={<>Admin API key provided by your server administrator.</>}
+          />
+
+          {/* Tracker Tokens Divider */}
           <div className="flex items-center gap-3 py-1">
             <div className="h-px flex-1 bg-border-muted" />
             <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
@@ -224,7 +299,7 @@ export function ProfileForm({ onSaved }: ProfileFormProps) {
           />
 
           <Button type="submit" className="w-full" disabled={!username.trim() || saving || validatingGithub || validatingJira}>
-            {saving ? 'Validating tokens...' : 'Save'}
+            {saving ? 'Saving...' : 'Save'}
           </Button>
           </fieldset>
         </form>

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -98,18 +98,22 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     setSaving(true)
     setApiKeyError(null)
 
+    async function commitProfile(trimmedUsername: string) {
+      setUsername(trimmedUsername)
+      setGithubToken(githubToken.trim())
+      setJiraEmail(jiraEmail.trim())
+      setJiraToken(jiraToken.trim())
+      await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+    }
+
     // Try admin login if API key is provided
     if (apiKey.trim() && onAdminLogin) {
       try {
         await onAdminLogin(trimmed, apiKey.trim())
         // Admin login succeeded — also save the username cookie
-        setUsername(trimmed)
-        setGithubToken(githubToken.trim())
-        setJiraEmail(jiraEmail.trim())
-        setJiraToken(jiraToken.trim())
-        await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+        await commitProfile(trimmed)
         setSaving(false)
-        onSaved()
+        await onSaved()
         return
       } catch (err) {
         setSaving(false)
@@ -130,20 +134,15 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         needsGithubValidation ? validateGithub() : Promise.resolve(),
         needsJiraValidation ? validateJira() : Promise.resolve(),
       ])
-      setSaving(false)
 
       const results = validations.map((r) => r.status === 'fulfilled' ? r.value : false)
-      if (needsGithubValidation && results[0] === false) return
-      if (needsJiraValidation && results[1] === false) return
+      if (needsGithubValidation && results[0] === false) { setSaving(false); return }
+      if (needsJiraValidation && results[1] === false) { setSaving(false); return }
     }
 
-    setUsername(trimmed)
-    setGithubToken(githubToken.trim())
-    setJiraEmail(jiraEmail.trim())
-    setJiraToken(jiraToken.trim())
-    await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+    await commitProfile(trimmed)
     setSaving(false)
-    onSaved()
+    await onSaved()
   }
 
   async function validateToken(

--- a/frontend/src/components/shared/ProtectedRoute.tsx
+++ b/frontend/src/components/shared/ProtectedRoute.tsx
@@ -8,15 +8,18 @@ interface Props {
 }
 
 export function ProtectedRoute({ children, adminOnly }: Props) {
-  const { isAdmin, loading } = useAuth()
+  const { isAdmin, loading, username } = useAuth()
 
-  if (!isLoggedIn()) {
+  // Wait for auth to resolve before any redirect
+  if (loading) return null
+
+  // Use auth context username (resolves from session OR cookie)
+  if (!username && !isLoggedIn()) {
     return <Navigate to="/register" replace />
   }
 
-  if (adminOnly) {
-    if (loading) return null  // Prevent flash while checking admin status
-    if (!isAdmin) return <Navigate to="/" replace />
+  if (adminOnly && !isAdmin) {
+    return <Navigate to="/" replace />
   }
 
   return <>{children}</>

--- a/frontend/src/components/shared/ProtectedRoute.tsx
+++ b/frontend/src/components/shared/ProtectedRoute.tsx
@@ -1,9 +1,23 @@
 import { Navigate } from 'react-router-dom'
 import { isLoggedIn } from '@/lib/cookies'
+import { useAuth } from '@/lib/auth'
 
-export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+interface Props {
+  children: React.ReactNode
+  adminOnly?: boolean
+}
+
+export function ProtectedRoute({ children, adminOnly }: Props) {
+  const { isAdmin, loading } = useAuth()
+
   if (!isLoggedIn()) {
     return <Navigate to="/register" replace />
   }
+
+  if (adminOnly) {
+    if (loading) return null  // Prevent flash while checking admin status
+    if (!isAdmin) return <Navigate to="/" replace />
+  }
+
   return <>{children}</>
 }

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -14,6 +14,18 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null)
 
+async function syncTokensFromServer(forUsername: string) {
+  if (!forUsername) return
+  try {
+    const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+    if (tokens.github_token) setGithubToken(tokens.github_token)
+    if (tokens.jira_email) setJiraEmail(tokens.jira_email)
+    if (tokens.jira_token) setJiraToken(tokens.jira_token)
+  } catch {
+    // Server tokens not available — keep localStorage values
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [username, setUsernameState] = useState(getUsername())
   const [isAdmin, setIsAdminState] = useState(getIsAdmin())
@@ -31,17 +43,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (me.username) {
         setUsername(me.username)
       }
-      // Sync tokens from server to localStorage
-      if (me.username) {
-        try {
-          const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-          if (tokens.github_token) setGithubToken(tokens.github_token)
-          if (tokens.jira_email) setJiraEmail(tokens.jira_email)
-          if (tokens.jira_token) setJiraToken(tokens.jira_token)
-        } catch {
-          // Server tokens not available — keep localStorage values
-        }
-      }
+      await syncTokensFromServer(me.username)
     } catch {
       // Any error means no valid admin session — fall back to cookie identity
       const cookieUsername = getUsername()
@@ -50,17 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRoleState('user')
       setIsAdmin(false)
       setRole('user')
-      // Sync tokens from server to localStorage for cookie-based users
-      if (cookieUsername) {
-        try {
-          const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-          if (tokens.github_token) setGithubToken(tokens.github_token)
-          if (tokens.jira_email) setJiraEmail(tokens.jira_email)
-          if (tokens.jira_token) setJiraToken(tokens.jira_token)
-        } catch {
-          // Server tokens not available — keep localStorage values
-        }
-      }
+      await syncTokensFromServer(cookieUsername)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,0 +1,113 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
+import { api, ApiError } from './api'
+import { getUsername, setUsername, getIsAdmin, setIsAdmin, setRole, clearTokens, clearUsername, setGithubToken, setJiraEmail, setJiraToken } from './cookies'
+
+interface AuthState {
+  username: string
+  isAdmin: boolean
+  role: string
+  loading: boolean
+  login: (username: string, apiKey: string) => Promise<void>
+  logout: () => Promise<void>
+  refreshAuth: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthState | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [username, setUsernameState] = useState(getUsername())
+  const [isAdmin, setIsAdminState] = useState(getIsAdmin())
+  const [role, setRoleState] = useState('user')
+  const [loading, setLoading] = useState(true)
+
+  const refreshAuth = useCallback(async () => {
+    try {
+      const me = await api.get<{ username: string; role: string; is_admin: boolean }>('/api/auth/me')
+      setUsernameState(me.username)
+      setIsAdminState(me.is_admin)
+      setRoleState(me.role)
+      setIsAdmin(me.is_admin)
+      setRole(me.role)
+      if (me.username) {
+        setUsername(me.username)
+      }
+      // Sync tokens from server to localStorage
+      if (me.username) {
+        try {
+          const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+          if (tokens.github_token) setGithubToken(tokens.github_token)
+          if (tokens.jira_email) setJiraEmail(tokens.jira_email)
+          if (tokens.jira_token) setJiraToken(tokens.jira_token)
+        } catch {
+          // Server tokens not available — keep localStorage values
+        }
+      }
+    } catch {
+      // Any error means no valid admin session — fall back to cookie identity
+      const cookieUsername = getUsername()
+      setUsernameState(cookieUsername)
+      setIsAdminState(false)
+      setRoleState('user')
+      setIsAdmin(false)
+      setRole('user')
+      // Sync tokens from server to localStorage for cookie-based users
+      if (cookieUsername) {
+        try {
+          const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+          if (tokens.github_token) setGithubToken(tokens.github_token)
+          if (tokens.jira_email) setJiraEmail(tokens.jira_email)
+          if (tokens.jira_token) setJiraToken(tokens.jira_token)
+        } catch {
+          // Server tokens not available — keep localStorage values
+        }
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refreshAuth()
+  }, [refreshAuth])
+
+  const login = useCallback(async (loginUsername: string, apiKey: string) => {
+    const result = await api.post<{ username: string; role: string; is_admin: boolean }>(
+      '/api/auth/login',
+      { username: loginUsername, api_key: apiKey }
+    )
+    setUsernameState(result.username)
+    setIsAdminState(result.is_admin)
+    setRoleState(result.role)
+    setUsername(result.username)
+    setIsAdmin(result.is_admin)
+    setRole(result.role)
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      await api.post('/api/auth/logout')
+    } catch {
+      // ignore
+    }
+    setIsAdminState(false)
+    setRoleState('user')
+    setIsAdmin(false)
+    setRole('user')
+    clearTokens()
+    clearUsername()
+    // Reset username state to empty
+    setUsernameState('')
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ username, isAdmin, role, loading, login, logout, refreshAuth }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -18,9 +18,9 @@ async function syncTokensFromServer(forUsername: string) {
   if (!forUsername) return
   try {
     const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-    if (tokens.github_token) setGithubToken(tokens.github_token)
-    if (tokens.jira_email) setJiraEmail(tokens.jira_email)
-    if (tokens.jira_token) setJiraToken(tokens.jira_token)
+    setGithubToken(tokens.github_token)
+    setJiraEmail(tokens.jira_email)
+    setJiraToken(tokens.jira_token)
   } catch {
     // Server tokens not available — keep localStorage values
   }

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -2,6 +2,8 @@ const COOKIE_NAME = 'jji_username'
 const GITHUB_TOKEN_KEY = 'jji_github_token'
 const JIRA_TOKEN_KEY = 'jji_jira_token'
 const JIRA_EMAIL_KEY = 'jji_jira_email'
+const ADMIN_KEY = 'jji_is_admin'
+const ROLE_KEY = 'jji_role'
 
 export function getUsername(): string {
   const match = document.cookie.match(
@@ -68,11 +70,53 @@ export function setJiraEmail(email: string): void {
   writeStoredValue(JIRA_EMAIL_KEY, email)
 }
 
+export function getIsAdmin(): boolean {
+  try {
+    return localStorage.getItem(ADMIN_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function setIsAdmin(isAdmin: boolean): void {
+  try {
+    if (isAdmin) {
+      localStorage.setItem(ADMIN_KEY, 'true')
+    } else {
+      localStorage.removeItem(ADMIN_KEY)
+    }
+  } catch {
+    // ignore
+  }
+}
+
+export function getRole(): string {
+  try {
+    return localStorage.getItem(ROLE_KEY) ?? 'user'
+  } catch {
+    return 'user'
+  }
+}
+
+export function setRole(role: string): void {
+  try {
+    if (role && role !== 'user') {
+      localStorage.setItem(ROLE_KEY, role)
+    } else {
+      localStorage.removeItem(ROLE_KEY)
+    }
+  } catch {
+    // ignore
+  }
+}
+
 export function clearTokens(): void {
   try {
     localStorage.removeItem(GITHUB_TOKEN_KEY)
     localStorage.removeItem(JIRA_TOKEN_KEY)
     localStorage.removeItem(JIRA_EMAIL_KEY)
+    localStorage.removeItem(ADMIN_KEY)
+    localStorage.removeItem(ROLE_KEY)
   } catch {
     // Storage unavailable — silently ignore
   }

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -2,6 +2,8 @@ const COOKIE_NAME = 'jji_username'
 const GITHUB_TOKEN_KEY = 'jji_github_token'
 const JIRA_TOKEN_KEY = 'jji_jira_token'
 const JIRA_EMAIL_KEY = 'jji_jira_email'
+// Display-only UI hints — NOT an authorization boundary.
+// All admin gating is enforced server-side in AuthMiddleware.
 const ADMIN_KEY = 'jji_is_admin'
 const ROLE_KEY = 'jji_role'
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -33,6 +33,7 @@ import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
 import { useTableSort } from '@/lib/useTableSort'
 import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle } from 'lucide-react'
+import { useAuth } from '@/lib/auth'
 
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
@@ -96,6 +97,7 @@ function getJobDisplayName(job: DashboardJob | null | undefined): string {
 
 export function DashboardPage() {
   const navigate = useNavigate()
+  const { isAdmin } = useAuth()
   const [jobs, setJobs] = useState<DashboardJob[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
@@ -276,9 +278,11 @@ export function DashboardPage() {
                 <SortableHeader label="Comments" sortKey="comment_count" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-center" />
                 <SortableHeader label="Children" sortKey="child_job_count" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-center" />
                 <SortableHeader label="Created" sortKey="created_at" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
-                <TableHead className="w-10">
-                  <span className="sr-only">Actions</span>
-                </TableHead>
+                {isAdmin && (
+                  <TableHead className="w-10">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -397,21 +401,23 @@ export function DashboardPage() {
                     </TableCell>
 
                     {/* Delete */}
-                    <TableCell>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Delete analysis ${getJobDisplayName(job)}`}
-                        className="h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setDeleteTarget(job)
-                        }}
-                      >
-                        <Trash2 className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-red" />
-                      </Button>
-                    </TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Delete analysis ${getJobDisplayName(job)}`}
+                          className="h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setDeleteTarget(job)
+                          }}
+                        >
+                          <Trash2 className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-red" />
+                        </Button>
+                      </TableCell>
+                    )}
                   </TableRow>
                 )
               })}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom'
 import { ProfileForm } from '@/components/shared/ProfileForm'
+import { useAuth } from '@/lib/auth'
 
 export function RegisterPage() {
   const navigate = useNavigate()
+  const { login, refreshAuth } = useAuth()
 
   return (
     <div className="relative flex min-h-screen items-center justify-center bg-surface-page overflow-hidden">
@@ -23,10 +25,14 @@ export function RegisterPage() {
         </div>
         {/* Form */}
         <div className="animate-slide-up [animation-delay:80ms] [animation-fill-mode:backwards]">
-          <ProfileForm onSaved={() => navigate('/')} />
+          <ProfileForm
+            onSaved={async () => { await refreshAuth(); navigate('/') }}
+            onAdminLogin={async (u, k) => { await login(u, k) }}
+          />
         </div>
         <p className="mt-6 animate-slide-up text-center text-xs text-text-tertiary [animation-delay:160ms] [animation-fill-mode:backwards]">
-          Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.<br />No account or password required.
+          Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.<br />
+          Admin API key enables admin features via server-side session.
         </p>
       </div>
     </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -31,7 +31,7 @@ export function RegisterPage() {
           />
         </div>
         <p className="mt-6 animate-slide-up text-center text-xs text-text-tertiary [animation-delay:160ms] [animation-fill-mode:backwards]">
-          Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.<br />
+          Tokens are stored locally and synced to the server (encrypted at rest) for cross-browser access.<br />
           Admin API key enables admin features via server-side session.
         </p>
       </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -23,7 +23,7 @@ export function SettingsPage() {
         onAdminLogin={async (u, k) => { await login(u, k) }}
       />
       <p className="mt-4 text-center text-xs text-text-tertiary">
-        Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.
+        Tokens are stored locally and synced to the server (encrypted at rest) for cross-browser access.
       </p>
     </div>
   )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,13 +1,27 @@
 import { useNavigate } from 'react-router-dom'
 import { ProfileForm } from '@/components/shared/ProfileForm'
+import { useAuth } from '@/lib/auth'
+import { Shield } from 'lucide-react'
 
 export function SettingsPage() {
   const navigate = useNavigate()
+  const { isAdmin, role, login, refreshAuth } = useAuth()
 
   return (
     <div className="mx-auto max-w-md">
-      <h1 className="mb-6 font-display text-lg font-bold tracking-tight text-text-primary">Settings</h1>
-      <ProfileForm onSaved={() => navigate('/')} />
+      <div className="mb-6 flex items-center gap-3">
+        <h1 className="font-display text-lg font-bold tracking-tight text-text-primary">Settings</h1>
+        {isAdmin && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-signal-amber/10 px-2 py-0.5 text-xs font-medium text-signal-amber">
+            <Shield className="h-3 w-3" />
+            {role}
+          </span>
+        )}
+      </div>
+      <ProfileForm
+        onSaved={async () => { await refreshAuth(); navigate('/') }}
+        onAdminLogin={async (u, k) => { await login(u, k) }}
+      />
       <p className="mt-4 text-center text-xs text-text-tertiary">
         Tokens are stored locally in your browser and sent only when validating, previewing, or creating issues.
       </p>

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,0 +1,486 @@
+import { useCallback, useEffect, useState } from 'react'
+import { api, ApiError } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Copy, Check, RefreshCw, Trash2, UserPlus, Shield } from 'lucide-react'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import { formatTimestamp } from '@/lib/utils'
+import type { AdminUser, CreateUserResponse, RotateKeyResponse, ChangeRoleResponse } from '@/types'
+
+function CopyableKey({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // fallback: select text
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-text-secondary">{label}</p>
+      <div className="flex items-center gap-2 rounded-md border border-border-muted bg-surface-elevated px-3 py-2">
+        <code className="flex-1 break-all font-mono text-xs text-text-primary">{value}</code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="shrink-0 rounded p-1 text-text-tertiary transition-colors hover:text-text-secondary"
+          aria-label="Copy to clipboard"
+        >
+          {copied ? <Check className="h-4 w-4 text-signal-green" /> : <Copy className="h-4 w-4" />}
+        </button>
+      </div>
+      <p className="text-xs text-signal-amber">
+        ⚠ Save this key now — it cannot be retrieved later.
+      </p>
+    </div>
+  )
+}
+
+export function UsersPage() {
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Create dialog
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newUsername, setNewUsername] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [createdUser, setCreatedUser] = useState<CreateUserResponse | null>(null)
+
+  // Rotate key dialog
+  const [rotateTarget, setRotateTarget] = useState<string | null>(null)
+  const [rotating, setRotating] = useState(false)
+  const [rotatedKey, setRotatedKey] = useState<RotateKeyResponse | null>(null)
+
+  // Change role dialog
+  const [roleChangeTarget, setRoleChangeTarget] = useState<{ username: string; currentRole: string; newRole: string } | null>(null)
+  const [changingRole, setChangingRole] = useState(false)
+  const [roleChangeResult, setRoleChangeResult] = useState<ChangeRoleResponse | null>(null)
+
+  // Delete dialog
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  // Action error
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      const data = await api.get<{ users: AdminUser[] }>('/api/admin/users')
+      setUsers(data.users)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load users')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetchUsers() }, [fetchUsers])
+
+  async function handleCreate() {
+    const trimmed = newUsername.trim()
+    if (!trimmed) return
+    setCreating(true)
+    setCreateError(null)
+    try {
+      const result = await api.post<CreateUserResponse>('/api/admin/users', { username: trimmed })
+      setCreatedUser(result)
+      fetchUsers()
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { detail?: string } | null
+        setCreateError(body?.detail ?? `Failed to create user (${err.status})`)
+      } else {
+        setCreateError('Failed to create user')
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleRotateKey() {
+    if (!rotateTarget) return
+    setRotating(true)
+    setActionError(null)
+    try {
+      const result = await api.post<RotateKeyResponse>(`/api/admin/users/${encodeURIComponent(rotateTarget)}/rotate-key`)
+      setRotatedKey(result)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { detail?: string } | null
+        setActionError(body?.detail ?? `Failed to rotate key (${err.status})`)
+      } else {
+        setActionError('Failed to rotate key')
+      }
+    } finally {
+      setRotating(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+    setDeleting(true)
+    setActionError(null)
+    try {
+      await api.delete(`/api/admin/users/${encodeURIComponent(deleteTarget)}`)
+      setUsers((prev) => prev.filter((u) => u.username !== deleteTarget))
+      setDeleteTarget(null)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { detail?: string } | null
+        setActionError(body?.detail ?? `Failed to delete user (${err.status})`)
+      } else {
+        setActionError('Failed to delete user')
+      }
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  function closeCreateDialog() {
+    setCreateOpen(false)
+    setNewUsername('')
+    setCreateError(null)
+    setCreatedUser(null)
+  }
+
+  function closeRotateDialog() {
+    setRotateTarget(null)
+    setRotatedKey(null)
+    setActionError(null)
+  }
+
+  async function handleChangeRole() {
+    if (!roleChangeTarget) return
+    setChangingRole(true)
+    setActionError(null)
+    const newRole = roleChangeTarget.newRole
+    try {
+      const result = await api.put<ChangeRoleResponse>(
+        `/api/admin/users/${encodeURIComponent(roleChangeTarget.username)}/role`,
+        { role: newRole }
+      )
+      setRoleChangeResult(result)
+      fetchUsers()
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { detail?: string } | null
+        setActionError(body?.detail ?? `Failed to change role (${err.status})`)
+      } else {
+        setActionError('Failed to change role')
+      }
+    } finally {
+      setChangingRole(false)
+    }
+  }
+
+  function closeRoleChangeDialog() {
+    setRoleChangeTarget(null)
+    setRoleChangeResult(null)
+    setActionError(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-xl font-bold text-text-primary">User Management</h1>
+          <p className="mt-0.5 text-sm text-text-tertiary">
+            {users.length} {users.length === 1 ? 'user' : 'users'}
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} className="gap-1.5">
+          <UserPlus className="h-4 w-4" />
+          Create Admin
+        </Button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p role="alert" className="text-center text-signal-red py-8">{error}</p>
+      )}
+      {actionError && (
+        <p role="alert" className="text-center text-signal-red text-sm py-2">{actionError}</p>
+      )}
+
+      {/* Table */}
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-11 w-full" />
+          ))}
+        </div>
+      ) : users.length === 0 && !error ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-border-muted bg-surface-card py-16 text-center">
+          <p className="text-text-secondary">No users yet.</p>
+        </div>
+      ) : !error && (
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-surface-card hover:bg-surface-card">
+              <TableHead>Username</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Last Seen</TableHead>
+              <TableHead className="w-40 text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user, i) => (
+              <TableRow
+                key={user.username}
+                className={i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}
+              >
+                <TableCell>
+                  <span className="inline-flex items-center gap-1.5 font-mono text-sm text-text-primary">
+                    {user.role === 'admin' ? (
+                      <Shield className="h-3.5 w-3.5 text-signal-amber" />
+                    ) : (
+                      <div className="h-2 w-2 rounded-full bg-signal-green" />
+                    )}
+                    {user.username}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  {user.role === 'admin' ? (
+                    <span className="inline-flex items-center rounded-full bg-signal-amber/10 px-2 py-0.5 text-xs font-medium text-signal-amber">
+                      admin
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center rounded-full bg-surface-elevated px-2 py-0.5 text-xs font-medium text-text-secondary">
+                      user
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="font-mono text-xs text-text-tertiary">
+                  {formatTimestamp(user.created_at)}
+                </TableCell>
+                <TableCell className="font-mono text-xs text-text-tertiary">
+                  {user.last_seen ? formatTimestamp(user.last_seen) : '—'}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    {/* Role select */}
+                    <Select
+                      value={user.role}
+                      onValueChange={(newRole) => {
+                        if (newRole !== user.role) {
+                          setRoleChangeTarget({ username: user.username, currentRole: user.role, newRole })
+                        }
+                      }}
+                    >
+                      <SelectTrigger className="h-7 w-[80px] text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="user">user</SelectItem>
+                        <SelectItem value="admin">admin</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {/* Rotate key — only for admins (regular users have no API key) */}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Rotate key for ${user.username}`}
+                      className={`h-7 w-7${user.role !== 'admin' ? ' invisible' : ''}`}
+                      title="Rotate API key"
+                      disabled={user.role !== 'admin'}
+                      onClick={() => setRotateTarget(user.username)}
+                    >
+                      <RefreshCw className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-blue" />
+                    </Button>
+                    {/* Delete */}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Delete ${user.username}`}
+                      className="h-7 w-7"
+                      title="Delete user"
+                      onClick={() => setDeleteTarget(user.username)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-red" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Create Admin Dialog */}
+      <Dialog open={createOpen} onOpenChange={(open) => { if (!open) closeCreateDialog() }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Admin User</DialogTitle>
+            <DialogDescription>
+              Create a new admin user. An API key will be generated automatically.
+            </DialogDescription>
+          </DialogHeader>
+          {createdUser ? (
+            <div className="space-y-4 py-2">
+              <p className="text-sm text-text-secondary">
+                Admin user <span className="font-mono font-medium text-text-primary">{createdUser.username}</span> created successfully.
+              </p>
+              <CopyableKey label="API Key" value={createdUser.api_key} />
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-1.5">
+                <label htmlFor="new-username" className="block text-sm font-medium text-text-secondary">
+                  Username
+                </label>
+                <Input
+                  id="new-username"
+                  value={newUsername}
+                  onChange={(e) => { setNewUsername(e.target.value); setCreateError(null) }}
+                  placeholder="e.g. admin"
+                  autoFocus
+                  className="font-mono"
+                />
+                {createError && (
+                  <p className="text-xs text-signal-red">{createError}</p>
+                )}
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            {createdUser ? (
+              <Button onClick={closeCreateDialog}>Done</Button>
+            ) : (
+              <>
+                <Button variant="ghost" onClick={closeCreateDialog} disabled={creating}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreate} disabled={!newUsername.trim() || creating}>
+                  {creating ? 'Creating...' : 'Create'}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rotate Key Dialog */}
+      <Dialog open={rotateTarget !== null} onOpenChange={(open) => { if (!open) closeRotateDialog() }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rotate API Key</DialogTitle>
+            <DialogDescription>
+              {rotatedKey
+                ? `New API key for ${rotatedKey.username}:`
+                : `Generate a new API key for "${rotateTarget}"? The old key will stop working immediately.`
+              }
+            </DialogDescription>
+          </DialogHeader>
+          {rotatedKey ? (
+            <div className="py-2">
+              <CopyableKey label="New API Key" value={rotatedKey.new_api_key} />
+            </div>
+          ) : null}
+          <DialogFooter>
+            {rotatedKey ? (
+              <Button onClick={closeRotateDialog}>Done</Button>
+            ) : (
+              <>
+                <Button variant="ghost" onClick={closeRotateDialog} disabled={rotating}>
+                  Cancel
+                </Button>
+                <Button onClick={handleRotateKey} disabled={rotating}>
+                  {rotating ? 'Rotating...' : 'Rotate Key'}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Change Role Dialog */}
+      <Dialog open={roleChangeTarget !== null} onOpenChange={(open) => { if (!open) closeRoleChangeDialog() }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {roleChangeTarget?.newRole === 'admin' ? 'Promote to Admin' : 'Demote to User'}
+            </DialogTitle>
+            <DialogDescription>
+              {roleChangeResult
+                ? (roleChangeResult.api_key
+                    ? `${roleChangeResult.username} is now an admin. Save the API key below.`
+                    : `${roleChangeResult.username} has been demoted to regular user.`)
+                : (roleChangeTarget?.newRole === 'admin'
+                    ? `Promote "${roleChangeTarget?.username}" to admin? An API key will be generated.`
+                    : `Demote "${roleChangeTarget?.username}" to regular user? Their API key will be revoked and admin sessions invalidated.`)
+              }
+            </DialogDescription>
+          </DialogHeader>
+          {roleChangeResult?.api_key ? (
+            <div className="py-2">
+              <CopyableKey label="API Key" value={roleChangeResult.api_key} />
+            </div>
+          ) : null}
+          <DialogFooter>
+            {roleChangeResult ? (
+              <Button onClick={closeRoleChangeDialog}>Done</Button>
+            ) : (
+              <>
+                <Button variant="ghost" onClick={closeRoleChangeDialog} disabled={changingRole}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleChangeRole}
+                  disabled={changingRole}
+                  variant={roleChangeTarget?.newRole === 'user' ? 'destructive' : 'default'}
+                >
+                  {changingRole
+                    ? 'Changing...'
+                    : (roleChangeTarget?.newRole === 'admin' ? 'Promote' : 'Demote')
+                  }
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirm Dialog */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}
+        title="Delete user"
+        description={`Permanently delete "${deleteTarget}"? This will revoke their admin access.`}
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={handleDelete}
+        loading={deleting}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -262,7 +262,7 @@ export function UsersPage() {
                     {user.role === 'admin' ? (
                       <Shield className="h-3.5 w-3.5 text-signal-amber" />
                     ) : (
-                      <div className="h-2 w-2 rounded-full bg-signal-green" />
+                      <span className="h-2 w-2 rounded-full bg-signal-green" />
                     )}
                     {user.username}
                   </span>
@@ -406,6 +406,9 @@ export function UsersPage() {
               <CopyableKey label="New API Key" value={rotatedKey.new_api_key} />
             </div>
           ) : null}
+          {actionError && !rotatedKey && (
+            <p className="text-xs text-signal-red px-1">{actionError}</p>
+          )}
           <DialogFooter>
             {rotatedKey ? (
               <Button onClick={closeRotateDialog}>Done</Button>
@@ -446,6 +449,9 @@ export function UsersPage() {
               <CopyableKey label="API Key" value={roleChangeResult.api_key} />
             </div>
           ) : null}
+          {actionError && !roleChangeResult && (
+            <p className="text-xs text-signal-red px-1">{actionError}</p>
+          )}
           <DialogFooter>
             {roleChangeResult ? (
               <Button onClick={closeRoleChangeDialog}>Done</Button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -13,6 +13,38 @@
 /** Shared status union matching the backend contract. */
 export type AnalysisStatus = 'waiting' | 'pending' | 'running' | 'completed' | 'failed'
 
+// -- Auth -----------------------------------------------------------
+
+export interface AuthUser {
+  username: string
+  role: string
+  is_admin: boolean
+}
+
+export interface AdminUser {
+  username: string
+  role: string
+  created_at: string
+  last_seen: string | null
+}
+
+export interface CreateUserResponse {
+  username: string
+  api_key: string
+  role: string
+}
+
+export interface RotateKeyResponse {
+  username: string
+  new_api_key: string
+}
+
+export interface ChangeRoleResponse {
+  username: string
+  role: string
+  api_key?: string
+}
+
 // -- Analysis domain ------------------------------------------------
 
 export interface JiraMatch {

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -36,15 +36,20 @@ class JJIClient:
         timeout: float = 30.0,
         username: str = "",
         verify_ssl: bool = True,
+        api_key: str = "",
     ):
         self.server_url = server_url.rstrip("/")
         cookies = {}
         if username:
             cookies["jji_username"] = username
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         self._client = httpx.Client(
             base_url=self.server_url,
             timeout=timeout,
             cookies=cookies,
+            headers=headers,
             verify=verify_ssl,
         )
 
@@ -102,6 +107,54 @@ class JJIClient:
             )
 
         return response.json()
+
+    # -- Auth -----------------------------------------------------------------
+
+    def login(self, username: str, api_key: str) -> dict:
+        """Login as admin. POST /api/auth/login"""
+        return self._request(
+            "POST",
+            "/api/auth/login",
+            json={"username": username, "api_key": api_key},
+        )
+
+    def logout(self) -> dict:
+        """Logout (clear session). POST /api/auth/logout"""
+        return self._request("POST", "/api/auth/logout")
+
+    def auth_me(self) -> dict:
+        """Get current user info. GET /api/auth/me"""
+        return self._request("GET", "/api/auth/me")
+
+    # -- Admin ----------------------------------------------------------------
+
+    def admin_list_users(self) -> dict:
+        """List all users. GET /api/admin/users"""
+        return self._request("GET", "/api/admin/users")
+
+    def admin_create_user(self, username: str) -> dict:
+        """Create an admin user. POST /api/admin/users"""
+        return self._request(
+            "POST",
+            "/api/admin/users",
+            json={"username": username},
+        )
+
+    def admin_delete_user(self, username: str) -> dict:
+        """Delete an admin user. DELETE /api/admin/users/{username}"""
+        return self._request("DELETE", f"/api/admin/users/{username}")
+
+    def admin_rotate_key(self, username: str) -> dict:
+        """Rotate an admin user's API key. POST /api/admin/users/{username}/rotate-key"""
+        return self._request("POST", f"/api/admin/users/{username}/rotate-key")
+
+    def admin_change_role(self, username: str, role: str) -> dict:
+        """Change a user's role. PUT /api/admin/users/{username}/role"""
+        return self._request(
+            "PUT",
+            f"/api/admin/users/{username}/role",
+            json={"role": role},
+        )
 
     # -- Health ---------------------------------------------------------------
 
@@ -511,6 +564,26 @@ class JJIClient:
             f"/results/{job_id}/create-jira-bug",
             json=payload,
             accept_statuses=(201,),
+        )
+
+    # -- User Tokens ----------------------------------------------------------
+
+    def get_user_tokens(self) -> dict:
+        """Get saved user tokens. GET /api/user/tokens"""
+        return self._request("GET", "/api/user/tokens")
+
+    def save_user_tokens(
+        self, github_token: str = "", jira_email: str = "", jira_token: str = ""
+    ) -> dict:
+        """Save user tokens. PUT /api/user/tokens"""
+        return self._request(
+            "PUT",
+            "/api/user/tokens",
+            json={
+                "github_token": github_token,
+                "jira_email": jira_email,
+                "jira_token": jira_token,
+            },
         )
 
     # -- Token Validation -----------------------------------------------------

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -576,15 +576,14 @@ class JJIClient:
         self, github_token: str = "", jira_email: str = "", jira_token: str = ""
     ) -> dict:
         """Save user tokens. PUT /api/user/tokens"""
-        return self._request(
-            "PUT",
-            "/api/user/tokens",
-            json={
-                "github_token": github_token,
-                "jira_email": jira_email,
-                "jira_token": jira_token,
-            },
-        )
+        body: dict = {}
+        if github_token:
+            body["github_token"] = github_token
+        if jira_email:
+            body["jira_email"] = jira_email
+        if jira_token:
+            body["jira_token"] = jira_token
+        return self._request("PUT", "/api/user/tokens", json=body)
 
     # -- Token Validation -----------------------------------------------------
 

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -56,6 +56,8 @@ class ServerConfig:
     wait_for_completion: bool | None = None
     poll_interval_minutes: int = 0  # 0 means use server default
     max_wait_minutes: int = 0  # 0 means use server default
+    # Admin authentication
+    api_key: str = ""  # Admin API key for authentication
 
 
 def _validate_section_server_field(
@@ -232,6 +234,8 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         wait_for_completion=data.get("wait_for_completion"),
         poll_interval_minutes=data.get("poll_interval_minutes", 0),
         max_wait_minutes=data.get("max_wait_minutes", 0),
+        # Admin authentication
+        api_key=data.get("api_key", ""),
     )
 
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -31,12 +31,18 @@ classifications_app = typer.Typer(
     help="List test classifications.", no_args_is_help=True
 )
 config_app = typer.Typer(help="Manage JJI configuration.")
+auth_app = typer.Typer(help="Authentication commands.", no_args_is_help=True)
+admin_app = typer.Typer(help="Admin management commands.", no_args_is_help=True)
+admin_users_app = typer.Typer(help="Manage admin users.", no_args_is_help=True)
 
 app.add_typer(results_app, name="results")
 app.add_typer(history_app, name="history")
 app.add_typer(comments_app, name="comments")
 app.add_typer(classifications_app, name="classifications")
 app.add_typer(config_app, name="config")
+app.add_typer(auth_app, name="auth")
+app.add_typer(admin_app, name="admin")
+admin_app.add_typer(admin_users_app, name="users")
 
 # -- Global state managed via app callback ------------------------------------
 
@@ -58,7 +64,10 @@ def _get_client(server_url: str = "", username: str = "") -> JJIClient:
     url = server_url or _state.get("server_url", "")
     uname = username or _state.get("username", "")
     verify_ssl = not _state.get("no_verify_ssl", False)
-    return JJIClient(server_url=url, username=uname, verify_ssl=verify_ssl)
+    api_key = _state.get("api_key", "")
+    return JJIClient(
+        server_url=url, username=uname, verify_ssl=verify_ssl, api_key=api_key
+    )
 
 
 def _handle_error(err: JJIError) -> None:
@@ -66,7 +75,12 @@ def _handle_error(err: JJIError) -> None:
     typer.echo(f"Error: {err}", err=True)
     if err.status_code == 401:
         typer.echo(
-            "Hint: Use --user <name> or set JJI_USERNAME to authenticate.",
+            "Hint: Use --api-key or set JJI_API_KEY to authenticate as admin.",
+            err=True,
+        )
+    elif err.status_code == 403:
+        typer.echo(
+            "Hint: This action requires admin access. Use --api-key or set JJI_API_KEY.",
             err=True,
         )
     raise typer.Exit(code=1)
@@ -206,6 +220,12 @@ def main_callback(
         envvar="JJI_USERNAME",
         help="Username displayed in comments and reviews.",
     ),
+    api_key: str = typer.Option(
+        "",
+        "--api-key",
+        envvar="JJI_API_KEY",
+        help="Admin API key for Bearer token authentication.",
+    ),
     no_verify_ssl: bool | None = typer.Option(
         None,
         "--no-verify-ssl",
@@ -252,6 +272,13 @@ def main_callback(
     _state["username"] = username
     _state["no_verify_ssl"] = no_verify_ssl
     _state["server_config"] = cfg
+
+    if api_key:
+        _state["api_key"] = api_key
+    elif cfg and cfg.api_key:
+        _state["api_key"] = cfg.api_key
+    else:
+        _state["api_key"] = ""
 
 
 # -- Health -------------------------------------------------------------------
@@ -1547,6 +1574,162 @@ def override_classification_cmd(
         print_output(data, columns=[], as_json=True)
     else:
         typer.echo(f"Classification overridden to: {data.get('classification', '')}")
+
+
+# -- Auth ---------------------------------------------------------------------
+
+
+@auth_app.command("login")
+def auth_login(
+    username: str = typer.Option(..., "--username", "-u", help="Admin username."),
+    api_key: str = typer.Option(..., "--api-key", "-k", help="Admin API key."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Login as admin user."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.login(username, api_key),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        role = data.get("role", "user")
+        is_admin = data.get("is_admin", False)
+        typer.echo(
+            f"Logged in as {data.get('username', username)} (role: {role}, admin: {is_admin})"
+        )
+
+
+@auth_app.command("logout")
+def auth_logout(
+    json_output: bool = _JSON_OPTION,
+):
+    """Logout (clear admin session)."""
+    _run_client_command(json_output, lambda c: c.logout())
+
+
+@auth_app.command("whoami")
+def auth_whoami(
+    json_output: bool = _JSON_OPTION,
+):
+    """Show current authenticated user info."""
+    _run_client_command(
+        json_output,
+        lambda c: c.auth_me(),
+        columns=["username", "role", "is_admin"],
+    )
+
+
+# -- Admin --------------------------------------------------------------------
+
+
+@admin_users_app.command("list")
+def admin_users_list(
+    json_output: bool = _JSON_OPTION,
+):
+    """List all users (admin and regular)."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.admin_list_users(),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        users = data.get("users", [])
+        if users:
+            print_output(
+                users,
+                columns=["username", "role", "created_at", "last_seen"],
+                labels={"created_at": "CREATED", "last_seen": "LAST SEEN"},
+                as_json=False,
+            )
+        else:
+            typer.echo("No users found.")
+
+
+@admin_users_app.command("create")
+def admin_users_create(
+    username: str = typer.Argument(..., help="Username for the new admin user."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Create a new admin user. The API key is shown once \u2014 save it."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.admin_create_user(username),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Created admin user: {data.get('username', username)}")
+        typer.echo(f"API Key: {data.get('api_key', '(not returned)')}")
+        typer.echo("")
+        typer.echo(
+            "\u26a0\ufe0f  Save this API key now \u2014 it cannot be retrieved later."
+        )
+
+
+@admin_users_app.command("delete")
+def admin_users_delete(
+    username: str = typer.Argument(..., help="Username of the admin to delete."),
+    json_output: bool = _JSON_OPTION,
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation prompt."
+    ),
+):
+    """Delete an admin user."""
+    if not force:
+        confirm = typer.confirm(f"Delete admin user '{username}'?")
+        if not confirm:
+            raise typer.Abort()
+    _run_client_command(
+        json_output,
+        lambda c: c.admin_delete_user(username),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Deleted admin user: {username}")
+
+
+@admin_users_app.command("rotate-key")
+def admin_users_rotate_key(
+    username: str = typer.Argument(
+        ..., help="Username of the admin to rotate key for."
+    ),
+    json_output: bool = _JSON_OPTION,
+):
+    """Rotate an admin user's API key. The new key is shown once."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.admin_rotate_key(username),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Rotated API key for: {data.get('username', username)}")
+        typer.echo(f"New API Key: {data.get('new_api_key', '(not returned)')}")
+        typer.echo("")
+        typer.echo(
+            "\u26a0\ufe0f  Save this API key now \u2014 it cannot be retrieved later."
+        )
+
+
+@admin_users_app.command("change-role")
+def admin_users_change_role(
+    username: str = typer.Argument(..., help="Username to change role for."),
+    role: str = typer.Argument(..., help="New role: 'admin' or 'user'."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Change a user's role. Promoting to admin generates an API key."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.admin_change_role(username, role),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Changed role of '{data.get('username', username)}' to '{role}'")
+        api_key = data.get("api_key")
+        if api_key:
+            typer.echo(f"API Key: {api_key}")
+            typer.echo("")
+            typer.echo(
+                "\u26a0\ufe0f  Save this API key now \u2014 it cannot be retrieved later."
+            )
 
 
 # -- Config -------------------------------------------------------------------

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1585,7 +1585,11 @@ def auth_login(
     api_key: str = typer.Option(..., "--api-key", "-k", help="Admin API key."),
     json_output: bool = _JSON_OPTION,
 ):
-    """Login as admin user."""
+    """Validate admin credentials. This does not persist a session.
+
+    For persistent auth, set api_key in ~/.config/jji/config.toml or use
+    --api-key / JJI_API_KEY on each command.
+    """
     data = _run_client_command(
         json_output,
         lambda c: c.login(username, api_key),

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -175,6 +175,12 @@ class Settings(BaseSettings):
     poll_interval_minutes: int = Field(default=2, gt=0)
     max_wait_minutes: int = Field(default=0, ge=0)
 
+    # Admin authentication
+    admin_key: str = Field(
+        default="", repr=False
+    )  # JJI_ADMIN_KEY — bootstraps admin superuser
+    secure_cookies: bool = True  # Set to False for local HTTP dev
+
     # Trusted public base URL — used for result_url and tracker links.
     # When set, _extract_base_url() returns this value verbatim.
     # When unset, _extract_base_url() returns an empty string (relative

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -197,6 +197,28 @@ def strip_sensitive_from_response(result_data: dict) -> dict:
     return result
 
 
+def encrypt_value(value: str) -> str:
+    """Encrypt a single string value. Returns prefixed ciphertext."""
+    if not value:
+        return ""
+    fernet = _get_fernet()
+    token = fernet.encrypt(value.encode()).decode()
+    return f"{_ENCRYPTED_PREFIX}{token}"
+
+
+def decrypt_value(value: str) -> str:
+    """Decrypt a single string value. Returns plaintext, or empty string on failure."""
+    if not value or not value.startswith(_ENCRYPTED_PREFIX):
+        return value or ""
+    fernet = _get_fernet()
+    ciphertext = value[len(_ENCRYPTED_PREFIX) :]
+    try:
+        return fernet.decrypt(ciphertext.encode()).decode()
+    except InvalidToken:
+        logger.warning("Failed to decrypt value: encryption key may have changed")
+        return ""
+
+
 def decrypt_sensitive_fields(params: dict) -> dict:
     """Return a shallow copy of *params* with sensitive values decrypted.
 

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -125,33 +125,19 @@ def _get_or_create_key_file() -> str:
     return key
 
 
+def _resolve_encryption_secret() -> str:
+    """Return the raw encryption secret (env var or file-based fallback)."""
+    return os.environ.get("JJI_ENCRYPTION_KEY", "") or _get_or_create_key_file()
+
+
 def get_hmac_secret() -> str:
-    """Return the HMAC secret for API key hashing.
-
-    Uses the same key resolution as Fernet encryption:
-    1. JJI_ENCRYPTION_KEY environment variable
-    2. Auto-generated file-based key
-
-    This is separate from ADMIN_KEY to decouple key rotation
-    from API key hash invalidation.
-    """
-    secret = os.environ.get("JJI_ENCRYPTION_KEY", "")
-    if not secret:
-        secret = _get_or_create_key_file()
-    return secret
+    """Return the HMAC secret for API key hashing."""
+    return _resolve_encryption_secret()
 
 
 def _get_fernet() -> Fernet:
-    """Return a ``Fernet`` instance using the configured encryption key.
-
-    Key resolution order:
-    1. ``JJI_ENCRYPTION_KEY`` environment variable (recommended for production).
-    2. Auto-generated file-based key (``~/.local/share/jji/.encryption_key``).
-    """
-    secret = os.environ.get("JJI_ENCRYPTION_KEY", "")
-    if not secret:
-        secret = _get_or_create_key_file()
-    return Fernet(_derive_fernet_key(secret))
+    """Return a Fernet instance using the configured encryption key."""
+    return Fernet(_derive_fernet_key(_resolve_encryption_secret()))
 
 
 def encrypt_sensitive_fields(params: dict) -> dict:

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -223,7 +223,7 @@ def encrypt_value(value: str) -> str:
 
 
 def decrypt_value(value: str) -> str:
-    """Decrypt a single string value. Returns plaintext, or empty string on failure."""
+    """Decrypt a single string value. Returns plaintext, or original value on failure."""
     if not value or not value.startswith(_ENCRYPTED_PREFIX):
         return value or ""
     fernet = _get_fernet()
@@ -231,8 +231,10 @@ def decrypt_value(value: str) -> str:
     try:
         return fernet.decrypt(ciphertext.encode()).decode()
     except InvalidToken:
-        logger.warning("Failed to decrypt value: encryption key may have changed")
-        return ""
+        logger.warning(
+            "Failed to decrypt value: encryption key may have changed. Preserving ciphertext."
+        )
+        return value  # Preserve the encrypted value instead of returning ""
 
 
 def decrypt_sensitive_fields(params: dict) -> dict:

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -125,6 +125,22 @@ def _get_or_create_key_file() -> str:
     return key
 
 
+def get_hmac_secret() -> str:
+    """Return the HMAC secret for API key hashing.
+
+    Uses the same key resolution as Fernet encryption:
+    1. JJI_ENCRYPTION_KEY environment variable
+    2. Auto-generated file-based key
+
+    This is separate from ADMIN_KEY to decouple key rotation
+    from API key hash invalidation.
+    """
+    secret = os.environ.get("JJI_ENCRYPTION_KEY", "")
+    if not secret:
+        secret = _get_or_create_key_file()
+    return secret
+
+
 def _get_fernet() -> Fernet:
     """Return a ``Fernet`` instance using the configured encryption key.
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -592,9 +592,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request.state.is_admin = is_admin
         request.state.role = "admin" if is_admin else "user"
 
-        # Track regular user activity (non-admin, has username)
-        if username and not is_admin:
-            # Fire and forget — don't block the request
+        # Track user activity (update last_seen for all users)
+        if username:
             task = asyncio.create_task(_safe_track_user(username))
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -93,10 +93,15 @@ from jenkins_job_insight.storage import (
 # Inline favicon
 
 
+# Semaphore to limit concurrent track_user tasks
+_track_user_semaphore = asyncio.Semaphore(10)
+
+
 async def _safe_track_user(username: str) -> None:
-    """Track user activity, swallowing any errors."""
+    """Track user activity with bounded concurrency, swallowing any errors."""
     try:
-        await storage.track_user(username)
+        async with _track_user_semaphore:
+            await storage.track_user(username)
     except Exception:
         logger.debug("Failed to track user activity for %s", username, exc_info=True)
 
@@ -492,9 +497,6 @@ async def _deferred_resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
 async def lifespan(app: FastAPI):
     _install_job_id_filter()
     await init_db()
-    settings = get_settings()
-    if settings.admin_key:
-        storage.configure_admin_key(settings.admin_key)
     await storage.cleanup_expired_sessions()
     waiting_jobs = await storage.mark_stale_results_failed()
     if waiting_jobs:
@@ -1769,21 +1771,26 @@ async def add_comment(
 async def delete_comment_endpoint(
     job_id: str, comment_id: int, request: Request, _: None = Depends(_bind_job_id)
 ) -> dict:
-    """Delete a comment. Username check is a UI courtesy, not security.
+    """Delete a comment. Username scoping is a UI courtesy.
 
-    This project has no authentication — all users are trusted.
-    See issue #55 for future auth plans.
+    Admin users can delete any comment. Regular users can only delete
+    their own comments (matched by username).
     """
     logger.debug(f"DELETE /results/{job_id}/comments/{comment_id}")
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
 
-    deleted = await storage.delete_comment(comment_id, username, job_id=job_id)
+    # Admins can delete any comment; regular users only their own
+    delete_username = "" if request.state.is_admin else username
+    deleted = await storage.delete_comment(comment_id, delete_username, job_id=job_id)
     if not deleted:
-        raise HTTPException(
-            status_code=404, detail="Comment not found or not owned by you"
+        detail = (
+            "Comment not found"
+            if request.state.is_admin
+            else "Comment not found or not owned by you"
         )
+        raise HTTPException(status_code=404, detail=detail)
 
     return {"status": "deleted"}
 
@@ -3466,6 +3473,10 @@ async def login(request: Request) -> JSONResponse:
         raise HTTPException(status_code=400, detail="Username and api_key are required")
 
     settings = get_settings()
+    if not settings.admin_key:
+        raise HTTPException(
+            status_code=503, detail="Admin authentication not configured"
+        )
     is_admin = False
     authenticated = False
 
@@ -3513,7 +3524,7 @@ async def login(request: Request) -> JSONResponse:
         secure=settings.secure_cookies,
         max_age=365 * 24 * 60 * 60,
     )
-    logger.info(f"[AUDIT] Admin login: '{username}'")
+    logger.info(f"[AUDIT] Login success: user='{username}' is_admin={is_admin}")
     return response
 
 
@@ -3561,7 +3572,11 @@ async def get_user_tokens_endpoint(request: Request) -> JSONResponse:
 
 @app.put("/api/user/tokens")
 async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
-    """Save tokens for the current user. Tokens are encrypted at rest."""
+    """Save tokens for the current user. Tokens are encrypted at rest.
+
+    Only fields present in the JSON body are updated. Omitted fields are left unchanged.
+    Pass empty string to clear a field.
+    """
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
@@ -3570,12 +3585,18 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
     except Exception as exc:
         raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
 
-    await storage.save_user_tokens(
-        username,
-        github_token=body.get("github_token", ""),
-        jira_email=body.get("jira_email", ""),
-        jira_token=body.get("jira_token", ""),
-    )
+    kwargs: dict[str, str | None] = {}
+    if "github_token" in body:
+        kwargs["github_token"] = body["github_token"]
+    if "jira_email" in body:
+        kwargs["jira_email"] = body["jira_email"]
+    if "jira_token" in body:
+        kwargs["jira_token"] = body["jira_token"]
+
+    if not kwargs:
+        return JSONResponse(content={"ok": True})
+
+    await storage.save_user_tokens(username, **kwargs)
     logger.debug(f"Saved tokens for user '{username}'")
     return JSONResponse(content={"ok": True})
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 import json
 import logging
 import math
@@ -90,6 +91,16 @@ from jenkins_job_insight.storage import (
 )
 
 # Inline favicon
+
+
+async def _safe_track_user(username: str) -> None:
+    """Track user activity, swallowing any errors."""
+    try:
+        await storage.track_user(username)
+    except Exception:
+        logger.debug("Failed to track user activity for %s", username, exc_info=True)
+
+
 FAVICON_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="0.9em" font-size="90">\xf0\x9f\x94\x8d</text></svg>'
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -481,6 +492,10 @@ async def _deferred_resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
 async def lifespan(app: FastAPI):
     _install_job_id_filter()
     await init_db()
+    settings = get_settings()
+    if settings.admin_key:
+        storage.configure_admin_key(settings.admin_key)
+    await storage.cleanup_expired_sessions()
     waiting_jobs = await storage.mark_stale_results_failed()
     if waiting_jobs:
         # Schedule resumption as a background task so it runs after the
@@ -508,25 +523,87 @@ if _FRONTEND_DIR.is_dir():
     )
 
 
-class UsernameMiddleware(BaseHTTPMiddleware):
-    """Middleware that checks for jji_username cookie and redirects to /register if missing."""
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Authenticate requests: admin via session/Bearer, regular users via cookie."""
+
+    _PUBLIC_PATHS = frozenset(
+        {
+            "/register",
+            "/health",
+            "/favicon.ico",
+        }
+    )
 
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
-        # Allow register page, health check, static assets, and API paths without auth
+
+        # Set defaults
+        request.state.username = ""
+        request.state.is_admin = False
+        request.state.role = "user"
+
+        # Public paths and static assets — pass through
         if (
-            path in ("/register", "/health", "/favicon.ico", "/api")
-            or path.startswith("/register")
+            path in self._PUBLIC_PATHS
             or path.startswith("/assets/")
-            or path.startswith("/api/")
+            or path.startswith("/register")
         ):
             return await call_next(request)
 
-        username = request.cookies.get("jji_username", "")
-        request.state.username = username
+        settings = get_settings()
+        is_admin = False
+        username = ""
+        authenticated_admin = False
 
-        # Only redirect browser (HTML) requests without auth
+        # 1. Check session cookie (jji_session) — admin session
+        session_token = request.cookies.get("jji_session")
+        if session_token:
+            session = await storage.get_session(session_token)
+            if session:
+                is_admin = bool(session["is_admin"])
+                username = str(session["username"])
+                authenticated_admin = is_admin
+
+        # 2. Check Bearer token — admin API key or admin_key
+        if not authenticated_admin:
+            auth_header = request.headers.get("authorization", "")
+            if auth_header.startswith("Bearer "):
+                token = auth_header[7:]
+                if settings.admin_key and hmac.compare_digest(
+                    token, settings.admin_key
+                ):
+                    is_admin = True
+                    username = "admin"
+                    authenticated_admin = True
+                else:
+                    user = await storage.get_user_by_key(token)
+                    if user and user.get("role") == "admin":
+                        is_admin = True
+                        username = str(user["username"])
+                        authenticated_admin = True
+
+        # 3. Fall back to jji_username cookie (regular users)
         if not username:
+            username = request.cookies.get("jji_username", "")
+
+        request.state.username = username
+        request.state.is_admin = is_admin
+        request.state.role = "admin" if is_admin else "user"
+
+        # Track regular user activity (non-admin, has username)
+        if username and not is_admin:
+            # Fire and forget — don't block the request
+            asyncio.create_task(_safe_track_user(username))
+
+        # Admin-only path enforcement
+        if path.startswith("/api/admin/"):
+            if not authenticated_admin:
+                return JSONResponse(
+                    status_code=403, content={"detail": "Admin access required"}
+                )
+
+        # Redirect to /register if no username for browser HTML requests (keep existing behavior)
+        if not username and not path.startswith("/api/"):
             accept = request.headers.get("accept", "")
             if "text/html" in accept:
                 return RedirectResponse(url="/register", status_code=303)
@@ -534,7 +611,7 @@ class UsernameMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-app.add_middleware(UsernameMiddleware)
+app.add_middleware(AuthMiddleware)
 
 
 @app.get("/", include_in_schema=False)
@@ -1672,7 +1749,7 @@ async def add_comment(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
 
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
     try:
         comment_id = await storage.add_comment(
             job_id=job_id,
@@ -1698,7 +1775,7 @@ async def delete_comment_endpoint(
     See issue #55 for future auth plans.
     """
     logger.debug(f"DELETE /results/{job_id}/comments/{comment_id}")
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
 
@@ -1725,7 +1802,7 @@ async def set_reviewed(
     await _validate_test_name_in_result(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
     try:
         await storage.set_reviewed(
             job_id=job_id,
@@ -2251,7 +2328,7 @@ async def create_github_issue_endpoint(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
 
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
     issue_body = body.body
     if username:
         issue_body += f"\n\n---\n_Reported by: {username} via jenkins-job-insight_"
@@ -2339,7 +2416,7 @@ async def create_jira_bug_endpoint(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
 
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
     bug_body = body.body
     if username:
         bug_body += f"\n\n----\nReported by: {username} via jenkins-job-insight"
@@ -2913,7 +2990,7 @@ async def override_classification_endpoint(
     await _validate_test_name_in_result(
         job_id, body.test_name, body.child_job_name, body.child_build_number
     )
-    username = request.cookies.get("jji_username", "")
+    username = request.state.username
 
     # Look up parent_job_name for the test_classifications entry
     parent_job_name = await storage.get_parent_job_name_for_test(
@@ -2975,28 +3052,15 @@ async def list_job_results(limit: int = Query(50, le=100)) -> list[dict]:
 async def delete_job_endpoint(
     job_id: str, request: Request, _: None = Depends(_bind_job_id)
 ) -> dict:
-    """Delete an analyzed job and all related data.
-
-    This project operates on a trusted network with no authentication.
-    All users can perform all actions. The username cookie check below
-    is a UI convenience (prevents accidental deletions from scripts),
-    not a security boundary. See issue #55 for future auth plans.
-    """
-    # Basic sanity check — not security. All users are trusted.
-    # This just ensures a human with a registered name is making the request.
-    username = request.cookies.get("jji_username", "")
-    if not username:
-        raise HTTPException(
-            status_code=401,
-            detail="Please register a username first",
-        )
+    """Delete an analyzed job and all related data. Admin only."""
+    _require_admin(request)
 
     result = await storage.get_result(job_id)
     if not result:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
     await storage.delete_job(job_id)
-    logger.info(f"Deleted job {job_id} by user {username}")
+    logger.info(f"[AUDIT] Admin '{request.state.username}' deleted job {job_id}")
     return {"status": "deleted", "job_id": job_id}
 
 
@@ -3289,7 +3353,7 @@ async def classify_test(request: Request, body: ClassifyTestRequest) -> dict:
             detail="KNOWN_BUG requires non-empty references (e.g., Jira tickets or historical bug URLs).",
         )
 
-    created_by = request.cookies.get("jji_username", "ai")
+    created_by = request.state.username or "ai"
 
     # Human classifications are visible immediately.
     # AI classifications become visible after analysis completes
@@ -3376,6 +3440,271 @@ def _serve_spa() -> HTMLResponse:
     if not index_file.is_file():
         raise HTTPException(status_code=404, detail="Frontend not built")
     return HTMLResponse(content=index_file.read_text(encoding="utf-8"))
+
+
+# --- Auth endpoints ---
+
+
+def _require_admin(request: Request) -> None:
+    """Raise 403 if the request is not from an authenticated admin."""
+    if not request.state.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+@app.post("/api/auth/login")
+async def login(request: Request) -> JSONResponse:
+    """Authenticate admin with username + API key. Returns session cookie."""
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    username = str(body.get("username", ""))
+    api_key = str(body.get("api_key", ""))
+
+    if not username or not api_key:
+        raise HTTPException(status_code=400, detail="Username and api_key are required")
+
+    settings = get_settings()
+    is_admin = False
+    authenticated = False
+
+    # Check admin_key — username must be "admin"
+    if (
+        username == "admin"
+        and settings.admin_key
+        and hmac.compare_digest(api_key, settings.admin_key)
+    ):
+        is_admin = True
+        authenticated = True
+    else:
+        # Check user API key
+        user = await storage.get_user_by_key(api_key)
+        if user and user["username"] == username:
+            authenticated = True
+            if user.get("role") == "admin":
+                is_admin = True
+
+    if not authenticated:
+        logger.info(f"[AUDIT] Failed login attempt for username '{username}'")
+        raise HTTPException(status_code=401, detail="Invalid username or API key")
+
+    session_token = await storage.create_session(username, is_admin=is_admin)
+    response = JSONResponse(
+        content={
+            "username": username,
+            "role": "admin" if is_admin else "user",
+            "is_admin": is_admin,
+        }
+    )
+    response.set_cookie(
+        "jji_session",
+        session_token,
+        httponly=True,
+        samesite="strict",
+        secure=settings.secure_cookies,
+        max_age=storage.SESSION_TTL_SECONDS,
+    )
+    # Also set jji_username cookie for compatibility
+    response.set_cookie(
+        "jji_username",
+        username,
+        samesite="lax",
+        secure=settings.secure_cookies,
+        max_age=365 * 24 * 60 * 60,
+    )
+    logger.info(f"[AUDIT] Admin login: '{username}'")
+    return response
+
+
+@app.post("/api/auth/logout")
+async def logout(request: Request) -> JSONResponse:
+    """Clear admin session."""
+    session_token = request.cookies.get("jji_session")
+    if session_token:
+        await storage.delete_session(session_token)
+    settings = get_settings()
+    response = JSONResponse(content={"ok": True})
+    response.delete_cookie(
+        "jji_session",
+        httponly=True,
+        samesite="strict",
+        secure=settings.secure_cookies,
+    )
+    return response
+
+
+@app.get("/api/auth/me")
+async def auth_me(request: Request) -> JSONResponse:
+    """Return current user info."""
+    return JSONResponse(
+        content={
+            "username": request.state.username,
+            "role": request.state.role,
+            "is_admin": request.state.is_admin,
+        }
+    )
+
+
+# --- User token endpoints ---
+
+
+@app.get("/api/user/tokens")
+async def get_user_tokens_endpoint(request: Request) -> JSONResponse:
+    """Get the current user's saved tokens."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    tokens = await storage.get_user_tokens(username)
+    return JSONResponse(content=tokens)
+
+
+@app.put("/api/user/tokens")
+async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
+    """Save tokens for the current user. Tokens are encrypted at rest."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    await storage.save_user_tokens(
+        username,
+        github_token=body.get("github_token", ""),
+        jira_email=body.get("jira_email", ""),
+        jira_token=body.get("jira_token", ""),
+    )
+    logger.debug(f"Saved tokens for user '{username}'")
+    return JSONResponse(content={"ok": True})
+
+
+# --- Admin endpoints ---
+
+
+@app.post("/api/admin/users")
+async def create_admin_user_endpoint(request: Request) -> JSONResponse:
+    """Create a new admin user. Returns the generated API key."""
+    _require_admin(request)
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    username = body.get("username", "")
+    if not username:
+        raise HTTPException(status_code=400, detail="Username is required")
+
+    try:
+        username, raw_key = await storage.create_admin_user(username)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.info(
+        f"[AUDIT] Admin '{request.state.username}' created admin user '{username}'"
+    )
+    return JSONResponse(
+        content={"username": username, "api_key": raw_key, "role": "admin"},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.delete("/api/admin/users/{username}")
+async def delete_admin_user_endpoint(request: Request, username: str) -> dict:
+    """Delete an admin user."""
+    _require_admin(request)
+    if username == request.state.username:
+        raise HTTPException(status_code=400, detail="Cannot delete your own account")
+
+    deleted = await storage.delete_admin_user(username)
+    if not deleted:
+        raise HTTPException(
+            status_code=404, detail=f"Admin user '{username}' not found"
+        )
+
+    logger.info(
+        f"[AUDIT] Admin '{request.state.username}' deleted admin user '{username}'"
+    )
+    return {"deleted": username}
+
+
+@app.put("/api/admin/users/{username}/role")
+async def change_user_role_endpoint(request: Request, username: str) -> JSONResponse:
+    """Change a user's role (promote to admin or demote to user).
+
+    When promoting to admin, an API key is generated and returned.
+    When demoting to user, the API key is removed and sessions invalidated.
+    """
+    _require_admin(request)
+    if username == request.state.username:
+        raise HTTPException(status_code=400, detail="Cannot change your own role")
+
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+
+    new_role = body.get("role", "")
+    if not new_role:
+        raise HTTPException(status_code=400, detail="Role is required")
+
+    try:
+        username, raw_key = await storage.change_user_role(username, new_role)
+    except ValueError as exc:
+        detail = str(exc)
+        status = 404 if "not found" in detail.lower() else 400
+        raise HTTPException(status_code=status, detail=detail) from exc
+
+    logger.info(
+        f"[AUDIT] Admin '{request.state.username}' changed role of '{username}' to '{new_role}'"
+    )
+
+    content: dict = {"username": username, "role": new_role}
+    if raw_key:
+        content["api_key"] = raw_key
+    return JSONResponse(
+        content=content,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.get("/api/admin/users")
+async def list_users_endpoint(request: Request) -> dict:
+    """List all users (admin and regular)."""
+    _require_admin(request)
+    users = await storage.list_users()
+    return {"users": users}
+
+
+@app.post("/api/admin/users/{username}/rotate-key")
+async def rotate_key_endpoint(request: Request, username: str) -> JSONResponse:
+    """Rotate an admin user's API key."""
+    _require_admin(request)
+    try:
+        body_bytes = await request.body()
+        if body_bytes and body_bytes.strip():
+            body = await request.json()
+            custom_key = body.get("new_key")
+        else:
+            custom_key = None
+    except Exception:
+        custom_key = None
+
+    try:
+        new_key = await storage.rotate_admin_key(username, custom_key=custom_key)
+    except ValueError as exc:
+        detail = str(exc)
+        status = 404 if "not found" in detail.lower() else 400
+        raise HTTPException(status_code=status, detail=detail) from exc
+
+    logger.info(
+        f"[AUDIT] Admin '{request.state.username}' rotated key for '{username}'"
+    )
+    return JSONResponse(
+        content={"username": username, "new_api_key": new_key},
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3571,6 +3571,13 @@ async def get_user_tokens_endpoint(request: Request) -> JSONResponse:
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
+    # Verify user exists in DB (prevents reading tokens for unregistered usernames)
+    user = await storage.get_user_by_username(username)
+    if not user:
+        return JSONResponse(
+            content={"github_token": "", "jira_email": "", "jira_token": ""},
+            headers={"Cache-Control": "no-store"},
+        )
     tokens = await storage.get_user_tokens(username)
     return JSONResponse(
         content=tokens,
@@ -3588,6 +3595,10 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
+    # Verify user exists in DB
+    user = await storage.get_user_by_username(username)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found. Register first.")
     body = await _read_json_object(request)
 
     kwargs: dict[str, str | None] = {}

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3573,7 +3573,10 @@ async def get_user_tokens_endpoint(request: Request) -> JSONResponse:
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
     tokens = await storage.get_user_tokens(username)
-    return JSONResponse(content=tokens)
+    return JSONResponse(
+        content=tokens,
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @app.put("/api/user/tokens")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -595,7 +595,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # Track regular user activity (non-admin, has username)
         if username and not is_admin:
             # Fire and forget — don't block the request
-            asyncio.create_task(_safe_track_user(username))
+            task = asyncio.create_task(_safe_track_user(username))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
 
         # Admin-only path enforcement
         if path.startswith("/api/admin/"):
@@ -3452,6 +3454,17 @@ def _serve_spa() -> HTMLResponse:
 # --- Auth endpoints ---
 
 
+async def _read_json_object(request: Request) -> dict:
+    """Parse request body as a JSON object. Raises HTTPException on invalid input."""
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="JSON body must be an object")
+    return body
+
+
 def _require_admin(request: Request) -> None:
     """Raise 403 if the request is not from an authenticated admin."""
     if not request.state.is_admin:
@@ -3461,10 +3474,7 @@ def _require_admin(request: Request) -> None:
 @app.post("/api/auth/login")
 async def login(request: Request) -> JSONResponse:
     """Authenticate admin with username + API key. Returns session cookie."""
-    try:
-        body = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    body = await _read_json_object(request)
 
     username = str(body.get("username", ""))
     api_key = str(body.get("api_key", ""))
@@ -3473,10 +3483,6 @@ async def login(request: Request) -> JSONResponse:
         raise HTTPException(status_code=400, detail="Username and api_key are required")
 
     settings = get_settings()
-    if not settings.admin_key:
-        raise HTTPException(
-            status_code=503, detail="Admin authentication not configured"
-        )
     is_admin = False
     authenticated = False
 
@@ -3580,10 +3586,7 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
-    try:
-        body = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    body = await _read_json_object(request)
 
     kwargs: dict[str, str | None] = {}
     if "github_token" in body:
@@ -3608,10 +3611,7 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
 async def create_admin_user_endpoint(request: Request) -> JSONResponse:
     """Create a new admin user. Returns the generated API key."""
     _require_admin(request)
-    try:
-        body = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    body = await _read_json_object(request)
 
     username = body.get("username", "")
     if not username:
@@ -3638,7 +3638,10 @@ async def delete_admin_user_endpoint(request: Request, username: str) -> dict:
     if username == request.state.username:
         raise HTTPException(status_code=400, detail="Cannot delete your own account")
 
-    deleted = await storage.delete_admin_user(username)
+    try:
+        deleted = await storage.delete_admin_user(username)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not deleted:
         raise HTTPException(
             status_code=404, detail=f"Admin user '{username}' not found"
@@ -3661,10 +3664,7 @@ async def change_user_role_endpoint(request: Request, username: str) -> JSONResp
     if username == request.state.username:
         raise HTTPException(status_code=400, detail="Cannot change your own role")
 
-    try:
-        body = await request.json()
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    body = await _read_json_object(request)
 
     new_role = body.get("role", "")
     if not new_role:
@@ -3706,11 +3706,19 @@ async def rotate_key_endpoint(request: Request, username: str) -> JSONResponse:
         body_bytes = await request.body()
         if body_bytes and body_bytes.strip():
             body = await request.json()
+            if not isinstance(body, dict):
+                raise HTTPException(
+                    status_code=400, detail="JSON body must be an object"
+                )
             custom_key = body.get("new_key")
         else:
             custom_key = None
-    except Exception:
-        custom_key = None
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid JSON body: {exc}"
+        ) from exc
 
     try:
         new_key = await storage.rotate_admin_key(username, custom_key=custom_key)

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2397,26 +2397,31 @@ async def delete_admin_user(username: str) -> bool:
     Raises ValueError if this would delete the last admin user.
     """
     async with aiosqlite.connect(DB_PATH) as db:
-        # Check this wouldn't delete the last admin
-        cursor = await db.execute("SELECT COUNT(*) FROM users WHERE role = 'admin'")
-        admin_count = (await cursor.fetchone())[0]
-        if admin_count <= 1:
-            # Check if the target is actually an admin
-            cursor = await db.execute(
-                "SELECT role FROM users WHERE username = ?", (username,)
-            )
-            row = await cursor.fetchone()
-            if row and row[0] == "admin":
-                raise ValueError("Cannot delete the last admin user")
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            cursor = await db.execute("SELECT COUNT(*) FROM users WHERE role = 'admin'")
+            admin_count = (await cursor.fetchone())[0]
+            if admin_count <= 1:
+                cursor = await db.execute(
+                    "SELECT role FROM users WHERE username = ?", (username,)
+                )
+                row = await cursor.fetchone()
+                if row and row[0] == "admin":
+                    await db.execute("ROLLBACK")
+                    raise ValueError("Cannot delete the last admin user")
 
-        # Delete sessions first
-        await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
-        cursor = await db.execute(
-            "DELETE FROM users WHERE username = ? AND role = 'admin'",
-            (username,),
-        )
-        await db.commit()
-        return cursor.rowcount > 0
+            await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+            cursor = await db.execute(
+                "DELETE FROM users WHERE username = ? AND role = 'admin'",
+                (username,),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+        except ValueError:
+            raise
+        except Exception:
+            await db.execute("ROLLBACK")
+            raise
 
 
 async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
@@ -2464,21 +2469,30 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
                 (key_hash, username),
             )
         else:
-            # Demoting to user — ensure at least one admin remains
-            cursor = await db.execute(
-                "SELECT COUNT(*) FROM users WHERE role = 'admin' AND username != ?",
-                (username,),
-            )
-            remaining = (await cursor.fetchone())[0]
-            if remaining < 1:
-                msg = "Cannot demote the last admin user"
-                raise ValueError(msg)
-            # Remove API key and invalidate sessions
-            await db.execute(
-                "UPDATE users SET role = 'user', api_key_hash = NULL WHERE username = ?",
-                (username,),
-            )
-            await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+            # Demoting to user — use transaction for atomic last-admin check
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "SELECT COUNT(*) FROM users WHERE role = 'admin' AND username != ?",
+                    (username,),
+                )
+                other_admins = (await cursor.fetchone())[0]
+                if other_admins == 0:
+                    await db.execute("ROLLBACK")
+                    raise ValueError("Cannot demote the last admin user")
+                await db.execute(
+                    "UPDATE users SET role = 'user', api_key_hash = NULL WHERE username = ?",
+                    (username,),
+                )
+                await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+                await db.commit()
+            except ValueError:
+                raise
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
+
+            return username, raw_key
 
         await db.commit()
     return username, raw_key
@@ -2495,7 +2509,7 @@ async def list_users() -> list[dict]:
 
 
 async def track_user(username: str) -> None:
-    """Track a regular user — insert if new, update last_seen if existing."""
+    """Track user activity — insert if new, update last_seen if existing."""
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             "INSERT INTO users (username, role) VALUES (?, 'user') "

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2461,13 +2461,24 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
 
         raw_key = ""
         if new_role == "admin":
-            # Promoting to admin — generate API key
+            # Promoting to admin — use transaction for atomicity
             raw_key = generate_api_key()
             key_hash = hash_api_key(raw_key)
-            await db.execute(
-                "UPDATE users SET role = 'admin', api_key_hash = ? WHERE username = ?",
-                (key_hash, username),
-            )
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "UPDATE users SET role = 'admin', api_key_hash = ? WHERE username = ?",
+                    (key_hash, username),
+                )
+                if cursor.rowcount == 0:
+                    await db.execute("ROLLBACK")
+                    raise ValueError(f"User '{username}' not found")
+                await db.commit()
+            except ValueError:
+                raise
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
         else:
             # Demoting to user — use transaction for atomic last-admin check
             await db.execute("BEGIN IMMEDIATE")
@@ -2494,7 +2505,6 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
 
             return username, raw_key
 
-        await db.commit()
     return username, raw_key
 
 

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -14,7 +14,10 @@ from typing import get_args
 import aiosqlite
 from simple_logger.logger import get_logger
 
-from jenkins_job_insight.encryption import strip_sensitive_from_response
+from jenkins_job_insight.encryption import (
+    get_hmac_secret,
+    strip_sensitive_from_response,
+)
 from jenkins_job_insight.models import (
     HistoryClassificationLiteral,
     OverrideClassificationLiteral,
@@ -51,21 +54,6 @@ def validate_api_key(key: str) -> None:
         raise ValueError(msg)
 
 
-def _get_hmac_secret() -> str:
-    """Get the HMAC secret for API key hashing.
-
-    Uses JJI_ENCRYPTION_KEY (same key used for at-rest encryption) as
-    the HMAC pepper. This is deliberately separate from ADMIN_KEY so
-    that rotating ADMIN_KEY does not invalidate delegated API key hashes.
-
-    Falls back to the auto-generated file-based key when
-    JJI_ENCRYPTION_KEY is not set (same resolution as encryption.py).
-    """
-    from jenkins_job_insight.encryption import get_hmac_secret
-
-    return get_hmac_secret()
-
-
 def hash_api_key(key: str) -> str:
     """Hash an API key with HMAC-SHA256 for storage.
 
@@ -78,7 +66,7 @@ def hash_api_key(key: str) -> str:
     Returns:
         Hex-encoded HMAC-SHA256 digest.
     """
-    secret = _get_hmac_secret()
+    secret = get_hmac_secret()
     return hmac.new(secret.encode(), key.encode(), hashlib.sha256).hexdigest()
 
 
@@ -371,6 +359,13 @@ async def init_db() -> None:
                 expires_at TIMESTAMP NOT NULL
             )
         """)
+
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_username ON sessions (username)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions (expires_at)"
+        )
 
         await db.commit()
 
@@ -2394,8 +2389,23 @@ async def get_user_by_username(username: str) -> dict | None:
 
 
 async def delete_admin_user(username: str) -> bool:
-    """Delete an admin user. Returns True if deleted."""
+    """Delete an admin user. Returns True if deleted.
+
+    Raises ValueError if this would delete the last admin user.
+    """
     async with aiosqlite.connect(DB_PATH) as db:
+        # Check this wouldn't delete the last admin
+        cursor = await db.execute("SELECT COUNT(*) FROM users WHERE role = 'admin'")
+        admin_count = (await cursor.fetchone())[0]
+        if admin_count <= 1:
+            # Check if the target is actually an admin
+            cursor = await db.execute(
+                "SELECT role FROM users WHERE username = ?", (username,)
+            )
+            row = await cursor.fetchone()
+            if row and row[0] == "admin":
+                raise ValueError("Cannot delete the last admin user")
+
         # Delete sessions first
         await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
         cursor = await db.execute(

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2383,7 +2383,10 @@ async def get_user_by_username(username: str) -> dict | None:
     """Look up a user by username."""
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
-        cursor = await db.execute("SELECT * FROM users WHERE username = ?", (username,))
+        cursor = await db.execute(
+            "SELECT id, username, role, created_at, last_seen FROM users WHERE username = ?",
+            (username,),
+        )
         row = await cursor.fetchone()
         return dict(row) if row else None
 
@@ -2461,7 +2464,16 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
                 (key_hash, username),
             )
         else:
-            # Demoting to user — remove API key and invalidate sessions
+            # Demoting to user — ensure at least one admin remains
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM users WHERE role = 'admin' AND username != ?",
+                (username,),
+            )
+            remaining = (await cursor.fetchone())[0]
+            if remaining < 1:
+                msg = "Cannot demote the last admin user"
+                raise ValueError(msg)
+            # Remove API key and invalidate sessions
             await db.execute(
                 "UPDATE users SET role = 'user', api_key_hash = NULL WHERE username = ?",
                 (username,),

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -51,39 +51,35 @@ def validate_api_key(key: str) -> None:
         raise ValueError(msg)
 
 
-# Module-level admin key, set by configure_admin_key() at startup.
-_admin_key: str = ""
+def _get_hmac_secret() -> str:
+    """Get the HMAC secret for API key hashing.
+
+    Uses JJI_ENCRYPTION_KEY (same key used for at-rest encryption) as
+    the HMAC pepper. This is deliberately separate from ADMIN_KEY so
+    that rotating ADMIN_KEY does not invalidate delegated API key hashes.
+
+    Falls back to the auto-generated file-based key when
+    JJI_ENCRYPTION_KEY is not set (same resolution as encryption.py).
+    """
+    from jenkins_job_insight.encryption import get_hmac_secret
+
+    return get_hmac_secret()
 
 
-def configure_admin_key(key: str) -> None:
-    """Set the admin key used for API key HMAC hashing."""
-    global _admin_key
-    _admin_key = key
-
-
-def _get_admin_key() -> str:
-    """Get the admin key, raising if not configured."""
-    if not _admin_key:
-        msg = "Admin key not configured — call configure_admin_key() at startup"
-        raise RuntimeError(msg)
-    return _admin_key
-
-
-def hash_api_key(key: str, hmac_secret: str) -> str:
+def hash_api_key(key: str) -> str:
     """Hash an API key with HMAC-SHA256 for storage.
+
+    Uses the encryption key (JJI_ENCRYPTION_KEY) as the HMAC secret,
+    which is stable across ADMIN_KEY rotations.
 
     Args:
         key: The raw API key to hash.
-        hmac_secret: The HMAC secret (typically Settings.admin_key).
-            Required — callers must provide the secret explicitly.
 
     Returns:
         Hex-encoded HMAC-SHA256 digest.
     """
-    if not hmac_secret:
-        msg = "HMAC secret is required for API key hashing (set ADMIN_KEY env var)"
-        raise RuntimeError(msg)
-    return hmac.new(hmac_secret.encode(), key.encode(), hashlib.sha256).hexdigest()
+    secret = _get_hmac_secret()
+    return hmac.new(secret.encode(), key.encode(), hashlib.sha256).hexdigest()
 
 
 def generate_api_key() -> str:
@@ -446,12 +442,11 @@ async def add_comment(
 
 
 async def delete_comment(comment_id: int, username: str, job_id: str = "") -> bool:
-    """Delete a comment. Username check is a UI courtesy, not security.
+    """Delete a comment by ID, optionally scoped to username and job_id.
 
-    DESIGN DECISION: No authentication in this project.
-    All users are trusted. Username matching is a UI convenience
-    (shows delete button only for your own comments), NOT a security control.
-    Any user can delete any comment. See issue #55 for future auth plans.
+    When username is empty, the delete is not scoped by owner — the caller
+    is responsible for ensuring this is only used for admin-authorized requests.
+    When username is non-empty, only comments matching that username are deleted.
 
     Returns True if deleted, False if not found.
     """
@@ -2366,7 +2361,7 @@ async def create_admin_user(username: str) -> tuple[str, str]:
         msg = f"Invalid username: '{username}'. Must be 2-50 alphanumeric characters, dots, hyphens, underscores."
         raise ValueError(msg)
     raw_key = generate_api_key()
-    key_hash = hash_api_key(raw_key, _get_admin_key())
+    key_hash = hash_api_key(raw_key)
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             "INSERT INTO users (username, api_key_hash, role) VALUES (?, ?, 'admin')",
@@ -2378,7 +2373,7 @@ async def create_admin_user(username: str) -> tuple[str, str]:
 
 async def get_user_by_key(api_key: str) -> dict | None:
     """Look up a user by their raw API key."""
-    key_hash = hash_api_key(api_key, _get_admin_key())
+    key_hash = hash_api_key(api_key)
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
@@ -2433,7 +2428,6 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
     if username.lower() == "admin":
         msg = "Cannot change role of reserved 'admin' user"
         raise ValueError(msg)
-
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
@@ -2451,7 +2445,7 @@ async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
         if new_role == "admin":
             # Promoting to admin — generate API key
             raw_key = generate_api_key()
-            key_hash = hash_api_key(raw_key, _get_admin_key())
+            key_hash = hash_api_key(raw_key)
             await db.execute(
                 "UPDATE users SET role = 'admin', api_key_hash = ? WHERE username = ?",
                 (key_hash, username),
@@ -2534,7 +2528,7 @@ async def rotate_admin_key(username: str, custom_key: str | None = None) -> str:
         raw_key = custom_key
     else:
         raw_key = generate_api_key()
-    key_hash = hash_api_key(raw_key, _get_admin_key())
+    key_hash = hash_api_key(raw_key)
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             "UPDATE users SET api_key_hash = ? WHERE username = ? AND role = 'admin'",
@@ -2559,11 +2553,14 @@ async def cleanup_expired_sessions() -> None:
 async def save_user_tokens(
     username: str,
     *,
-    github_token: str = "",
-    jira_email: str = "",
-    jira_token: str = "",
+    github_token: str | None = None,
+    jira_email: str | None = None,
+    jira_token: str | None = None,
 ) -> None:
-    """Save encrypted user tokens. Only updates non-empty values."""
+    """Save encrypted user tokens. Only updates fields that are explicitly provided (not None).
+
+    Pass empty string to clear a field. Omit (None) to leave unchanged.
+    """
     from jenkins_job_insight.encryption import encrypt_value
 
     updates = []

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1,7 +1,11 @@
 """SQLite storage for analysis results."""
 
+import hashlib
+import hmac
 import json
 import os
+import re
+import secrets
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections.abc import Callable
@@ -33,6 +37,63 @@ _PRIMARY_CLASSIFICATIONS_SQL = (
 _HISTORY_CLASSIFICATIONS_SQL = (
     "(" + ", ".join(f"'{c}'" for c in HISTORY_CLASSIFICATIONS) + ")"
 )
+
+# --- Auth constants and helpers ---
+SESSION_TTL_HOURS = 8
+SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 3600
+MIN_KEY_LENGTH = 16
+
+
+def validate_api_key(key: str) -> None:
+    """Validate API key meets minimum requirements."""
+    if len(key) < MIN_KEY_LENGTH:
+        msg = f"API key must be at least {MIN_KEY_LENGTH} characters long"
+        raise ValueError(msg)
+
+
+# Module-level admin key, set by configure_admin_key() at startup.
+_admin_key: str = ""
+
+
+def configure_admin_key(key: str) -> None:
+    """Set the admin key used for API key HMAC hashing."""
+    global _admin_key
+    _admin_key = key
+
+
+def _get_admin_key() -> str:
+    """Get the admin key, raising if not configured."""
+    if not _admin_key:
+        msg = "Admin key not configured — call configure_admin_key() at startup"
+        raise RuntimeError(msg)
+    return _admin_key
+
+
+def hash_api_key(key: str, hmac_secret: str) -> str:
+    """Hash an API key with HMAC-SHA256 for storage.
+
+    Args:
+        key: The raw API key to hash.
+        hmac_secret: The HMAC secret (typically Settings.admin_key).
+            Required — callers must provide the secret explicitly.
+
+    Returns:
+        Hex-encoded HMAC-SHA256 digest.
+    """
+    if not hmac_secret:
+        msg = "HMAC secret is required for API key hashing (set ADMIN_KEY env var)"
+        raise RuntimeError(msg)
+    return hmac.new(hmac_secret.encode(), key.encode(), hashlib.sha256).hexdigest()
+
+
+def generate_api_key() -> str:
+    """Generate a random API key."""
+    return f"jji_{secrets.token_urlsafe(32)}"
+
+
+def _hash_session_token(token: str) -> str:
+    """Hash a session token for storage."""
+    return hashlib.sha256(token.encode()).hexdigest()
 
 
 def parse_result_json(raw: str | None, *, job_id: str = "") -> dict | None:
@@ -287,6 +348,33 @@ async def init_db() -> None:
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_tc_classification ON test_classifications (classification)"
         )
+
+        # Users table — tracks all users (regular and admin)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                api_key_hash TEXT UNIQUE,
+                role TEXT NOT NULL DEFAULT 'user',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Migration: add encrypted token columns to users table
+        for col in ("github_token_enc", "jira_email_enc", "jira_token_enc"):
+            await _migrate_add_column(db, "users", col, "TEXT NOT NULL DEFAULT ''")
+
+        # Sessions table — admin session tokens
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                token TEXT PRIMARY KEY,
+                username TEXT NOT NULL,
+                is_admin INTEGER NOT NULL DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMP NOT NULL
+            )
+        """)
 
         await db.commit()
 
@@ -2263,3 +2351,259 @@ async def get_ai_configs() -> list[dict]:
         )
         rows = await cursor.fetchall()
         return [{"ai_provider": row[0], "ai_model": row[1]} for row in rows]
+
+
+# --- Auth storage functions ---
+
+
+async def create_admin_user(username: str) -> tuple[str, str]:
+    """Create an admin user and return (username, raw_api_key).
+    Raises ValueError if username is invalid or taken."""
+    if username.lower() == "admin":
+        msg = "Username 'admin' is reserved"
+        raise ValueError(msg)
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{1,49}$", username):
+        msg = f"Invalid username: '{username}'. Must be 2-50 alphanumeric characters, dots, hyphens, underscores."
+        raise ValueError(msg)
+    raw_key = generate_api_key()
+    key_hash = hash_api_key(raw_key, _get_admin_key())
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO users (username, api_key_hash, role) VALUES (?, ?, 'admin')",
+            (username, key_hash),
+        )
+        await db.commit()
+    return username, raw_key
+
+
+async def get_user_by_key(api_key: str) -> dict | None:
+    """Look up a user by their raw API key."""
+    key_hash = hash_api_key(api_key, _get_admin_key())
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT id, username, role, created_at, last_seen FROM users WHERE api_key_hash = ?",
+            (key_hash,),
+        )
+        row = await cursor.fetchone()
+        return dict(row) if row else None
+
+
+async def get_user_by_username(username: str) -> dict | None:
+    """Look up a user by username."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT * FROM users WHERE username = ?", (username,))
+        row = await cursor.fetchone()
+        return dict(row) if row else None
+
+
+async def delete_admin_user(username: str) -> bool:
+    """Delete an admin user. Returns True if deleted."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        # Delete sessions first
+        await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+        cursor = await db.execute(
+            "DELETE FROM users WHERE username = ? AND role = 'admin'",
+            (username,),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def change_user_role(username: str, new_role: str) -> tuple[str, str]:
+    """Change a user's role. Returns (username, raw_api_key).
+
+    When promoting to admin, generates a new API key.
+    When demoting to user, removes the API key and invalidates sessions.
+
+    Args:
+        username: The user to change.
+        new_role: The new role ('admin' or 'user').
+
+    Returns:
+        Tuple of (username, raw_api_key). raw_api_key is empty when demoting.
+
+    Raises:
+        ValueError: If username not found, role is invalid, or already has the role.
+    """
+    if new_role not in ("admin", "user"):
+        msg = f"Invalid role: '{new_role}'. Must be 'admin' or 'user'."
+        raise ValueError(msg)
+    if username.lower() == "admin":
+        msg = "Cannot change role of reserved 'admin' user"
+        raise ValueError(msg)
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT username, role FROM users WHERE username = ?", (username,)
+        )
+        user = await cursor.fetchone()
+        if not user:
+            msg = f"User '{username}' not found"
+            raise ValueError(msg)
+        if user["role"] == new_role:
+            msg = f"User '{username}' already has role '{new_role}'"
+            raise ValueError(msg)
+
+        raw_key = ""
+        if new_role == "admin":
+            # Promoting to admin — generate API key
+            raw_key = generate_api_key()
+            key_hash = hash_api_key(raw_key, _get_admin_key())
+            await db.execute(
+                "UPDATE users SET role = 'admin', api_key_hash = ? WHERE username = ?",
+                (key_hash, username),
+            )
+        else:
+            # Demoting to user — remove API key and invalidate sessions
+            await db.execute(
+                "UPDATE users SET role = 'user', api_key_hash = NULL WHERE username = ?",
+                (username,),
+            )
+            await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+
+        await db.commit()
+    return username, raw_key
+
+
+async def list_users() -> list[dict]:
+    """List all users (without key hashes)."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT id, username, role, created_at, last_seen FROM users ORDER BY created_at DESC"
+        )
+        return [dict(row) for row in await cursor.fetchall()]
+
+
+async def track_user(username: str) -> None:
+    """Track a regular user — insert if new, update last_seen if existing."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO users (username, role) VALUES (?, 'user') "
+            "ON CONFLICT(username) DO UPDATE SET last_seen = CURRENT_TIMESTAMP",
+            (username,),
+        )
+        await db.commit()
+
+
+async def create_session(
+    username: str, is_admin: bool = False, ttl_hours: int = SESSION_TTL_HOURS
+) -> str:
+    """Create an opaque session token. Returns raw token."""
+    token = secrets.token_urlsafe(32)
+    token_hash = _hash_session_token(token)
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=ttl_hours)
+    expires_str = expires_at.strftime("%Y-%m-%d %H:%M:%S")
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO sessions (token, username, is_admin, expires_at) VALUES (?, ?, ?, ?)",
+            (token_hash, username, 1 if is_admin else 0, expires_str),
+        )
+        await db.commit()
+    return token
+
+
+async def get_session(token: str) -> dict | None:
+    """Look up a session. Returns None if expired or not found."""
+    token_hash = _hash_session_token(token)
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM sessions WHERE token = ? AND expires_at > datetime('now')",
+            (token_hash,),
+        )
+        row = await cursor.fetchone()
+        return dict(row) if row else None
+
+
+async def delete_session(token: str) -> None:
+    """Delete a session (logout)."""
+    token_hash = _hash_session_token(token)
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM sessions WHERE token = ?", (token_hash,))
+        await db.commit()
+
+
+async def rotate_admin_key(username: str, custom_key: str | None = None) -> str:
+    """Generate or set a new API key for an admin user. Returns the raw new key."""
+    if custom_key:
+        validate_api_key(custom_key)
+        raw_key = custom_key
+    else:
+        raw_key = generate_api_key()
+    key_hash = hash_api_key(raw_key, _get_admin_key())
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "UPDATE users SET api_key_hash = ? WHERE username = ? AND role = 'admin'",
+            (key_hash, username),
+        )
+        if cursor.rowcount == 0:
+            msg = f"Admin user '{username}' not found"
+            raise ValueError(msg)
+        # Invalidate all existing sessions for this user
+        await db.execute("DELETE FROM sessions WHERE username = ?", (username,))
+        await db.commit()
+    return raw_key
+
+
+async def cleanup_expired_sessions() -> None:
+    """Remove expired sessions."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM sessions WHERE expires_at <= datetime('now')")
+        await db.commit()
+
+
+async def save_user_tokens(
+    username: str,
+    *,
+    github_token: str = "",
+    jira_email: str = "",
+    jira_token: str = "",
+) -> None:
+    """Save encrypted user tokens. Only updates non-empty values."""
+    from jenkins_job_insight.encryption import encrypt_value
+
+    updates = []
+    params: list[str] = []
+    if github_token is not None:
+        updates.append("github_token_enc = ?")
+        params.append(encrypt_value(github_token))
+    if jira_email is not None:
+        updates.append("jira_email_enc = ?")
+        params.append(encrypt_value(jira_email))
+    if jira_token is not None:
+        updates.append("jira_token_enc = ?")
+        params.append(encrypt_value(jira_token))
+
+    if not updates:
+        return
+
+    params.append(username)
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            f"UPDATE users SET {', '.join(updates)} WHERE username = ?",
+            params,
+        )
+        await db.commit()
+
+
+async def get_user_tokens(username: str) -> dict[str, str]:
+    """Get decrypted user tokens. Returns dict with github_token, jira_email, jira_token."""
+    from jenkins_job_insight.encryption import decrypt_value
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "SELECT github_token_enc, jira_email_enc, jira_token_enc FROM users WHERE username = ?",
+            (username,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return {"github_token": "", "jira_email": "", "jira_token": ""}
+        return {
+            "github_token": decrypt_value(row[0] or ""),
+            "jira_email": decrypt_value(row[1] or ""),
+            "jira_token": decrypt_value(row[2] or ""),
+        }

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2542,7 +2542,7 @@ async def get_session(token: str) -> dict | None:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
-            "SELECT * FROM sessions WHERE token = ? AND expires_at > datetime('now')",
+            "SELECT username, is_admin, created_at, expires_at FROM sessions WHERE token = ? AND expires_at > datetime('now')",
             (token_hash,),
         )
         row = await cursor.fetchone()
@@ -2617,7 +2617,7 @@ async def save_user_tokens(
     params.append(username)
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
-            f"UPDATE users SET {', '.join(updates)} WHERE username = ?",
+            f"UPDATE users SET {', '.join(updates)} WHERE username = ?",  # noqa: S608 — columns are hardcoded literals
             params,
         )
         await db.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def build_test_env(**overrides: str) -> dict[str, str]:
 def make_test_client(
     handler: Callable[[httpx.Request], httpx.Response],
     username: str = "",
+    api_key: str = "",
 ) -> JJIClient:
     """Create a JJIClient with a mock transport for testing.
 
@@ -52,13 +53,17 @@ def make_test_client(
     cookies = {}
     if username:
         cookies["jji_username"] = username
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
 
     mock_http = httpx.Client(
         transport=httpx.MockTransport(handler),
         base_url=CLI_TEST_BASE_URL,
         cookies=cookies,
+        headers=headers,
     )
-    client = JJIClient(CLI_TEST_BASE_URL, username=username)
+    client = JJIClient(CLI_TEST_BASE_URL, username=username, api_key=api_key)
     client._client.close()
     client._client = mock_http
     return client

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -419,6 +419,15 @@ class TestUserTokens:
         data = resp.json()
         assert data["github_token"] == ""
 
+    def test_save_tokens_for_untracked_user(self, client):
+        """Saving tokens for a user not yet in DB should return 404."""
+        resp = client.put(
+            "/api/user/tokens",
+            json={"github_token": "ghp_new"},
+            cookies={"jji_username": "brand_new_user"},
+        )
+        assert resp.status_code == 404
+
     def test_save_partial_tokens(self, client):
         """Saving one token should NOT wipe others."""
         client.get("/api/dashboard", cookies={"jji_username": "partial"})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -276,15 +276,17 @@ class TestBearerTokenAuth:
 class TestChangeUserRole:
     def test_promote_user_to_admin(self, client):
         cookies = _admin_login(client)
-        # Create as admin first, demote to user, then promote back
+        # Create two admins so we can safely demote one (last-admin guard)
         client.post(
             "/api/admin/users", json={"username": "promoteuser"}, cookies=cookies
         )
+        client.post("/api/admin/users", json={"username": "keeper"}, cookies=cookies)
         client.put(
             "/api/admin/users/promoteuser/role",
             json={"role": "user"},
             cookies=cookies,
         )
+        client.delete("/api/admin/users/keeper", cookies=cookies)
         # Now promote from user to admin
         resp = client.put(
             "/api/admin/users/promoteuser/role",
@@ -299,8 +301,9 @@ class TestChangeUserRole:
 
     def test_demote_admin_to_user(self, client):
         cookies = _admin_login(client)
-        # Create admin user
+        # Create two admins so we can safely demote one (last-admin guard)
         client.post("/api/admin/users", json={"username": "demoteme"}, cookies=cookies)
+        client.post("/api/admin/users", json={"username": "keeper2"}, cookies=cookies)
         # Demote to user
         resp = client.put(
             "/api/admin/users/demoteme/role",
@@ -311,6 +314,22 @@ class TestChangeUserRole:
         data = resp.json()
         assert data["role"] == "user"
         assert "api_key" not in data  # No key for regular users
+        # Clean up
+        client.delete("/api/admin/users/keeper2", cookies=cookies)
+
+    def test_demote_last_admin_blocked(self, client):
+        cookies = _admin_login(client)
+        # Create a single admin — demoting should be blocked
+        client.post("/api/admin/users", json={"username": "onlyadmin"}, cookies=cookies)
+        resp = client.put(
+            "/api/admin/users/onlyadmin/role",
+            json={"role": "user"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 400
+        assert "last admin" in resp.json()["detail"].lower()
+        # Clean up
+        client.delete("/api/admin/users/onlyadmin", cookies=cookies)
 
     def test_change_role_requires_admin(self, client):
         resp = client.put(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -400,9 +400,9 @@ class TestUserTokens:
         resp = client.get("/api/user/tokens", cookies={"jji_username": "tokenuser"})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["github_token"] == "ghp_test123"
+        assert data["github_token"] == "ghp_test123"  # noqa: S105
         assert data["jira_email"] == "a@b.com"
-        assert data["jira_token"] == "jira_tok"
+        assert data["jira_token"] == "jira_tok"  # noqa: S105
 
     def test_get_tokens_no_user(self, client):
         resp = client.get("/api/user/tokens")
@@ -445,9 +445,9 @@ class TestUserTokens:
         # Verify jira tokens were NOT wiped
         resp = client.get("/api/user/tokens", cookies={"jji_username": "partial"})
         data = resp.json()
-        assert data["github_token"] == "ghp_updated"
+        assert data["github_token"] == "ghp_updated"  # noqa: S105
         assert data["jira_email"] == "orig@test.com"  # NOT wiped
-        assert data["jira_token"] == "jira_orig"  # NOT wiped
+        assert data["jira_token"] == "jira_orig"  # NOT wiped  # noqa: S105
 
     def test_tokens_encrypted_at_rest(self, client, temp_db_path):
         """Verify tokens are not stored as plaintext in the DB."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -53,6 +53,23 @@ def _admin_login(
     return resp.cookies
 
 
+def _wait_for_user_tracked(client, username, timeout=2.0):
+    """Poll until user appears in admin users list."""
+    import time
+
+    cookies = _admin_login(client)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get("/api/admin/users", cookies=cookies)
+        users = resp.json().get("users", [])
+        if any(u["username"] == username for u in users):
+            # Clear admin session cookies so subsequent requests aren't affected
+            client.cookies.clear()
+            return
+        time.sleep(0.05)
+    raise TimeoutError(f"User '{username}' not tracked within {timeout}s")
+
+
 class TestAuthLogin:
     def test_admin_login_success(self, client):
         resp = client.post(
@@ -164,11 +181,14 @@ class TestAdminUsers:
 
     def test_delete_admin_user(self, client):
         cookies = _admin_login(client)
-        # Create then delete
+        # Create two admins so we can safely delete one (last-admin guard)
+        client.post("/api/admin/users", json={"username": "keeper"}, cookies=cookies)
         client.post("/api/admin/users", json={"username": "todelete"}, cookies=cookies)
         resp = client.delete("/api/admin/users/todelete", cookies=cookies)
         assert resp.status_code == 200
         assert resp.json()["deleted"] == "todelete"
+        # Clean up
+        client.delete("/api/admin/users/keeper", cookies=cookies)
 
     def test_delete_self_forbidden(self, client):
         cookies = _admin_login(client)
@@ -343,11 +363,9 @@ class TestChangeUserRole:
 class TestUserTokens:
     def test_save_and_get_tokens(self, client):
         """Tokens round-trip through encrypt/decrypt."""
-        import time
-
         # Track a user first
         client.get("/api/dashboard", cookies={"jji_username": "tokenuser"})
-        time.sleep(0.1)
+        _wait_for_user_tracked(client, "tokenuser")
         # Save tokens
         resp = client.put(
             "/api/user/tokens",
@@ -384,10 +402,8 @@ class TestUserTokens:
 
     def test_save_partial_tokens(self, client):
         """Saving one token should NOT wipe others."""
-        import time
-
         client.get("/api/dashboard", cookies={"jji_username": "partial"})
-        time.sleep(0.1)
+        _wait_for_user_tracked(client, "partial")
 
         # Save all three tokens
         client.put(
@@ -417,12 +433,11 @@ class TestUserTokens:
     def test_tokens_encrypted_at_rest(self, client, temp_db_path):
         """Verify tokens are not stored as plaintext in the DB."""
         import asyncio
-        import time
 
         import aiosqlite
 
         client.get("/api/dashboard", cookies={"jji_username": "enctest"})
-        time.sleep(0.1)
+        _wait_for_user_tracked(client, "enctest")
         client.put(
             "/api/user/tokens",
             json={"github_token": "ghp_secret_value"},
@@ -529,15 +544,7 @@ class TestAdminDeleteComment:
 class TestUserTracking:
     def test_regular_user_tracked(self, client):
         """Regular user activity is tracked in the users table."""
-        import time
-
         # Make a request as a regular user
         client.get("/api/dashboard", cookies={"jji_username": "trackeduser"})
-        # Give the fire-and-forget task a moment
-        time.sleep(0.1)
-        # Check the user was tracked
-        cookies = _admin_login(client)
-        resp = client.get("/api/admin/users", cookies=cookies)
-        users = resp.json()["users"]
-        usernames = [u["username"] for u in users]
-        assert "trackeduser" in usernames
+        # Poll until the fire-and-forget task completes
+        _wait_for_user_tracked(client, "trackeduser")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,449 @@
+"""Tests for admin authentication and user tracking."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.config import get_settings
+
+
+@pytest.fixture
+def _init_db(temp_db_path):
+    """Initialize database with test path."""
+    import asyncio
+
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(storage.init_db())
+        yield
+
+
+@pytest.fixture
+def client(_init_db, temp_db_path):
+    """Create a test client with admin key configured."""
+    with patch.dict(
+        os.environ,
+        {
+            "ADMIN_KEY": "test-admin-key-16chars",  # pragma: allowlist secret
+            "SECURE_COOKIES": "false",
+        },
+    ):
+        get_settings.cache_clear()
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            storage.configure_admin_key(
+                "test-admin-key-16chars"
+            )  # pragma: allowlist secret
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as c:
+                yield c
+        get_settings.cache_clear()
+        storage.configure_admin_key("")  # cleanup
+
+
+def _admin_login(
+    client,
+    username="admin",
+    api_key="test-admin-key-16chars",  # pragma: allowlist secret
+):
+    """Helper to login as admin and return cookies."""
+    resp = client.post(
+        "/api/auth/login", json={"username": username, "api_key": api_key}
+    )
+    assert resp.status_code == 200
+    return resp.cookies
+
+
+class TestAuthLogin:
+    def test_admin_login_success(self, client):
+        resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "test-admin-key-16chars",  # pragma: allowlist secret
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "admin"
+        assert data["is_admin"] is True
+        assert data["role"] == "admin"
+        assert "jji_session" in resp.cookies
+
+    def test_admin_login_wrong_key(self, client):
+        resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "wrong-key",  # pragma: allowlist secret
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_admin_login_missing_fields(self, client):
+        resp = client.post("/api/auth/login", json={"username": "admin"})
+        assert resp.status_code == 400
+
+    def test_login_invalid_json(self, client):
+        resp = client.post(
+            "/api/auth/login",
+            content="not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+
+class TestAuthMe:
+    def test_me_as_admin(self, client):
+        cookies = _admin_login(client)
+        resp = client.get("/api/auth/me", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_admin"] is True
+        assert data["role"] == "admin"
+
+    def test_me_as_regular_user(self, client):
+        resp = client.get("/api/auth/me", cookies={"jji_username": "testuser"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "testuser"
+        assert data["is_admin"] is False
+        assert data["role"] == "user"
+
+    def test_me_no_auth(self, client):
+        resp = client.get("/api/auth/me")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == ""
+        assert data["is_admin"] is False
+
+
+class TestAuthLogout:
+    def test_logout(self, client):
+        cookies = _admin_login(client)
+        resp = client.post("/api/auth/logout", cookies=cookies)
+        assert resp.status_code == 200
+        # Session should be invalidated
+        resp2 = client.get("/api/auth/me", cookies=cookies)
+        data = resp2.json()
+        assert data["is_admin"] is False
+
+
+class TestAdminUsers:
+    def test_create_admin_user(self, client):
+        cookies = _admin_login(client)
+        resp = client.post(
+            "/api/admin/users", json={"username": "newadmin"}, cookies=cookies
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "newadmin"
+        assert data["role"] == "admin"
+        assert "api_key" in data
+
+    def test_create_admin_requires_auth(self, client):
+        resp = client.post("/api/admin/users", json={"username": "newadmin"})
+        assert resp.status_code == 403
+
+    def test_create_admin_regular_user_forbidden(self, client):
+        resp = client.post(
+            "/api/admin/users",
+            json={"username": "newadmin"},
+            cookies={"jji_username": "regular"},
+        )
+        assert resp.status_code == 403
+
+    def test_list_users(self, client):
+        cookies = _admin_login(client)
+        resp = client.get("/api/admin/users", cookies=cookies)
+        assert resp.status_code == 200
+        assert "users" in resp.json()
+
+    def test_list_users_requires_admin(self, client):
+        resp = client.get("/api/admin/users", cookies={"jji_username": "regular"})
+        assert resp.status_code == 403
+
+    def test_delete_admin_user(self, client):
+        cookies = _admin_login(client)
+        # Create then delete
+        client.post("/api/admin/users", json={"username": "todelete"}, cookies=cookies)
+        resp = client.delete("/api/admin/users/todelete", cookies=cookies)
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == "todelete"
+
+    def test_delete_self_forbidden(self, client):
+        cookies = _admin_login(client)
+        resp = client.delete("/api/admin/users/admin", cookies=cookies)
+        assert resp.status_code == 400
+
+    def test_delete_nonexistent(self, client):
+        cookies = _admin_login(client)
+        resp = client.delete("/api/admin/users/nonexistent", cookies=cookies)
+        assert resp.status_code == 404
+
+    def test_rotate_key(self, client):
+        cookies = _admin_login(client)
+        client.post(
+            "/api/admin/users", json={"username": "rotateuser"}, cookies=cookies
+        )
+        resp = client.post("/api/admin/users/rotateuser/rotate-key", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "rotateuser"
+        assert "new_api_key" in data
+
+
+class TestDeleteJobAdminOnly:
+    def test_delete_job_requires_admin(self, client):
+        """Regular users cannot delete jobs."""
+        resp = client.delete(
+            "/results/fake-job-id", cookies={"jji_username": "regular"}
+        )
+        assert resp.status_code == 403
+
+    def test_delete_job_no_auth(self, client):
+        """Unauthenticated users cannot delete jobs."""
+        resp = client.delete("/results/fake-job-id")
+        assert resp.status_code == 403
+
+    def test_delete_job_as_admin(self, client):
+        """Admin can delete jobs."""
+        cookies = _admin_login(client)
+        # Will get 404 since job doesn't exist, but NOT 403
+        resp = client.delete("/results/fake-job-id", cookies=cookies)
+        assert resp.status_code == 404  # Not found, not forbidden
+
+
+class TestBearerTokenAuth:
+    def test_bearer_admin_key(self, client):
+        """Bearer token with admin_key works."""
+        resp = client.get(
+            "/api/auth/me",
+            headers={"Authorization": "Bearer test-admin-key-16chars"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_admin"] is True
+
+    def test_bearer_user_api_key(self, client):
+        """Bearer token with user API key works."""
+        # Create admin user via Bearer token (admin key)
+        create_resp = client.post(
+            "/api/admin/users",
+            json={"username": "apiuser"},
+            headers={"Authorization": "Bearer test-admin-key-16chars"},
+        )
+        assert create_resp.status_code == 200
+        api_key = create_resp.json()["api_key"]
+        # Use the created user's API key as Bearer token
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {api_key}"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "apiuser"
+        assert data["is_admin"] is True
+
+    def test_bearer_invalid_key(self, client):
+        """Bearer token with invalid key returns non-admin."""
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": "Bearer invalid-key"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_admin"] is False
+
+
+class TestChangeUserRole:
+    def test_promote_user_to_admin(self, client):
+        cookies = _admin_login(client)
+        # Create as admin first, demote to user, then promote back
+        client.post(
+            "/api/admin/users", json={"username": "promoteuser"}, cookies=cookies
+        )
+        client.put(
+            "/api/admin/users/promoteuser/role",
+            json={"role": "user"},
+            cookies=cookies,
+        )
+        # Now promote from user to admin
+        resp = client.put(
+            "/api/admin/users/promoteuser/role",
+            json={"role": "admin"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "promoteuser"
+        assert data["role"] == "admin"
+        assert "api_key" in data  # API key generated on promotion
+
+    def test_demote_admin_to_user(self, client):
+        cookies = _admin_login(client)
+        # Create admin user
+        client.post("/api/admin/users", json={"username": "demoteme"}, cookies=cookies)
+        # Demote to user
+        resp = client.put(
+            "/api/admin/users/demoteme/role",
+            json={"role": "user"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["role"] == "user"
+        assert "api_key" not in data  # No key for regular users
+
+    def test_change_role_requires_admin(self, client):
+        resp = client.put(
+            "/api/admin/users/someone/role",
+            json={"role": "admin"},
+            cookies={"jji_username": "regular"},
+        )
+        assert resp.status_code == 403
+
+    def test_change_role_cannot_change_self(self, client):
+        cookies = _admin_login(client)
+        resp = client.put(
+            "/api/admin/users/admin/role",
+            json={"role": "user"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 400
+
+    def test_change_role_same_role(self, client):
+        cookies = _admin_login(client)
+        client.post(
+            "/api/admin/users", json={"username": "alreadyadmin"}, cookies=cookies
+        )
+        resp = client.put(
+            "/api/admin/users/alreadyadmin/role",
+            json={"role": "admin"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 400
+
+    def test_change_role_missing_role(self, client):
+        cookies = _admin_login(client)
+        resp = client.put(
+            "/api/admin/users/someone/role",
+            json={},
+            cookies=cookies,
+        )
+        assert resp.status_code == 400
+
+    def test_change_role_user_not_found(self, client):
+        cookies = _admin_login(client)
+        resp = client.put(
+            "/api/admin/users/nonexistent/role",
+            json={"role": "admin"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 404
+
+
+class TestUserTokens:
+    def test_save_and_get_tokens(self, client):
+        """Tokens round-trip through encrypt/decrypt."""
+        import time
+
+        # Track a user first
+        client.get("/api/dashboard", cookies={"jji_username": "tokenuser"})
+        time.sleep(0.1)
+        # Save tokens
+        resp = client.put(
+            "/api/user/tokens",
+            json={
+                "github_token": "ghp_test123",
+                "jira_email": "a@b.com",
+                "jira_token": "jira_tok",
+            },
+            cookies={"jji_username": "tokenuser"},
+        )
+        assert resp.status_code == 200
+        # Get tokens back
+        resp = client.get("/api/user/tokens", cookies={"jji_username": "tokenuser"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["github_token"] == "ghp_test123"
+        assert data["jira_email"] == "a@b.com"
+        assert data["jira_token"] == "jira_tok"
+
+    def test_get_tokens_no_user(self, client):
+        resp = client.get("/api/user/tokens")
+        assert resp.status_code == 401
+
+    def test_save_tokens_no_user(self, client):
+        resp = client.put("/api/user/tokens", json={"github_token": "x"})
+        assert resp.status_code == 401
+
+    def test_get_tokens_nonexistent_user(self, client):
+        """Non-tracked user gets empty tokens."""
+        resp = client.get("/api/user/tokens", cookies={"jji_username": "ghost"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["github_token"] == ""
+
+    def test_save_partial_tokens(self, client):
+        """Can save just one token without affecting others."""
+        import time
+
+        client.get("/api/dashboard", cookies={"jji_username": "partial"})
+        time.sleep(0.1)
+        # Save only github_token
+        client.put(
+            "/api/user/tokens",
+            json={"github_token": "ghp_only"},
+            cookies={"jji_username": "partial"},
+        )
+        resp = client.get("/api/user/tokens", cookies={"jji_username": "partial"})
+        data = resp.json()
+        assert data["github_token"] == "ghp_only"
+        assert data["jira_email"] == ""
+
+    def test_tokens_encrypted_at_rest(self, client, temp_db_path):
+        """Verify tokens are not stored as plaintext in the DB."""
+        import asyncio
+        import time
+
+        import aiosqlite
+
+        client.get("/api/dashboard", cookies={"jji_username": "enctest"})
+        time.sleep(0.1)
+        client.put(
+            "/api/user/tokens",
+            json={"github_token": "ghp_secret_value"},
+            cookies={"jji_username": "enctest"},
+        )
+
+        # Read raw DB value
+        async def check():
+            async with aiosqlite.connect(temp_db_path) as db:
+                cursor = await db.execute(
+                    "SELECT github_token_enc FROM users WHERE username = 'enctest'"
+                )
+                row = await cursor.fetchone()
+                assert row is not None
+                raw = row[0]
+                assert raw != "ghp_secret_value"  # Not plaintext
+                assert raw.startswith("enc:")  # Encrypted
+
+        asyncio.run(check())
+
+
+class TestUserTracking:
+    def test_regular_user_tracked(self, client):
+        """Regular user activity is tracked in the users table."""
+        import time
+
+        # Make a request as a regular user
+        client.get("/api/dashboard", cookies={"jji_username": "trackeduser"})
+        # Give the fire-and-forget task a moment
+        time.sleep(0.1)
+        # Check the user was tracked
+        cookies = _admin_login(client)
+        resp = client.get("/api/admin/users", cookies=cookies)
+        users = resp.json()["users"]
+        usernames = [u["username"] for u in users]
+        assert "trackeduser" in usernames

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,20 +27,17 @@ def client(_init_db, temp_db_path):
         os.environ,
         {
             "ADMIN_KEY": "test-admin-key-16chars",  # pragma: allowlist secret
+            "JJI_ENCRYPTION_KEY": "test-encryption-key-for-hmac",  # pragma: allowlist secret
             "SECURE_COOKIES": "false",
         },
     ):
         get_settings.cache_clear()
         with patch.object(storage, "DB_PATH", temp_db_path):
-            storage.configure_admin_key(
-                "test-admin-key-16chars"
-            )  # pragma: allowlist secret
             from jenkins_job_insight.main import app
 
             with TestClient(app) as c:
                 yield c
         get_settings.cache_clear()
-        storage.configure_admin_key("")  # cleanup
 
 
 def _admin_login(
@@ -386,21 +383,36 @@ class TestUserTokens:
         assert data["github_token"] == ""
 
     def test_save_partial_tokens(self, client):
-        """Can save just one token without affecting others."""
+        """Saving one token should NOT wipe others."""
         import time
 
         client.get("/api/dashboard", cookies={"jji_username": "partial"})
         time.sleep(0.1)
-        # Save only github_token
+
+        # Save all three tokens
         client.put(
             "/api/user/tokens",
-            json={"github_token": "ghp_only"},
+            json={
+                "github_token": "ghp_original",
+                "jira_email": "orig@test.com",
+                "jira_token": "jira_orig",
+            },
             cookies={"jji_username": "partial"},
         )
+
+        # Now update ONLY github_token
+        client.put(
+            "/api/user/tokens",
+            json={"github_token": "ghp_updated"},
+            cookies={"jji_username": "partial"},
+        )
+
+        # Verify jira tokens were NOT wiped
         resp = client.get("/api/user/tokens", cookies={"jji_username": "partial"})
         data = resp.json()
-        assert data["github_token"] == "ghp_only"
-        assert data["jira_email"] == ""
+        assert data["github_token"] == "ghp_updated"
+        assert data["jira_email"] == "orig@test.com"  # NOT wiped
+        assert data["jira_token"] == "jira_orig"  # NOT wiped
 
     def test_tokens_encrypted_at_rest(self, client, temp_db_path):
         """Verify tokens are not stored as plaintext in the DB."""
@@ -430,6 +442,88 @@ class TestUserTokens:
                 assert raw.startswith("enc:")  # Encrypted
 
         asyncio.run(check())
+
+
+class TestAdminDeleteComment:
+    def test_admin_can_delete_other_users_comment(self, client):
+        """Admin should be able to delete comments from other users."""
+        import asyncio
+
+        cookies = _admin_login(client)
+
+        # Create a result with a failure so comment endpoints work
+        result_data = {
+            "status": "completed",
+            "summary": "",
+            "failures": [
+                {
+                    "test_name": "test_foo",
+                    "error": "err",
+                    "analysis": {"classification": "CODE ISSUE"},
+                }
+            ],
+        }
+        asyncio.run(
+            storage.save_result(
+                "test-job-1", "http://jenkins/1", "completed", result_data
+            )
+        )
+
+        # Add a comment directly as "regularuser"
+        comment_id = asyncio.run(
+            storage.add_comment(
+                job_id="test-job-1",
+                test_name="test_foo",
+                comment="regular user comment",
+                username="regularuser",
+            )
+        )
+
+        # Admin deletes the regular user's comment
+        resp = client.delete(
+            f"/results/test-job-1/comments/{comment_id}",
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+
+    def test_regular_user_cannot_delete_other_users_comment(self, client):
+        """Regular user should NOT be able to delete another user's comment."""
+        import asyncio
+
+        # Create a result with a failure
+        result_data = {
+            "status": "completed",
+            "summary": "",
+            "failures": [
+                {
+                    "test_name": "test_bar",
+                    "error": "err",
+                    "analysis": {"classification": "CODE ISSUE"},
+                }
+            ],
+        }
+        asyncio.run(
+            storage.save_result(
+                "test-job-2", "http://jenkins/2", "completed", result_data
+            )
+        )
+
+        # Add a comment directly as "alice"
+        comment_id = asyncio.run(
+            storage.add_comment(
+                job_id="test-job-2",
+                test_name="test_bar",
+                comment="alice's comment",
+                username="alice",
+            )
+        )
+
+        # "bob" tries to delete alice's comment — should fail
+        resp = client.delete(
+            f"/results/test-job-2/comments/{comment_id}",
+            cookies={"jji_username": "bob"},
+        )
+        assert resp.status_code == 404  # Not found (not owned by bob)
 
 
 class TestUserTracking:

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1185,3 +1185,169 @@ class TestJJIClientPushReportPortal:
         with pytest.raises(JJIError) as exc_info:
             client.push_reportportal("job-123")
         assert exc_info.value.status_code == 400
+
+
+class TestJJIClientAuth:
+    def test_login(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/auth/login"
+            body = json.loads(request.content)
+            assert body["username"] == "admin"
+            assert body["api_key"] == "test-key"  # noqa: S105  # pragma: allowlist secret
+            return httpx.Response(
+                200,
+                json={"username": "admin", "role": "admin", "is_admin": True},
+            )
+
+        client = _make_client(handler)
+        result = client.login("admin", "test-key")
+        assert result["username"] == "admin"
+        assert result["is_admin"] is True
+
+    def test_logout(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/auth/logout"
+            return httpx.Response(200, json={"status": "logged_out"})
+
+        client = _make_client(handler)
+        result = client.logout()
+        assert result["status"] == "logged_out"
+
+    def test_auth_me(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/auth/me"
+            return httpx.Response(
+                200,
+                json={"username": "admin", "role": "admin", "is_admin": True},
+            )
+
+        client = _make_client(handler)
+        result = client.auth_me()
+        assert result["username"] == "admin"
+
+    def test_login_wrong_key(self):
+        client = _make_client(
+            lambda request: httpx.Response(401, json={"detail": "Invalid credentials"})
+        )
+        with pytest.raises(JJIError) as exc_info:
+            client.login("admin", "wrong-key")
+        assert exc_info.value.status_code == 401
+
+
+class TestJJIClientAdminUsers:
+    def test_admin_list_users(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/admin/users"
+            return httpx.Response(
+                200,
+                json={"users": [{"username": "admin", "role": "admin"}]},
+            )
+
+        client = _make_client(handler)
+        result = client.admin_list_users()
+        assert "users" in result
+        assert result["users"][0]["username"] == "admin"
+
+    def test_admin_create_user(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/admin/users"
+            body = json.loads(request.content)
+            assert body["username"] == "newadmin"
+            return httpx.Response(
+                200,
+                json={
+                    "username": "newadmin",
+                    "api_key": "not-a-real-key",  # pragma: allowlist secret
+                    "role": "admin",
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.admin_create_user("newadmin")
+        assert result["username"] == "newadmin"
+        assert "api_key" in result
+
+    def test_admin_delete_user(self):
+        def handler(request):
+            assert request.method == "DELETE"
+            assert "/api/admin/users/oldadmin" in str(request.url)
+            return httpx.Response(200, json={"deleted": "oldadmin"})
+
+        client = _make_client(handler)
+        result = client.admin_delete_user("oldadmin")
+        assert result["deleted"] == "oldadmin"
+
+    def test_admin_rotate_key(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert "/api/admin/users/myuser/rotate-key" in str(request.url)
+            return httpx.Response(
+                200,
+                json={
+                    "username": "myuser",
+                    "new_api_key": "not-a-real-key",  # pragma: allowlist secret
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.admin_rotate_key("myuser")
+        assert result["username"] == "myuser"
+        assert result["new_api_key"] == "not-a-real-key"  # pragma: allowlist secret
+
+    def test_admin_change_role(self):
+        def handler(request):
+            assert request.url.path == "/api/admin/users/myuser/role"
+            assert request.method == "PUT"
+            body = json.loads(request.content)
+            assert body["role"] == "admin"
+            return httpx.Response(
+                200,
+                json={
+                    "username": "myuser",
+                    "role": "admin",
+                    "api_key": "not-a-real-key",  # pragma: allowlist secret
+                },
+            )
+
+        client = _make_client(handler, api_key="test-key")
+        result = client.admin_change_role("myuser", "admin")
+        assert result["role"] == "admin"
+        assert result["api_key"] == "not-a-real-key"  # pragma: allowlist secret
+
+    def test_admin_create_user_forbidden(self):
+        client = _make_client(
+            lambda request: httpx.Response(
+                403, json={"detail": "Admin access required"}
+            )
+        )
+        with pytest.raises(JJIError) as exc_info:
+            client.admin_create_user("newadmin")
+        assert exc_info.value.status_code == 403
+
+
+class TestJJIClientApiKeyHeader:
+    def test_api_key_sent_as_bearer_header(self):
+        def check_header(request):
+            auth = request.headers.get("authorization", "")
+            assert auth == "Bearer test-api-key"  # noqa: S105
+            return httpx.Response(
+                200,
+                json={"username": "admin", "role": "admin", "is_admin": True},
+            )
+
+        client = _make_client(check_header, api_key="test-api-key")  # noqa: S106
+        client.auth_me()
+
+    def test_no_api_key_no_auth_header(self):
+        def check_no_auth(request):
+            auth = request.headers.get("authorization", "")
+            assert auth == ""
+            return httpx.Response(200, json={"status": "ok"})
+
+        client = _make_client(check_no_auth)
+        client.health()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -504,14 +504,25 @@ class TestErrorHandling:
         assert result.exit_code != 0
         assert "404" in result.output or "not found" in result.output.lower()
 
-    def test_401_error_hints_about_user_flag(self, mock_client):
-        """_handle_error should hint about --user when server returns 401."""
+    def test_401_error_hints_about_api_key_flag(self, mock_client):
+        """_handle_error should hint about --api-key when server returns 401."""
         mock_client.delete_job.side_effect = JJIError(
             status_code=401, detail="Please register a username first"
         )
         result = runner.invoke(app, ["results", "delete", "job-123"])
         assert result.exit_code == 1
-        assert "--user" in result.output
+        assert "--api-key" in result.output
+        assert "JJI_API_KEY" in result.output
+
+    def test_403_error_hints_about_admin_access(self, mock_client):
+        """_handle_error should hint about admin access when server returns 403."""
+        mock_client.delete_job.side_effect = JJIError(
+            status_code=403, detail="Admin access required"
+        )
+        result = runner.invoke(app, ["results", "delete", "job-123"])
+        assert result.exit_code == 1
+        assert "admin access" in result.output.lower()
+        assert "--api-key" in result.output
 
 
 class TestNullFieldHandling:
@@ -1368,7 +1379,7 @@ class TestNoVerifySSL:
             result = runner.invoke(app, ["--no-verify-ssl", "health"])
             assert result.exit_code == 0
             mock_cls.assert_called_once_with(
-                server_url=_TEST_SERVER, username="", verify_ssl=False
+                server_url=_TEST_SERVER, username="", verify_ssl=False, api_key=""
             )
 
     def test_without_no_verify_ssl_flag(self):
@@ -1390,7 +1401,7 @@ class TestNoVerifySSL:
             result = runner.invoke(app, ["health"])
             assert result.exit_code == 0
             mock_cls.assert_called_once_with(
-                server_url=_TEST_SERVER, username="", verify_ssl=True
+                server_url=_TEST_SERVER, username="", verify_ssl=True, api_key=""
             )
 
     def test_no_verify_ssl_env_var(self):
@@ -1417,7 +1428,7 @@ class TestNoVerifySSL:
             result = runner.invoke(app, ["health"])
             assert result.exit_code == 0
             mock_cls.assert_called_once_with(
-                server_url=_TEST_SERVER, username="", verify_ssl=False
+                server_url=_TEST_SERVER, username="", verify_ssl=False, api_key=""
             )
 
 
@@ -2374,3 +2385,330 @@ class TestPushRpCommand:
             child_job_name="my-child",
             child_build_number=42,
         )
+
+
+class TestAuthLoginCommand:
+    def test_auth_login(self, mock_client):
+        mock_client.login.return_value = {
+            "username": "admin",
+            "role": "admin",
+            "is_admin": True,
+        }
+        result = runner.invoke(
+            app,
+            ["auth", "login", "--username", "admin", "--api-key", "test-key"],  # noqa: S106
+        )
+        assert result.exit_code == 0
+        assert "Logged in as admin" in result.output
+        assert "admin: True" in result.output
+        mock_client.login.assert_called_once_with("admin", "test-key")
+
+    def test_auth_login_json(self, mock_client):
+        mock_client.login.return_value = {
+            "username": "admin",
+            "role": "admin",
+            "is_admin": True,
+        }
+        result = runner.invoke(
+            app,
+            ["--json", "auth", "login", "--username", "admin", "--api-key", "key"],  # noqa: S106
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["is_admin"] is True
+
+    def test_auth_login_error(self, mock_client):
+        mock_client.login.side_effect = JJIError(status_code=401, detail="Invalid")
+        result = runner.invoke(
+            app,
+            ["auth", "login", "--username", "admin", "--api-key", "bad"],  # noqa: S106
+        )
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+class TestAuthLogoutCommand:
+    def test_auth_logout(self, mock_client):
+        mock_client.logout.return_value = {"status": "logged_out"}
+        result = runner.invoke(app, ["auth", "logout"])
+        assert result.exit_code == 0
+
+    def test_auth_logout_json(self, mock_client):
+        mock_client.logout.return_value = {"status": "logged_out"}
+        result = runner.invoke(app, ["--json", "auth", "logout"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["status"] == "logged_out"
+
+
+class TestAuthWhoamiCommand:
+    def test_auth_whoami(self, mock_client):
+        mock_client.auth_me.return_value = {
+            "username": "admin",
+            "role": "admin",
+            "is_admin": True,
+        }
+        result = runner.invoke(app, ["auth", "whoami"])
+        assert result.exit_code == 0
+        assert "admin" in result.output
+
+    def test_auth_whoami_json(self, mock_client):
+        mock_client.auth_me.return_value = {
+            "username": "testuser",
+            "role": "user",
+            "is_admin": False,
+        }
+        result = runner.invoke(app, ["--json", "auth", "whoami"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["username"] == "testuser"
+        assert parsed["is_admin"] is False
+
+
+class TestAdminUsersListCommand:
+    def test_admin_users_list(self, mock_client):
+        mock_client.admin_list_users.return_value = {
+            "users": [
+                {
+                    "username": "admin",
+                    "role": "admin",
+                    "created_at": "2026-01-01",
+                    "last_seen": "2026-04-18",
+                },
+            ]
+        }
+        result = runner.invoke(app, ["admin", "users", "list"])
+        assert result.exit_code == 0
+        assert "admin" in result.output
+
+    def test_admin_users_list_json(self, mock_client):
+        mock_client.admin_list_users.return_value = {
+            "users": [{"username": "admin", "role": "admin"}]
+        }
+        result = runner.invoke(app, ["--json", "admin", "users", "list"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "users" in parsed
+
+
+class TestAdminUsersCreateCommand:
+    def test_admin_users_create(self, mock_client):
+        mock_client.admin_create_user.return_value = {
+            "username": "newadmin",
+            "api_key": "not-a-real-key",  # pragma: allowlist secret
+            "role": "admin",
+        }
+        result = runner.invoke(app, ["admin", "users", "create", "newadmin"])
+        assert result.exit_code == 0
+        assert "Created admin user: newadmin" in result.output
+        assert "not-a-real-key" in result.output
+        assert "Save this API key" in result.output
+        mock_client.admin_create_user.assert_called_once_with("newadmin")
+
+    def test_admin_users_create_json(self, mock_client):
+        mock_client.admin_create_user.return_value = {
+            "username": "newadmin",
+            "api_key": "not-a-real-key",  # pragma: allowlist secret
+            "role": "admin",
+        }
+        result = runner.invoke(app, ["--json", "admin", "users", "create", "newadmin"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["username"] == "newadmin"
+        assert parsed["api_key"] == "not-a-real-key"  # pragma: allowlist secret
+
+    def test_admin_users_create_error(self, mock_client):
+        mock_client.admin_create_user.side_effect = JJIError(
+            status_code=403, detail="Admin access required"
+        )
+        result = runner.invoke(app, ["admin", "users", "create", "newadmin"])
+        assert result.exit_code == 1
+
+
+class TestAdminUsersDeleteCommand:
+    def test_admin_users_delete_with_force(self, mock_client):
+        mock_client.admin_delete_user.return_value = {"deleted": "oldadmin"}
+        result = runner.invoke(app, ["admin", "users", "delete", "oldadmin", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted admin user: oldadmin" in result.output
+        mock_client.admin_delete_user.assert_called_once_with("oldadmin")
+
+    def test_admin_users_delete_with_confirm(self, mock_client):
+        mock_client.admin_delete_user.return_value = {"deleted": "oldadmin"}
+        result = runner.invoke(
+            app, ["admin", "users", "delete", "oldadmin"], input="y\n"
+        )
+        assert result.exit_code == 0
+        assert "Deleted admin user: oldadmin" in result.output
+
+    def test_admin_users_delete_aborted(self, mock_client):
+        result = runner.invoke(
+            app, ["admin", "users", "delete", "oldadmin"], input="n\n"
+        )
+        assert result.exit_code != 0  # Abort
+
+    def test_admin_users_delete_json(self, mock_client):
+        mock_client.admin_delete_user.return_value = {"deleted": "oldadmin"}
+        result = runner.invoke(
+            app, ["--json", "admin", "users", "delete", "oldadmin", "--force"]
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["deleted"] == "oldadmin"
+
+
+class TestAdminUsersRotateKeyCommand:
+    def test_admin_users_rotate_key(self, mock_client):
+        mock_client.admin_rotate_key.return_value = {
+            "username": "myuser",
+            "new_api_key": "not-a-real-key",  # pragma: allowlist secret
+        }
+        result = runner.invoke(app, ["admin", "users", "rotate-key", "myuser"])
+        assert result.exit_code == 0
+        assert "Rotated API key for: myuser" in result.output
+        assert "not-a-real-key" in result.output
+        assert "Save this API key" in result.output
+        mock_client.admin_rotate_key.assert_called_once_with("myuser")
+
+    def test_admin_users_rotate_key_json(self, mock_client):
+        mock_client.admin_rotate_key.return_value = {
+            "username": "myuser",
+            "new_api_key": "not-a-real-key",  # pragma: allowlist secret
+        }
+        result = runner.invoke(
+            app, ["--json", "admin", "users", "rotate-key", "myuser"]
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["new_api_key"] == "not-a-real-key"  # pragma: allowlist secret
+
+    def test_admin_users_rotate_key_error(self, mock_client):
+        mock_client.admin_rotate_key.side_effect = JJIError(
+            status_code=404, detail="User not found"
+        )
+        result = runner.invoke(app, ["admin", "users", "rotate-key", "nonexistent"])
+        assert result.exit_code == 1
+
+
+class TestAdminUsersChangeRole:
+    def test_change_role_promote(self, mock_client):
+        mock_client.admin_change_role.return_value = {
+            "username": "myuser",
+            "role": "admin",
+            "api_key": "not-a-real-key",  # pragma: allowlist secret
+        }
+        result = runner.invoke(
+            app, ["admin", "users", "change-role", "myuser", "admin"]
+        )
+        assert result.exit_code == 0
+        assert "admin" in result.output
+        assert "not-a-real-key" in result.output
+
+    def test_change_role_demote(self, mock_client):
+        mock_client.admin_change_role.return_value = {
+            "username": "myuser",
+            "role": "user",
+        }
+        result = runner.invoke(app, ["admin", "users", "change-role", "myuser", "user"])
+        assert result.exit_code == 0
+        assert "user" in result.output
+        assert "API Key" not in result.output
+
+    def test_change_role_json(self, mock_client):
+        mock_client.admin_change_role.return_value = {
+            "username": "myuser",
+            "role": "admin",
+            "api_key": "not-a-real-key",  # pragma: allowlist secret
+        }
+        result = runner.invoke(
+            app, ["--json", "admin", "users", "change-role", "myuser", "admin"]
+        )
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["role"] == "admin"
+
+
+class TestApiKeyOption:
+    def test_api_key_passed_to_client(self):
+        """--api-key should cause _get_client to create client with api_key."""
+        with (
+            patch.dict(
+                os.environ,
+                {"JJI_SERVER": _TEST_SERVER, "JJI_USERNAME": ""},
+                clear=True,
+            ),
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=ServerConfig(url=_TEST_SERVER),
+            ),
+            patch("jenkins_job_insight.cli.main.JJIClient") as mock_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.health.return_value = {"status": "healthy"}
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(
+                app,
+                ["--api-key", "my-secret-key", "health"],  # noqa: S106
+            )
+            assert result.exit_code == 0
+            mock_cls.assert_called_once_with(
+                server_url=_TEST_SERVER,
+                username="",
+                verify_ssl=True,
+                api_key="my-secret-key",  # pragma: allowlist secret
+            )
+
+    def test_api_key_from_config(self):
+        """api_key from config should be used when --api-key is not given."""
+        cfg = ServerConfig(
+            url=_TEST_SERVER,
+            api_key="config-key",  # pragma: allowlist secret
+        )
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=cfg,
+            ),
+            patch("jenkins_job_insight.cli.main.JJIClient") as mock_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.health.return_value = {"status": "healthy"}
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(app, ["health"])
+            assert result.exit_code == 0
+            mock_cls.assert_called_once_with(
+                server_url=_TEST_SERVER,
+                username="",
+                verify_ssl=True,
+                api_key="config-key",  # pragma: allowlist secret
+            )
+
+    def test_cli_api_key_overrides_config(self):
+        """CLI --api-key should override config api_key."""
+        cfg = ServerConfig(
+            url=_TEST_SERVER,
+            api_key="config-key",  # pragma: allowlist secret
+        )
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=cfg,
+            ),
+            patch("jenkins_job_insight.cli.main.JJIClient") as mock_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.health.return_value = {"status": "healthy"}
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(
+                app,
+                ["--api-key", "cli-key", "health"],  # noqa: S106
+            )
+            assert result.exit_code == 0
+            mock_cls.assert_called_once_with(
+                server_url=_TEST_SERVER,
+                username="",
+                verify_ssl=True,
+                api_key="cli-key",  # pragma: allowlist secret
+            )


### PR DESCRIPTION
Closes #126

## Summary

Adds admin authentication, user tracking, and role management to JJI while keeping the open-access experience for regular users.

## What Changed

### Backend
- **Auth middleware** replaces `UsernameMiddleware` — admin auth via session cookies + Bearer tokens, regular users via `jji_username` cookie (unchanged)
- **`ADMIN_KEY` env var** bootstraps the first admin superuser (login with username `admin` + the key)
- **Users table** tracks all users (regular + admin) with `username`, `role`, `created_at`, `last_seen`
- **Sessions table** for admin session tokens (8h TTL, hashed before storage)
- **API key hashing** uses `JJI_ENCRYPTION_KEY` as HMAC pepper (decoupled from `ADMIN_KEY` rotation)
- **Server-side token storage** — GitHub token, Jira email, Jira token encrypted at rest per user
- **Admin-only job deletion** — `DELETE /results/{job_id}` restricted to admin
- **Admin comment deletion** — admins can delete any user's comments
- **Bounded user tracking** — `asyncio.Semaphore(10)` caps concurrent `track_user` tasks

### API Endpoints (new)
| Endpoint | Description |
|----------|-------------|
| `POST /api/auth/login` | Admin login (username + API key → session cookie) |
| `POST /api/auth/logout` | Clear admin session |
| `GET /api/auth/me` | Current user info (role, is_admin) |
| `POST /api/admin/users` | Create admin user (returns API key) |
| `DELETE /api/admin/users/{username}` | Delete admin user |
| `GET /api/admin/users` | List all users (admin-only) |
| `PUT /api/admin/users/{username}/role` | Change user role (promote/demote) |
| `POST /api/admin/users/{username}/rotate-key` | Rotate admin API key |
| `GET /api/user/tokens` | Get saved user tokens (encrypted at rest) |
| `PUT /api/user/tokens` | Save user tokens (partial update safe) |

### Frontend
- **Unified register/login page** — optional API key field for admin authentication
- **Admin badge** in navbar (shield icon + "Admin" label)
- **Users page** (`/admin/users`) — admin-only user management with role dropdown, key rotation, create/delete
- **Delete button** only visible to admins on dashboard
- **Auth context** (`AuthProvider`) — calls `/api/auth/me` on load, syncs tokens from server
- **Server-side token sync** — tokens loaded from server on login, saved on profile update

### CLI
- `jji auth login/logout/whoami` — admin authentication commands
- `jji admin users list/create/delete/change-role/rotate-key` — admin user management
- `--api-key` global option + `JJI_API_KEY` env var for Bearer token auth
- `api_key` field in `~/.config/jji/config.toml` server configs

### OpenShift
- New `jenkins-job-insight-admin-key` secret + wired into deployment

## Testing
- 1188 backend tests + 80 frontend tests (all passing)
- New `tests/test_auth.py` with 28 tests covering login, logout, auth/me, admin CRUD, role changes, Bearer tokens, user tracking, comment deletion, token storage
- CLI client + CLI main tests for all new commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side admin auth (login/logout/whoami), admin user management (create/delete/role/rotate) with audit logs, CLI admin commands, web Users management page, and admin-only UI/controls (protected routes, badges, conditional actions).
  * Frontend-wide auth context, async login/logout flows, and server-synced encrypted token storage accessible across browsers.

* **Documentation**
  * Clarified server-only admin key handling and secure-cookie guidance (default: secure cookies).

* **Chores**
  * Extended credential-scan allowlist for additional test files.

* **Tests**
  * Expanded end-to-end and CLI tests for auth, admin flows, token persistence, and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->