### PR TITLE
fix(ui): disable Report Portal button when no failures (#115)

### DIFF
--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -397,7 +397,7 @@ function ReportContent() {
           )}
           <div className="ml-auto flex items-center gap-3">
             {state.reportportalAvailable && (result.child_job_analyses ?? []).length === 0 && (
-              <ReportPortalButton jobId={result.job_id} jobName={result.job_name ?? result.job_id} buildNumber={result.build_number} />
+              <ReportPortalButton jobId={result.job_id} jobName={result.job_name ?? result.job_id} buildNumber={result.build_number} hasFailures={(result.failures ?? []).length > 0} />
             )}
             {result.request_params && (
               <Button

--- a/frontend/src/pages/report/ChildJobSection.tsx
+++ b/frontend/src/pages/report/ChildJobSection.tsx
@@ -107,6 +107,7 @@ export function ChildJobSection({ child, jobId, depth = 0, activeHash, parentHas
             buildNumber={child.build_number}
             childJobName={child.job_name}
             childBuildNumber={child.build_number}
+            hasFailures={failures.length > 0}
           />
         )}
         {child.jenkins_url && (

--- a/frontend/src/pages/report/ReportPortalButton.tsx
+++ b/frontend/src/pages/report/ReportPortalButton.tsx
@@ -7,6 +7,12 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { api } from '@/lib/api'
 import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react'
 import type { ReportPortalPushResult } from '@/types'
@@ -57,9 +63,10 @@ interface ReportPortalButtonProps {
   buildNumber: number
   childJobName?: string
   childBuildNumber?: number
+  hasFailures: boolean
 }
 
-export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, childBuildNumber }: ReportPortalButtonProps) {
+export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, childBuildNumber, hasFailures }: ReportPortalButtonProps) {
   const { reportportalProject } = useReportState()
   const displayJobName = childJobName ?? jobName
   const displayBuildNumber = childBuildNumber ?? buildNumber
@@ -102,20 +109,31 @@ export function ReportPortalButton({ jobId, jobName, buildNumber, childJobName, 
 
   return (
     <>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="gap-1.5 text-xs"
-        onClick={() => setConfirmOpen(true)}
-        disabled={pushing}
-      >
-        {pushing ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <Upload className="h-3.5 w-3.5" />
-        )}
-        {pushing ? 'Pushing...' : 'Push to Report Portal'}
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 text-xs"
+                onClick={() => setConfirmOpen(true)}
+                disabled={pushing || !hasFailures}
+              >
+                {pushing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Upload className="h-3.5 w-3.5" />
+                )}
+                {pushing ? 'Pushing...' : 'Push to Report Portal'}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {!hasFailures && (
+            <TooltipContent>No failures to push</TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent className="sm:max-w-[400px] bg-surface-card border-border-default">


### PR DESCRIPTION
Closes #115

## Changes
- Added `hasFailures` boolean prop to `ReportPortalButton` component
- Button is disabled with tooltip "No failures to push" when there are no failures
- Updated both call sites: `ReportPage.tsx` and `ChildJobSection.tsx`

## Testing
- All 1270 tests pass (1190 backend + 80 frontend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Push to Report Portal" button is disabled when there are no failures to report or a push is in progress, preventing unnecessary submissions.
  * A tooltip ("No failures to push") explains why the button is inactive when applicable.
  * Failure state is now propagated so the button accurately reflects availability for child jobs as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->