### PR TITLE
fix: add Jenkins connection timeout to prevent hanging (#100)

### DIFF
--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -16,6 +16,7 @@ from ai_cli_runner import (
 )
 
 import jenkins
+import requests.exceptions
 from fastapi import HTTPException
 from simple_logger.logger import get_logger
 
@@ -656,6 +657,21 @@ def handle_jenkins_exception(
                 status_code=502,
                 detail=f"Jenkins error: {e!s}",
             )
+
+    if isinstance(
+        e,
+        (
+            requests.exceptions.Timeout,
+            requests.exceptions.ConnectionError,
+            TimeoutError,
+            ConnectionError,
+        ),
+    ):
+        logger.error(f"Jenkins unreachable for {job_name} #{build_number}: {e!s}")
+        raise HTTPException(
+            status_code=504,
+            detail="Jenkins is unreachable or timed out. Check server connectivity.",
+        )
 
     # For any other exception type
     raise HTTPException(
@@ -1459,6 +1475,7 @@ async def analyze_job(
         username=settings.jenkins_user,
         password=settings.jenkins_password,
         ssl_verify=settings.jenkins_ssl_verify,
+        timeout=settings.jenkins_timeout,
     )
 
     # Construct full Jenkins URL for the result

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -16,7 +16,6 @@ from ai_cli_runner import (
 )
 
 import jenkins
-import requests.exceptions
 from fastapi import HTTPException
 from simple_logger.logger import get_logger
 
@@ -658,15 +657,9 @@ def handle_jenkins_exception(
                 detail=f"Jenkins error: {e!s}",
             )
 
-    if isinstance(
-        e,
-        (
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            TimeoutError,
-            ConnectionError,
-        ),
-    ):
+    from jenkins_job_insight.utils import is_jenkins_connectivity_error
+
+    if is_jenkins_connectivity_error(e):
         logger.error(f"Jenkins unreachable for {job_name} #{build_number}: {e!s}")
         raise HTTPException(
             status_code=504,

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -206,7 +206,7 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jenkins_user=data.get("jenkins_user", ""),
         jenkins_password=data.get("jenkins_password", ""),
         jenkins_ssl_verify=data.get("jenkins_ssl_verify"),
-        jenkins_timeout=data.get("jenkins_timeout", 0),
+        jenkins_timeout=_validated_int(data, "jenkins_timeout"),
         # Tests
         tests_repo_url=data.get("tests_repo_url", ""),
         # AI

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -188,6 +188,13 @@ def _validated_int(data: dict, key: str) -> int:
     return value
 
 
+def _validated_non_negative_int(data: dict, key: str) -> int:
+    value = _validated_int(data, key)
+    if value < 0:
+        raise ValueError(f"Invalid config: '{key}' must be a non-negative integer")
+    return value
+
+
 def _server_config_from_dict(data: dict) -> ServerConfig:
     """Build a ServerConfig from a TOML server dict.
 
@@ -206,7 +213,7 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jenkins_user=data.get("jenkins_user", ""),
         jenkins_password=data.get("jenkins_password", ""),
         jenkins_ssl_verify=data.get("jenkins_ssl_verify"),
-        jenkins_timeout=_validated_int(data, "jenkins_timeout"),
+        jenkins_timeout=_validated_non_negative_int(data, "jenkins_timeout"),
         # Tests
         tests_repo_url=data.get("tests_repo_url", ""),
         # AI

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -27,6 +27,7 @@ class ServerConfig:
     jenkins_user: str = ""
     jenkins_password: str = ""
     jenkins_ssl_verify: bool | None = None
+    jenkins_timeout: int = 0  # 0 means use server default
     # Tests
     tests_repo_url: str = ""
     # AI
@@ -205,6 +206,7 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jenkins_user=data.get("jenkins_user", ""),
         jenkins_password=data.get("jenkins_password", ""),
         jenkins_ssl_verify=data.get("jenkins_ssl_verify"),
+        jenkins_timeout=data.get("jenkins_timeout", 0),
         # Tests
         tests_repo_url=data.get("tests_repo_url", ""),
         # AI

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -594,6 +594,7 @@ def analyze(
         "--jira-max-results": jira_max_results,
         "--ai-cli-timeout": ai_cli_timeout,
         "--jenkins-artifacts-max-size-mb": jenkins_artifacts_max_size_mb,
+        "--jenkins-timeout": jenkins_timeout,
     }
     for flag_name, flag_value in _positive_int_fields.items():
         if flag_value is not None and flag_value <= 0:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -501,6 +501,11 @@ def analyze(
         "--jenkins-ssl-verify/--no-jenkins-ssl-verify",
         help="Jenkins SSL certificate verification.",
     ),
+    jenkins_timeout: int | None = typer.Option(
+        None,
+        "--jenkins-timeout",
+        help="Jenkins API request timeout in seconds.",
+    ),
     jenkins_artifacts_max_size_mb: int = typer.Option(
         None,
         "--jenkins-artifacts-max-size-mb",
@@ -626,12 +631,14 @@ def analyze(
         _cfg_int_fields = {
             "ai_cli_timeout": cfg.ai_cli_timeout,
             "jira_max_results": cfg.jira_max_results,
+            "jenkins_timeout": cfg.jenkins_timeout,
             "poll_interval_minutes": cfg.poll_interval_minutes,
             "max_wait_minutes": cfg.max_wait_minutes,
         }
         _cfg_int_defaults = {
             "ai_cli_timeout": ServerConfig.ai_cli_timeout,
             "jira_max_results": ServerConfig.jira_max_results,
+            "jenkins_timeout": ServerConfig.jenkins_timeout,
             "poll_interval_minutes": ServerConfig.poll_interval_minutes,
             "max_wait_minutes": ServerConfig.max_wait_minutes,
         }
@@ -690,6 +697,7 @@ def analyze(
         "jira_max_results": jira_max_results,
         "ai_cli_timeout": ai_cli_timeout,
         "jenkins_artifacts_max_size_mb": jenkins_artifacts_max_size_mb,
+        "jenkins_timeout": jenkins_timeout,
         "poll_interval_minutes": poll_interval,
         "max_wait_minutes": max_wait,
     }

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -127,6 +127,9 @@ class Settings(BaseSettings):
     jenkins_user: str = ""
     jenkins_password: str = Field(default="", repr=False)
     jenkins_ssl_verify: bool = True
+    jenkins_timeout: int = Field(
+        default=30, gt=0, description="Jenkins API request timeout in seconds"
+    )
 
     # Optional defaults (can be overridden per-request in webhook)
     tests_repo_url: str | None = None

--- a/src/jenkins_job_insight/jenkins.py
+++ b/src/jenkins_job_insight/jenkins.py
@@ -16,7 +16,12 @@ class JenkinsClient(jenkins.Jenkins):
     """Extended Jenkins client with helper methods."""
 
     def __init__(
-        self, url: str, username: str, password: str, ssl_verify: bool = True
+        self,
+        url: str,
+        username: str,
+        password: str,
+        ssl_verify: bool = True,
+        timeout: int = 30,
     ) -> None:
         """Initialize Jenkins client.
 
@@ -25,8 +30,9 @@ class JenkinsClient(jenkins.Jenkins):
             username: Jenkins username.
             password: Jenkins password or API token.
             ssl_verify: Whether to verify SSL certificates. Set to False for self-signed certs.
+            timeout: HTTP request timeout in seconds.
         """
-        super().__init__(url=url, username=username, password=password)
+        super().__init__(url=url, username=username, password=password, timeout=timeout)
         logger.info(f"Connecting to Jenkins: {url}")
         if not ssl_verify:
             self._session.verify = False

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -878,14 +878,29 @@ async def _wait_for_jenkins_completion(
         timeout=jenkins_timeout,
     )
 
+    unreachable_error = (
+        "Cannot reach Jenkins; please verify the Jenkins URL, credentials, "
+        "and network connectivity"
+    )
+
+    def _is_jenkins_connectivity_error(exc: Exception) -> bool:
+        return isinstance(
+            exc,
+            (
+                OSError,
+                TimeoutError,
+                jenkins.TimeoutException,
+                jenkins.JenkinsException,
+            ),
+        )
+
     try:
         await asyncio.to_thread(client.get_whoami)
-    except (OSError, TimeoutError) as e:
+    except Exception as e:
+        if not _is_jenkins_connectivity_error(e):
+            raise
         logger.error("Cannot reach Jenkins at %s: %s", jenkins_url, e, exc_info=True)
-        return (
-            False,
-            "Cannot reach Jenkins; please verify the Jenkins URL and network connectivity",
-        )
+        return False, unreachable_error
 
     if max_wait_minutes > 0:
         deadline: float | None = _time.monotonic() + max_wait_minutes * 60
@@ -918,7 +933,10 @@ async def _wait_for_jenkins_completion(
             )
             return False, f"Jenkins job {job_name} #{build_number} not found (404)"
 
-        except (OSError, TimeoutError) as e:
+        except Exception as e:
+            if not _is_jenkins_connectivity_error(e):
+                logger.error(f"Non-transient error checking Jenkins status: {e}")
+                return False, f"Jenkins poll failed: {e}"
             consecutive_failures += 1
             logger.warning(
                 "Transient error checking Jenkins status (%d/%d): %s",
@@ -933,14 +951,7 @@ async def _wait_for_jenkins_completion(
                     consecutive_failures,
                     exc_info=True,
                 )
-                return (
-                    False,
-                    "Cannot reach Jenkins; please verify the Jenkins URL and network connectivity",
-                )
-
-        except Exception as e:
-            logger.error(f"Non-transient error checking Jenkins status: {e}")
-            return False, f"Jenkins poll failed: {e}"
+                return False, unreachable_error
 
         if deadline is not None:
             remaining = deadline - _time.monotonic()

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -878,6 +878,15 @@ async def _wait_for_jenkins_completion(
         timeout=jenkins_timeout,
     )
 
+    try:
+        await asyncio.to_thread(client.get_whoami)
+    except (OSError, TimeoutError) as e:
+        logger.error("Cannot reach Jenkins at %s: %s", jenkins_url, e, exc_info=True)
+        return (
+            False,
+            "Cannot reach Jenkins; please verify the Jenkins URL and network connectivity",
+        )
+
     if max_wait_minutes > 0:
         deadline: float | None = _time.monotonic() + max_wait_minutes * 60
     else:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -847,6 +847,7 @@ async def _wait_for_jenkins_completion(
     poll_interval_minutes: int,
     max_wait_minutes: int,
     jenkins_timeout: int = 30,
+    max_consecutive_failures: int = 5,
 ) -> tuple[bool, str]:
     """Poll Jenkins until the build finishes.
 
@@ -861,6 +862,8 @@ async def _wait_for_jenkins_completion(
         max_wait_minutes: Maximum minutes to wait before timing out.
             0 means no limit (poll forever until job finishes).
         jenkins_timeout: Jenkins API request timeout in seconds.
+        max_consecutive_failures: Number of consecutive transient errors
+            allowed before giving up. Defaults to 5.
 
     Returns:
         A tuple of (success, error_message). success is True if the build
@@ -890,14 +893,16 @@ async def _wait_for_jenkins_completion(
         if not is_jenkins_connectivity_error(e):
             raise
         logger.error("Cannot reach Jenkins at %s: %s", jenkins_url, e, exc_info=True)
-        return False, unreachable_error
+        return False, (
+            "Jenkins reachability check failed; please verify the Jenkins URL, "
+            "credentials, and network connectivity"
+        )
 
     if max_wait_minutes > 0:
         deadline: float | None = _time.monotonic() + max_wait_minutes * 60
     else:
         deadline = None  # No limit
 
-    max_consecutive_failures = 5
     consecutive_failures = 0
 
     while True:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -883,11 +883,15 @@ async def _wait_for_jenkins_completion(
     else:
         deadline = None  # No limit
 
+    max_consecutive_failures = 5
+    consecutive_failures = 0
+
     while True:
         try:
             build_info = await asyncio.to_thread(
                 client.get_build_info_safe, job_name, build_number
             )
+            consecutive_failures = 0
 
             if build_info and not build_info.get("building", True):
                 logger.info(
@@ -906,7 +910,24 @@ async def _wait_for_jenkins_completion(
             return False, f"Jenkins job {job_name} #{build_number} not found (404)"
 
         except (OSError, TimeoutError) as e:
-            logger.warning(f"Transient error checking Jenkins status: {e}")
+            consecutive_failures += 1
+            logger.warning(
+                "Transient error checking Jenkins status (%d/%d): %s",
+                consecutive_failures,
+                max_consecutive_failures,
+                e,
+            )
+            if consecutive_failures >= max_consecutive_failures:
+                logger.error(
+                    "Cannot reach Jenkins at %s after %d consecutive failures",
+                    jenkins_url,
+                    consecutive_failures,
+                    exc_info=True,
+                )
+                return (
+                    False,
+                    "Cannot reach Jenkins; please verify the Jenkins URL and network connectivity",
+                )
 
         except Exception as e:
             logger.error(f"Non-transient error checking Jenkins status: {e}")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -313,6 +313,7 @@ def _reconstruct_from_params(
         "jenkins_user",
         "jenkins_password",
         "jenkins_ssl_verify",
+        "jenkins_timeout",
         "wait_for_completion",
         "poll_interval_minutes",
         "max_wait_minutes",
@@ -774,6 +775,7 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
             "jenkins_user",
             "jenkins_password",
             "jenkins_ssl_verify",
+            "jenkins_timeout",
         ]
         for field in jenkins_fields:
             value = getattr(body, field, None)
@@ -844,6 +846,7 @@ async def _wait_for_jenkins_completion(
     jenkins_ssl_verify: bool,
     poll_interval_minutes: int,
     max_wait_minutes: int,
+    jenkins_timeout: int = 30,
 ) -> tuple[bool, str]:
     """Poll Jenkins until the build finishes.
 
@@ -857,6 +860,7 @@ async def _wait_for_jenkins_completion(
         poll_interval_minutes: Minutes between polls.
         max_wait_minutes: Maximum minutes to wait before timing out.
             0 means no limit (poll forever until job finishes).
+        jenkins_timeout: Jenkins API request timeout in seconds.
 
     Returns:
         A tuple of (success, error_message). success is True if the build
@@ -871,6 +875,7 @@ async def _wait_for_jenkins_completion(
         username=jenkins_user,
         password=jenkins_password,
         ssl_verify=jenkins_ssl_verify,
+        timeout=jenkins_timeout,
     )
 
     if max_wait_minutes > 0:
@@ -972,6 +977,7 @@ async def process_analysis_with_id(
                 jenkins_ssl_verify=settings.jenkins_ssl_verify,
                 poll_interval_minutes=settings.poll_interval_minutes,
                 max_wait_minutes=settings.max_wait_minutes,
+                jenkins_timeout=settings.jenkins_timeout,
             )
 
             if not completed:
@@ -1157,6 +1163,7 @@ def _build_request_params(
             "jenkins_user": merged.jenkins_user,
             "jenkins_password": merged.jenkins_password,
             "jenkins_ssl_verify": merged.jenkins_ssl_verify,
+            "jenkins_timeout": merged.jenkins_timeout,
             "wait_for_completion": merged.wait_for_completion,
             "poll_interval_minutes": merged.poll_interval_minutes,
             "max_wait_minutes": merged.max_wait_minutes,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -869,6 +869,7 @@ async def _wait_for_jenkins_completion(
     import jenkins
 
     from jenkins_job_insight.jenkins import JenkinsClient
+    from jenkins_job_insight.utils import is_jenkins_connectivity_error
 
     client = JenkinsClient(
         url=jenkins_url,
@@ -883,21 +884,10 @@ async def _wait_for_jenkins_completion(
         "and network connectivity"
     )
 
-    def _is_jenkins_connectivity_error(exc: Exception) -> bool:
-        return isinstance(
-            exc,
-            (
-                OSError,
-                TimeoutError,
-                jenkins.TimeoutException,
-                jenkins.JenkinsException,
-            ),
-        )
-
     try:
         await asyncio.to_thread(client.get_whoami)
     except Exception as e:
-        if not _is_jenkins_connectivity_error(e):
+        if not is_jenkins_connectivity_error(e):
             raise
         logger.error("Cannot reach Jenkins at %s: %s", jenkins_url, e, exc_info=True)
         return False, unreachable_error
@@ -934,9 +924,11 @@ async def _wait_for_jenkins_completion(
             return False, f"Jenkins job {job_name} #{build_number} not found (404)"
 
         except Exception as e:
-            if not _is_jenkins_connectivity_error(e):
-                logger.error(f"Non-transient error checking Jenkins status: {e}")
-                return False, f"Jenkins poll failed: {e}"
+            if not is_jenkins_connectivity_error(e):
+                logger.error(
+                    "Non-transient error checking Jenkins status", exc_info=True
+                )
+                return False, "Jenkins poll failed; check server logs for details"
             consecutive_failures += 1
             logger.warning(
                 "Transient error checking Jenkins status (%d/%d): %s",
@@ -1022,14 +1014,16 @@ async def process_analysis_with_id(
             )
 
             if not completed:
+                fail_data = {
+                    "job_name": body.job_name,
+                    "build_number": body.build_number,
+                    "error": wait_error,
+                }
+                await _preserve_request_params(job_id, fail_data)
                 await update_status(
                     job_id,
                     "failed",
-                    {
-                        "job_name": body.job_name,
-                        "build_number": body.build_number,
-                        "error": wait_error,
-                    },
+                    fail_data,
                 )
                 return
 
@@ -1107,13 +1101,13 @@ async def process_analysis_with_id(
     except Exception as e:
         logger.exception(f"Analysis failed for job {job_id}")
         error_detail = format_exception_with_type(e)
-        fail_data: dict = {
+        error_data: dict = {
             "job_name": body.job_name,
             "build_number": body.build_number,
             "error": error_detail,
         }
-        await _preserve_request_params(job_id, fail_data)
-        await update_status(job_id, "failed", fail_data)
+        await _preserve_request_params(job_id, error_data)
+        await update_status(job_id, "failed", error_data)
 
 
 def _build_base_request_params(

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -202,6 +202,10 @@ class AnalyzeRequest(BaseAnalysisRequest):
         default=None,
         description="Jenkins SSL verification (overrides JENKINS_SSL_VERIFY env var)",
     )
+    jenkins_timeout: Annotated[int, Field(gt=0)] | None = Field(
+        default=None,
+        description="Jenkins API request timeout in seconds (overrides JENKINS_TIMEOUT env var).",
+    )
     jenkins_artifacts_max_size_mb: Annotated[int, Field(gt=0)] | None = Field(
         default=None,
         description="Maximum Jenkins artifacts size in MB (overrides JENKINS_ARTIFACTS_MAX_SIZE_MB env var)",

--- a/src/jenkins_job_insight/utils.py
+++ b/src/jenkins_job_insight/utils.py
@@ -1,0 +1,25 @@
+"""Shared utilities for jenkins-job-insight."""
+
+from __future__ import annotations
+
+import jenkins
+import requests.exceptions
+
+
+#: Combined tuple of exception types that indicate a transient Jenkins
+#: connectivity problem (network outage, DNS failure, timeout, etc.).
+#: Used by both the polling loop in *main.py* and the pre-flight check
+#: in *analyzer.py*.
+JENKINS_CONNECTIVITY_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    OSError,
+    TimeoutError,
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectionError,
+    jenkins.TimeoutException,
+    jenkins.JenkinsException,
+)
+
+
+def is_jenkins_connectivity_error(exc: Exception) -> bool:
+    """Return ``True`` if *exc* looks like a transient Jenkins connectivity error."""
+    return isinstance(exc, JENKINS_CONNECTIVITY_EXCEPTIONS)

--- a/src/jenkins_job_insight/utils.py
+++ b/src/jenkins_job_insight/utils.py
@@ -10,13 +10,17 @@ import requests.exceptions
 #: connectivity problem (network outage, DNS failure, timeout, etc.).
 #: Used by both the polling loop in *main.py* and the pre-flight check
 #: in *analyzer.py*.
+#:
+#: Note: ``jenkins.JenkinsException`` is intentionally excluded — it is
+#: the base class for many non-transient errors (auth failures, 5xx,
+#: malformed responses).  Only ``jenkins.TimeoutException`` (a subclass)
+#: represents a true connectivity/timeout problem.
 JENKINS_CONNECTIVITY_EXCEPTIONS: tuple[type[BaseException], ...] = (
     OSError,
     TimeoutError,
     requests.exceptions.Timeout,
     requests.exceptions.ConnectionError,
     jenkins.TimeoutException,
-    jenkins.JenkinsException,
 )
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -70,11 +70,41 @@ class TestHandleJenkinsException:
 
     def test_handle_non_jenkins_exception(self) -> None:
         """Test that non-Jenkins exceptions return 502 with connection error."""
-        exc = ConnectionError("Failed to connect")
+        exc = ValueError("Some other error")
         with pytest.raises(HTTPException) as exc_info:
             handle_jenkins_exception(exc, "my-job", 123)
         assert exc_info.value.status_code == 502
         assert "Failed to connect to Jenkins" in exc_info.value.detail
+
+    def test_handle_timeout_exception(self) -> None:
+        """Test that timeout returns 504 with generic message."""
+        import requests
+
+        exc = requests.exceptions.Timeout("Connection timed out")
+        with pytest.raises(HTTPException) as exc_info:
+            handle_jenkins_exception(exc, "my-job", 123)
+        assert exc_info.value.status_code == 504
+        assert (
+            exc_info.value.detail
+            == "Jenkins is unreachable or timed out. Check server connectivity."
+        )
+        # Raw exception message must not leak into the HTTP response
+        assert "Connection timed out" not in exc_info.value.detail
+
+    def test_handle_connection_error_exception(self) -> None:
+        """Test that connection error returns 504 with generic message."""
+        import requests
+
+        exc = requests.exceptions.ConnectionError("Connection refused")
+        with pytest.raises(HTTPException) as exc_info:
+            handle_jenkins_exception(exc, "my-job", 123)
+        assert exc_info.value.status_code == 504
+        assert (
+            exc_info.value.detail
+            == "Jenkins is unreachable or timed out. Check server connectivity."
+        )
+        # Raw exception message must not leak into the HTTP response
+        assert "Connection refused" not in exc_info.value.detail
 
 
 class TestCallAiCliWithRetry:

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -921,6 +921,7 @@ class TestJJIClientAnalyzeExtras:
             "jenkins_user": "admin",
             "jenkins_password": "s3cret",  # pragma: allowlist secret
             "jenkins_ssl_verify": False,
+            "jenkins_timeout": 60,
             "jenkins_artifacts_max_size_mb": 50,
             "get_job_artifacts": True,
             "tests_repo_url": "https://github.com/org/tests",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -854,6 +854,7 @@ class TestAnalyzeAllOptions:
                 "jenkins_artifacts_max_size_mb",
                 50,
             ),
+            ("--jenkins-timeout", "60", "jenkins_timeout", 60),
         ],
     )
     def test_int_options(
@@ -1495,6 +1496,7 @@ class TestAnalyzeConfigDefaults:
         jenkins_user="cfg-jenkins-user",
         jenkins_password=_FAKE_JENKINS_PASSWORD,
         jenkins_ssl_verify=False,
+        jenkins_timeout=45,
         tests_repo_url="https://github.com/cfg/tests",
         ai_provider="gemini",
         ai_model="2.5-pro",
@@ -1556,6 +1558,7 @@ class TestAnalyzeConfigDefaults:
         kwargs = client.analyze.call_args[1]
         assert kwargs["ai_cli_timeout"] == 20
         assert kwargs["jira_max_results"] == 40
+        assert kwargs["jenkins_timeout"] == 45
 
     def test_config_boolean_fields_used_as_defaults(self):
         """Boolean config fields are sent when CLI flags are absent."""

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -16,13 +16,13 @@ class TestJenkinsClientInit:
         JenkinsClient(
             url="http://jenkins.example.com",
             username="user",
-            password="pass",  # pragma: allowlist secret
+            password="pass",  # noqa: S106  # pragma: allowlist secret
             timeout=60,
         )
         mock_init.assert_called_once_with(
             url="http://jenkins.example.com",
             username="user",
-            password="pass",  # pragma: allowlist secret
+            password="pass",  # noqa: S106  # pragma: allowlist secret
             timeout=60,
         )
 
@@ -32,12 +32,12 @@ class TestJenkinsClientInit:
         JenkinsClient(
             url="http://jenkins.example.com",
             username="user",
-            password="pass",  # pragma: allowlist secret
+            password="pass",  # noqa: S106  # pragma: allowlist secret
         )
         mock_init.assert_called_once_with(
             url="http://jenkins.example.com",
             username="user",
-            password="pass",  # pragma: allowlist secret
+            password="pass",  # noqa: S106  # pragma: allowlist secret
             timeout=30,
         )
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -1,8 +1,45 @@
 """Tests for Jenkins client."""
 
+from unittest.mock import patch
+
 import pytest
 
 from jenkins_job_insight.jenkins import JenkinsClient
+
+
+class TestJenkinsClientInit:
+    """Tests for JenkinsClient initialization."""
+
+    @patch("jenkins_job_insight.jenkins.jenkins.Jenkins.__init__", return_value=None)
+    def test_timeout_passed_to_parent(self, mock_init):
+        """Test that timeout parameter is passed to parent Jenkins class."""
+        JenkinsClient(
+            url="http://jenkins.example.com",
+            username="user",
+            password="pass",  # pragma: allowlist secret
+            timeout=60,
+        )
+        mock_init.assert_called_once_with(
+            url="http://jenkins.example.com",
+            username="user",
+            password="pass",  # pragma: allowlist secret
+            timeout=60,
+        )
+
+    @patch("jenkins_job_insight.jenkins.jenkins.Jenkins.__init__", return_value=None)
+    def test_default_timeout(self, mock_init):
+        """Test that default timeout is 30 seconds."""
+        JenkinsClient(
+            url="http://jenkins.example.com",
+            username="user",
+            password="pass",  # pragma: allowlist secret
+        )
+        mock_init.assert_called_once_with(
+            url="http://jenkins.example.com",
+            username="user",
+            password="pass",  # pragma: allowlist secret
+            timeout=30,
+        )
 
 
 class TestParseJenkinsUrl:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2425,7 +2425,7 @@ class TestWaitForJenkinsCompletion:
                 max_wait_minutes=5,
             )
             assert result is False
-            assert "bad credentials" in error
+            assert error == "Jenkins poll failed; check server logs for details"
             mock_client.get_build_info_safe.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2667,9 +2667,18 @@ class TestProcessAnalysisWaiting:
             patch(
                 "jenkins_job_insight.main.analyze_job", new_callable=AsyncMock
             ) as mock_analyze,
+            patch(
+                "jenkins_job_insight.main._preserve_request_params",
+                new_callable=AsyncMock,
+            ) as mock_preserve,
         ):
             await process_analysis_with_id("test-id", body, merged)
             mock_analyze.assert_not_called()
+            # _preserve_request_params should have been called with fail_data
+            mock_preserve.assert_called_once()
+            preserve_args = mock_preserve.call_args
+            assert preserve_args[0][0] == "test-id"
+            assert "error" in preserve_args[0][1]
             # The last update should be a failed status with timeout error
             last_status, last_result = stored[-1]
             assert last_status == "failed"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2334,6 +2334,7 @@ class TestWaitForJenkinsCompletion:
                 username="user",
                 password=FAKE_JENKINS_PASSWORD,
                 ssl_verify=False,
+                timeout=30,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #100

## Changes
- Added `jenkins_timeout` setting (default 30s) with full configuration parity:
  - Environment variable (`JENKINS_TIMEOUT`)
  - API payload field (`jenkins_timeout` in AnalyzeRequest)
  - `_merge_settings()` support for per-request override
  - CLI option (`--jenkins-timeout`)
  - Config file (`ServerConfig.jenkins_timeout`)
  - Stored params for re-analysis
- `JenkinsClient` now passes timeout to `python-jenkins` parent class
- `_wait_for_jenkins_completion()` also uses the timeout
- Added 504 Gateway Timeout handling for `Timeout` and `ConnectionError` exceptions
- Generic error messages in HTTP responses (no infrastructure details leaked)
- Full error details logged server-side only

## Testing
- All 1275 tests pass (1195 backend + 80 frontend)
- New tests: timeout passthrough, connection error handling, CLI option, config defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Jenkins API request timeout (default 30s) available via settings, config file (including “use server default”), CLI flag, request payload, and preserved across resumed analyses.

* **Bug Fixes**
  * Improved Jenkins connectivity handling: unreachable/timeouts now yield clearer “Cannot reach Jenkins” messaging and return HTTP 504; polling aborts earlier after repeated unreachable attempts.

* **Tests**
  * Added/updated tests covering timeout propagation, client initialization, and connectivity/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->