### PR TITLE
feat(ui): add date range filter to dashboard (#133)

### DIFF
--- a/frontend/src/components/shared/DateRangeFilter.tsx
+++ b/frontend/src/components/shared/DateRangeFilter.tsx
@@ -6,9 +6,10 @@ interface DateRangeFilterProps {
   to: string
   onFromChange: (value: string) => void
   onToChange: (value: string) => void
+  onClear?: () => void
 }
 
-export function DateRangeFilter({ from, to, onFromChange, onToChange }: DateRangeFilterProps) {
+export function DateRangeFilter({ from, to, onFromChange, onToChange, onClear }: DateRangeFilterProps) {
   return (
     <div className="flex items-center gap-1.5">
       <Calendar className="h-3.5 w-3.5 text-text-tertiary" />
@@ -32,7 +33,7 @@ export function DateRangeFilter({ from, to, onFromChange, onToChange }: DateRang
       {(from || to) && (
         <button
           type="button"
-          onClick={() => { onFromChange(''); onToChange('') }}
+          onClick={() => { if (onClear) { onClear() } else { onFromChange(''); onToChange('') } }}
           className="text-xs text-text-tertiary hover:text-text-secondary"
           aria-label="Clear date filter"
         >

--- a/frontend/src/components/shared/DateRangeFilter.tsx
+++ b/frontend/src/components/shared/DateRangeFilter.tsx
@@ -1,0 +1,44 @@
+import { Input } from '@/components/ui/input'
+import { Calendar, X } from 'lucide-react'
+
+interface DateRangeFilterProps {
+  from: string
+  to: string
+  onFromChange: (value: string) => void
+  onToChange: (value: string) => void
+}
+
+export function DateRangeFilter({ from, to, onFromChange, onToChange }: DateRangeFilterProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Calendar className="h-3.5 w-3.5 text-text-tertiary" />
+      <Input
+        type="date"
+        value={from}
+        max={to || undefined}
+        onChange={(e) => onFromChange(e.target.value)}
+        className="h-9 w-auto px-2 text-xs"
+        aria-label="Filter from date"
+      />
+      <span className="text-xs text-text-tertiary">–</span>
+      <Input
+        type="date"
+        value={to}
+        min={from || undefined}
+        onChange={(e) => onToChange(e.target.value)}
+        className="h-9 w-auto px-2 text-xs"
+        aria-label="Filter to date"
+      />
+      {(from || to) && (
+        <button
+          type="button"
+          onClick={() => { onFromChange(''); onToChange('') }}
+          className="text-xs text-text-tertiary hover:text-text-secondary"
+          aria-label="Clear date filter"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
+++ b/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
@@ -1,69 +1,82 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { DateRangeFilter } from '../DateRangeFilter'
+import type { ComponentProps } from 'react'
+
+const FROM_LABEL = 'Filter from date'
+const TO_LABEL = 'Filter to date'
+const CLEAR_LABEL = 'Clear date filter'
+
+function renderDateRangeFilter(overrides: Partial<ComponentProps<typeof DateRangeFilter>> = {}) {
+  const props = {
+    from: '',
+    to: '',
+    onFromChange: vi.fn(),
+    onToChange: vi.fn(),
+    ...overrides,
+  }
+  const result = render(<DateRangeFilter {...props} />)
+  return { ...result, props }
+}
 
 describe('DateRangeFilter', () => {
   it('renders both date inputs', () => {
-    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Filter from date')).toBeDefined()
-    expect(screen.getByLabelText('Filter to date')).toBeDefined()
+    renderDateRangeFilter()
+    expect(screen.getByLabelText(FROM_LABEL)).toBeDefined()
+    expect(screen.getByLabelText(TO_LABEL)).toBeDefined()
   })
 
   it('calls onFromChange when from date changes', () => {
-    const onFromChange = vi.fn()
-    render(<DateRangeFilter from="" to="" onFromChange={onFromChange} onToChange={() => {}} />)
-    fireEvent.change(screen.getByLabelText('Filter from date'), { target: { value: '2025-01-01' } })
-    expect(onFromChange).toHaveBeenCalledWith('2025-01-01')
+    const { props } = renderDateRangeFilter()
+    fireEvent.change(screen.getByLabelText(FROM_LABEL), { target: { value: '2025-01-01' } })
+    expect(props.onFromChange).toHaveBeenCalledWith('2025-01-01')
   })
 
   it('calls onToChange when to date changes', () => {
-    const onToChange = vi.fn()
-    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={onToChange} />)
-    fireEvent.change(screen.getByLabelText('Filter to date'), { target: { value: '2025-12-31' } })
-    expect(onToChange).toHaveBeenCalledWith('2025-12-31')
+    const { props } = renderDateRangeFilter()
+    fireEvent.change(screen.getByLabelText(TO_LABEL), { target: { value: '2025-12-31' } })
+    expect(props.onToChange).toHaveBeenCalledWith('2025-12-31')
   })
 
   it('does not show clear button when both values are empty', () => {
-    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.queryByLabelText('Clear date filter')).toBeNull()
+    renderDateRangeFilter()
+    expect(screen.queryByLabelText(CLEAR_LABEL)).toBeNull()
   })
 
   it('shows clear button when from is set', () => {
-    render(<DateRangeFilter from="2025-01-01" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Clear date filter')).toBeDefined()
+    renderDateRangeFilter({ from: '2025-01-01' })
+    expect(screen.getByLabelText(CLEAR_LABEL)).toBeDefined()
   })
 
   it('shows clear button when to is set', () => {
-    render(<DateRangeFilter from="" to="2025-12-31" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Clear date filter')).toBeDefined()
+    renderDateRangeFilter({ to: '2025-12-31' })
+    expect(screen.getByLabelText(CLEAR_LABEL)).toBeDefined()
   })
 
   it('clears both values when clear button is clicked', () => {
-    const onFromChange = vi.fn()
-    const onToChange = vi.fn()
-    render(<DateRangeFilter from="2025-01-01" to="2025-12-31" onFromChange={onFromChange} onToChange={onToChange} />)
-    fireEvent.click(screen.getByLabelText('Clear date filter'))
-    expect(onFromChange).toHaveBeenCalledWith('')
-    expect(onToChange).toHaveBeenCalledWith('')
+    const { props } = renderDateRangeFilter({ from: '2025-01-01', to: '2025-12-31' })
+    fireEvent.click(screen.getByLabelText(CLEAR_LABEL))
+    expect(props.onFromChange).toHaveBeenCalledWith('')
+    expect(props.onToChange).toHaveBeenCalledWith('')
   })
 
   it('sets max constraint on from input based on to value', () => {
-    render(<DateRangeFilter from="" to="2025-06-15" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Filter from date').getAttribute('max')).toBe('2025-06-15')
+    renderDateRangeFilter({ to: '2025-06-15' })
+    expect(screen.getByLabelText(FROM_LABEL).getAttribute('max')).toBe('2025-06-15')
   })
 
   it('sets min constraint on to input based on from value', () => {
-    render(<DateRangeFilter from="2025-01-01" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Filter to date').getAttribute('min')).toBe('2025-01-01')
+    renderDateRangeFilter({ from: '2025-01-01' })
+    expect(screen.getByLabelText(TO_LABEL).getAttribute('min')).toBe('2025-01-01')
   })
 
   it('does not set max on from input when to is empty', () => {
-    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Filter from date').getAttribute('max')).toBeNull()
+    renderDateRangeFilter()
+    expect(screen.getByLabelText(FROM_LABEL).getAttribute('max')).toBeNull()
   })
 
   it('does not set min on to input when from is empty', () => {
-    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
-    expect(screen.getByLabelText('Filter to date').getAttribute('min')).toBeNull()
+    renderDateRangeFilter()
+    expect(screen.getByLabelText(TO_LABEL).getAttribute('min')).toBeNull()
   })
 })

--- a/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
+++ b/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
@@ -79,4 +79,13 @@ describe('DateRangeFilter', () => {
     renderDateRangeFilter()
     expect(screen.getByLabelText(TO_LABEL).getAttribute('min')).toBeNull()
   })
+
+  it('calls onClear instead of onFromChange/onToChange when onClear is provided', () => {
+    const onClear = vi.fn()
+    const { props } = renderDateRangeFilter({ from: '2025-01-01', to: '2025-12-31', onClear })
+    fireEvent.click(screen.getByLabelText(CLEAR_LABEL))
+    expect(onClear).toHaveBeenCalledOnce()
+    expect(props.onFromChange).not.toHaveBeenCalled()
+    expect(props.onToChange).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
+++ b/frontend/src/components/shared/__tests__/DateRangeFilter.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DateRangeFilter } from '../DateRangeFilter'
+
+describe('DateRangeFilter', () => {
+  it('renders both date inputs', () => {
+    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Filter from date')).toBeDefined()
+    expect(screen.getByLabelText('Filter to date')).toBeDefined()
+  })
+
+  it('calls onFromChange when from date changes', () => {
+    const onFromChange = vi.fn()
+    render(<DateRangeFilter from="" to="" onFromChange={onFromChange} onToChange={() => {}} />)
+    fireEvent.change(screen.getByLabelText('Filter from date'), { target: { value: '2025-01-01' } })
+    expect(onFromChange).toHaveBeenCalledWith('2025-01-01')
+  })
+
+  it('calls onToChange when to date changes', () => {
+    const onToChange = vi.fn()
+    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={onToChange} />)
+    fireEvent.change(screen.getByLabelText('Filter to date'), { target: { value: '2025-12-31' } })
+    expect(onToChange).toHaveBeenCalledWith('2025-12-31')
+  })
+
+  it('does not show clear button when both values are empty', () => {
+    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.queryByLabelText('Clear date filter')).toBeNull()
+  })
+
+  it('shows clear button when from is set', () => {
+    render(<DateRangeFilter from="2025-01-01" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Clear date filter')).toBeDefined()
+  })
+
+  it('shows clear button when to is set', () => {
+    render(<DateRangeFilter from="" to="2025-12-31" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Clear date filter')).toBeDefined()
+  })
+
+  it('clears both values when clear button is clicked', () => {
+    const onFromChange = vi.fn()
+    const onToChange = vi.fn()
+    render(<DateRangeFilter from="2025-01-01" to="2025-12-31" onFromChange={onFromChange} onToChange={onToChange} />)
+    fireEvent.click(screen.getByLabelText('Clear date filter'))
+    expect(onFromChange).toHaveBeenCalledWith('')
+    expect(onToChange).toHaveBeenCalledWith('')
+  })
+
+  it('sets max constraint on from input based on to value', () => {
+    render(<DateRangeFilter from="" to="2025-06-15" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Filter from date').getAttribute('max')).toBe('2025-06-15')
+  })
+
+  it('sets min constraint on to input based on from value', () => {
+    render(<DateRangeFilter from="2025-01-01" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Filter to date').getAttribute('min')).toBe('2025-01-01')
+  })
+
+  it('does not set max on from input when to is empty', () => {
+    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Filter from date').getAttribute('max')).toBeNull()
+  })
+
+  it('does not set min on to input when from is empty', () => {
+    render(<DateRangeFilter from="" to="" onFromChange={() => {}} onToChange={() => {}} />)
+    expect(screen.getByLabelText('Filter to date').getAttribute('min')).toBeNull()
+  })
+})

--- a/frontend/src/lib/dateRange.ts
+++ b/frontend/src/lib/dateRange.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a Date set to the start of the given date string in UTC (00:00:00.000Z).
+ */
+export function utcStartOfDateInput(value: string): Date {
+  return new Date(`${value}T00:00:00.000Z`)
+}
+
+/**
+ * Returns a Date set to the end of the given date string in UTC (23:59:59.999Z).
+ */
+export function utcEndOfDateInput(value: string): Date {
+  return new Date(`${value}T23:59:59.999Z`)
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from '@/lib/api'
 import { GITHUB_REPO_URL } from '@/lib/constants'
 import type { DashboardJob } from '@/types'
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/tooltip'
 import { Skeleton } from '@/components/ui/skeleton'
 import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp } from '@/lib/utils'
+import { utcStartOfDateInput, utcEndOfDateInput } from '@/lib/dateRange'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { SearchInput } from '@/components/shared/SearchInput'
 import { Pagination } from '@/components/shared/Pagination'
@@ -107,8 +108,25 @@ export function DashboardPage() {
   const { sortKey, sortDir, handleSort } = useTableSort('dash', 'created_at', 'desc', ['created_at'])
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(20)
-  const [dateFrom, setDateFrom] = useState('')
-  const [dateTo, setDateTo] = useState('')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const dateFrom = searchParams.get('date_from') ?? ''
+  const dateTo = searchParams.get('date_to') ?? ''
+  const setDateFrom = useCallback((value: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      if (value) next.set('date_from', value)
+      else next.delete('date_from')
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
+  const setDateTo = useCallback((value: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      if (value) next.set('date_to', value)
+      else next.delete('date_to')
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
   const [deleteTarget, setDeleteTarget] = useState<DashboardJob | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -146,8 +164,8 @@ export function DashboardPage() {
   useEffect(() => { setPage(1) }, [search, statusFilter, perPage, dateFrom, dateTo])
 
   const filtered = useMemo(() => {
-    const fromBound = dateFrom ? (() => { const d = new Date(dateFrom); d.setUTCHours(0, 0, 0, 0); return d })() : null
-    const toBound = dateTo ? (() => { const d = new Date(dateTo); d.setUTCHours(23, 59, 59, 999); return d })() : null
+    const fromBound = dateFrom ? utcStartOfDateInput(dateFrom) : null
+    const toBound = dateTo ? utcEndOfDateInput(dateTo) : null
 
     return jobs.filter((j) => {
       const displayStatus = isAnalysisTimeout(j.status, j.error, j.summary) ? 'timeout' : j.status
@@ -292,7 +310,9 @@ export function DashboardPage() {
         ) : pageJobs.length === 0 && (!error || jobs.length > 0) ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-border-muted bg-surface-card py-16 text-center animate-fade-in">
             <p className="text-text-secondary">
-              {search ? 'No jobs match your search.' : 'No analysis runs yet.'}
+              {search || statusFilter !== STATUS_FILTER_ALL || dateFrom || dateTo
+                ? 'No jobs match your filters.'
+                : 'No analysis runs yet.'}
             </p>
           </div>
         ) : error && jobs.length === 0 ? null : (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -32,6 +32,7 @@ import { SearchInput } from '@/components/shared/SearchInput'
 import { Pagination } from '@/components/shared/Pagination'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
+import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
 import { useTableSort } from '@/lib/useTableSort'
 import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
@@ -106,6 +107,8 @@ export function DashboardPage() {
   const { sortKey, sortDir, handleSort } = useTableSort('dash', 'created_at', 'desc', ['created_at'])
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(20)
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<DashboardJob | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -140,17 +143,28 @@ export function DashboardPage() {
     const interval = setInterval(fetchJobs, 10_000)
     return () => clearInterval(interval)
   }, [fetchJobs])
-  useEffect(() => { setPage(1) }, [search, statusFilter, perPage])
+  useEffect(() => { setPage(1) }, [search, statusFilter, perPage, dateFrom, dateTo])
 
   const filtered = useMemo(() => {
+    const fromBound = dateFrom ? (() => { const d = new Date(dateFrom); d.setUTCHours(0, 0, 0, 0); return d })() : null
+    const toBound = dateTo ? (() => { const d = new Date(dateTo); d.setUTCHours(23, 59, 59, 999); return d })() : null
+
     return jobs.filter((j) => {
       const displayStatus = isAnalysisTimeout(j.status, j.error, j.summary) ? 'timeout' : j.status
       if (statusFilter !== STATUS_FILTER_ALL && displayStatus !== statusFilter) return false
+
+      if (fromBound || toBound) {
+        const jobDate = parseApiTimestamp(j.created_at)
+        if (Number.isNaN(jobDate.getTime())) return false
+        if (fromBound && jobDate < fromBound) return false
+        if (toBound && jobDate > toBound) return false
+      }
+
       if (!search) return true
       const q = search.toLowerCase()
       return (j.job_name ?? '').toLowerCase().includes(q) || j.job_id.toLowerCase().includes(q)
     })
-  }, [jobs, search, statusFilter])
+  }, [jobs, search, statusFilter, dateFrom, dateTo])
 
   const sorted = useMemo(() => {
     const copy = [...filtered]
@@ -247,6 +261,7 @@ export function DashboardPage() {
                 ))}
               </SelectContent>
             </Select>
+            <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} />
             <Select value={String(perPage)} onValueChange={(v) => setPerPage(Number(v))}>
               <SelectTrigger aria-label="Rows per page" className="w-full sm:w-20">
                 <SelectValue />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -127,6 +127,14 @@ export function DashboardPage() {
       return next
     }, { replace: true })
   }, [setSearchParams])
+  const clearDates = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.delete('date_from')
+      next.delete('date_to')
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
   const [deleteTarget, setDeleteTarget] = useState<DashboardJob | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -279,7 +287,7 @@ export function DashboardPage() {
                 ))}
               </SelectContent>
             </Select>
-            <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} />
+            <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} onClear={clearDates} />
             <Select value={String(perPage)} onValueChange={(v) => setPerPage(Number(v))}>
               <SelectTrigger aria-label="Rows per page" className="w-full sm:w-20">
                 <SelectValue />


### PR DESCRIPTION
Closes #133

## Changes
- Created shared `DateRangeFilter` component in `components/shared/DateRangeFilter.tsx`
  - Uses shadcn `Input` component for consistent styling
  - `min`/`max` constraints prevent invalid date ranges
  - Clear button (X icon) to reset both dates
  - Proper aria-labels for accessibility
- Dashboard filtering with UTC-aligned date boundaries (`setUTCHours`)
- Date boundaries computed once outside the filter loop (performance)
- 10 new unit tests for the DateRangeFilter component

## Testing
- All 1280 tests pass (1190 backend + 91 frontend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date range filtering on the dashboard with from/to date inputs, a clear button, and accessible labels.
  * Date filters sync with the URL and reset pagination when changed.
  * Jobs are filtered to the selected UTC day range; invalid timestamps are excluded.
* **Tests**
  * Added tests covering rendering, interactions, clear behavior, and date-constraint enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->