### PR TITLE
feat(ui): add GitHub issues link to dashboard (#118)

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Base URL for the project's GitHub repository. */
+export const GITHUB_REPO_URL = 'https://github.com/myk-org/jenkins-job-insight'

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -33,7 +33,7 @@ import { Pagination } from '@/components/shared/Pagination'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
 import { useTableSort } from '@/lib/useTableSort'
-import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, ExternalLink } from 'lucide-react'
+import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 
 const STATUS_FILTER_ALL = 'ALL'
@@ -228,7 +228,7 @@ export function DashboardPage() {
                 title="View GitHub issues"
                 className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
               >
-                <ExternalLink className="h-3 w-3" />
+                <Github className="h-3 w-3" />
                 View Issues
               </a>
             </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api } from '@/lib/api'
+import { GITHUB_REPO_URL } from '@/lib/constants'
 import type { DashboardJob } from '@/types'
 import { Button } from '@/components/ui/button'
 import {
@@ -32,7 +33,7 @@ import { Pagination } from '@/components/shared/Pagination'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
 import { useTableSort } from '@/lib/useTableSort'
-import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle } from 'lucide-react'
+import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, ExternalLink } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 
 const STATUS_FILTER_ALL = 'ALL'
@@ -216,9 +217,21 @@ export function DashboardPage() {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="font-display text-xl font-bold text-text-primary">Dashboard</h1>
-            <p className="mt-0.5 text-sm text-text-tertiary">
-              {filtered.length} analysis {filtered.length === 1 ? 'run' : 'runs'}
-            </p>
+            <div className="mt-0.5 flex items-center gap-3">
+              <p className="text-sm text-text-tertiary">
+                {filtered.length} analysis {filtered.length === 1 ? 'run' : 'runs'}
+              </p>
+              <a
+                href={`${GITHUB_REPO_URL}/issues`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="View GitHub issues"
+                className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
+              >
+                <ExternalLink className="h-3 w-3" />
+                View Issues
+              </a>
+            </div>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <SearchInput value={search} onChange={setSearch} placeholder="Filter jobs..." className="w-full sm:w-64" />


### PR DESCRIPTION
Closes #118

## Changes
- Added "View Issues" link in the dashboard header pointing to the GitHub issues page
- Uses shared `GITHUB_REPO_URL` constant from `lib/constants.ts`
- Opens in new tab with proper `rel="noopener noreferrer"`

## Testing
- All 1270 tests pass (1190 backend + 80 frontend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View Issues" link on the Dashboard header that opens the project's GitHub issues page in a new tab with an icon for easy reporting.
  * Introduced a centralized GitHub repository URL used by the app for external links, ensuring consistent navigation to the project on GitHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->