### PR TITLE
fix: prevent bootstrap admin from appearing as regular user

### DIFF
--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -285,50 +285,54 @@ export function UsersPage() {
                   {user.last_seen ? formatTimestamp(user.last_seen) : '—'}
                 </TableCell>
                 <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    {/* Role select */}
-                    <Select
-                      value={user.role}
-                      onValueChange={(newRole) => {
-                        if (newRole !== user.role) {
-                          setRoleChangeTarget({ username: user.username, currentRole: user.role, newRole })
-                        }
-                      }}
-                    >
-                      <SelectTrigger className="h-7 w-[80px] text-xs">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="user">user</SelectItem>
-                        <SelectItem value="admin">admin</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    {/* Rotate key — only for admins (regular users have no API key) */}
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Rotate key for ${user.username}`}
-                      className={`h-7 w-7${user.role !== 'admin' ? ' invisible' : ''}`}
-                      title="Rotate API key"
-                      disabled={user.role !== 'admin'}
-                      onClick={() => setRotateTarget(user.username)}
-                    >
-                      <RefreshCw className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-blue" />
-                    </Button>
-                    {/* Delete */}
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Delete ${user.username}`}
-                      className="h-7 w-7"
-                      title="Delete user"
-                      onClick={() => setDeleteTarget(user.username)}
-                    >
-                      <Trash2 className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-red" />
-                    </Button>
-                  </div>
+                  {user.username === 'admin' ? (
+                    <span className="text-xs text-text-tertiary italic">built-in</span>
+                  ) : (
+                    <div className="flex items-center justify-end gap-1">
+                      {/* Role select */}
+                      <Select
+                        value={user.role}
+                        onValueChange={(newRole) => {
+                          if (newRole !== user.role) {
+                            setRoleChangeTarget({ username: user.username, currentRole: user.role, newRole })
+                          }
+                        }}
+                      >
+                        <SelectTrigger className="h-7 w-[80px] text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="user">user</SelectItem>
+                          <SelectItem value="admin">admin</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {/* Rotate key — only for admins (regular users have no API key) */}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Rotate key for ${user.username}`}
+                        className={`h-7 w-7${user.role !== 'admin' ? ' invisible' : ''}`}
+                        title="Rotate API key"
+                        disabled={user.role !== 'admin'}
+                        onClick={() => setRotateTarget(user.username)}
+                      >
+                        <RefreshCw className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-blue" />
+                      </Button>
+                      {/* Delete */}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete ${user.username}`}
+                        className="h-7 w-7"
+                        title="Delete user"
+                        onClick={() => setDeleteTarget(user.username)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-text-tertiary hover:text-signal-red" />
+                      </Button>
+                    </div>
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2519,7 +2519,12 @@ async def list_users() -> list[dict]:
 
 
 async def track_user(username: str) -> None:
-    """Track user activity — insert if new, update last_seen if existing."""
+    """Track user activity — insert if new, update last_seen if existing.
+
+    Skips the reserved 'admin' username (bootstrap superuser).
+    """
+    if username.lower() == "admin":
+        return
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             "INSERT INTO users (username, role) VALUES (?, 'user') "


### PR DESCRIPTION
- track_user skips reserved 'admin' username (bootstrap superuser)
- Users page shows 'built-in' label instead of actions for the admin user

The bootstrap admin (authenticated via ADMIN_KEY env var) was being tracked in the users table as role='user' by track_user, making it appear as a regular user that could be promoted/demoted/deleted.