### PR TITLE
feat: improve failure card UX and add CLI command to report page

### DIFF
--- a/frontend/src/lib/useClipboard.ts
+++ b/frontend/src/lib/useClipboard.ts
@@ -6,15 +6,18 @@ export function useClipboard(resetMs = 2000) {
 
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
 
-  const copy = (text: string, key = 'default') => {
-    if (!navigator.clipboard?.writeText) return
-    void navigator.clipboard.writeText(text)
-      .then(() => {
-        setCopiedKey(key)
-        if (timerRef.current) clearTimeout(timerRef.current)
-        timerRef.current = setTimeout(() => setCopiedKey(null), resetMs)
-      })
-      .catch(() => setCopiedKey(null))
+  const copy = async (text: string, key = 'default'): Promise<boolean> => {
+    if (!navigator.clipboard?.writeText) return false
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedKey(key)
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setCopiedKey(null), resetMs)
+      return true
+    } catch {
+      setCopiedKey(null)
+      return false
+    }
   }
 
   return { copiedKey, isCopied: (k = 'default') => copiedKey === k, copy }

--- a/frontend/src/lib/useClipboard.ts
+++ b/frontend/src/lib/useClipboard.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useClipboard(resetMs = 2000) {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+
+  const copy = (text: string, key = 'default') => {
+    if (!navigator.clipboard?.writeText) return
+    void navigator.clipboard.writeText(text)
+      .then(() => {
+        setCopiedKey(key)
+        if (timerRef.current) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(() => setCopiedKey(null), resetMs)
+      })
+      .catch(() => setCopiedKey(null))
+  }
+
+  return { copiedKey, isCopied: (k = 'default') => copiedKey === k, copy }
+}

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -17,7 +17,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { ExpandCollapseButtons } from '@/components/shared/ExpandCollapseButtons'
 import { Button } from '@/components/ui/button'
-import { ExternalLink, CheckCircle2, Clock, Calendar, Cpu, Timer, FolderGit2, RotateCw } from 'lucide-react'
+import { ExternalLink, CheckCircle2, Clock, Calendar, Cpu, Timer, FolderGit2, RotateCw, Copy, Check } from 'lucide-react'
 import { ReAnalyzeDialog } from './report/ReAnalyzeDialog'
 import { ReportPortalButton } from './report/ReportPortalButton'
 import { reviewKey } from './report/ReportContext'
@@ -76,6 +76,34 @@ export function ReportPage() {
     <ReportProvider key={jobId ?? 'unknown'}>
       <ReportContent />
     </ReportProvider>
+  )
+}
+
+function CliCommand({ jobId }: { jobId: string }) {
+  const [copied, setCopied] = useState(false)
+  const command = `jji results show ${jobId} --json`
+
+  useEffect(() => {
+    if (!copied) return
+    const timer = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(timer)
+  }, [copied])
+
+  return (
+    <p className="flex items-center gap-1.5">
+      CLI:{' '}
+      <code className="font-mono bg-background-offset px-1.5 py-0.5 rounded">{command}</code>
+      <button
+        onClick={() => {
+          if (!navigator.clipboard?.writeText) return
+          void navigator.clipboard.writeText(command).then(() => setCopied(true)).catch(() => {})
+        }}
+        className="inline-flex items-center hover:text-text-secondary transition-colors"
+        title="Copy CLI command"
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      </button>
+    </p>
   )
 }
 
@@ -536,6 +564,7 @@ function ReportContent() {
         <p>
           Job ID: <span className="font-mono">{result.job_id}</span>
         </p>
+        <CliCommand jobId={result.job_id} />
         {state.completedAt && <p>Completed: {formatTimestamp(state.completedAt)}</p>}
         {result.ai_provider && (
           <p>

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { api } from '@/lib/api'
+import { useClipboard } from '@/lib/useClipboard'
 import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp } from '@/lib/utils'
 import { buildRepoUrls, type RepoUrl } from '@/lib/autoLink'
 import { groupFailures } from '@/lib/grouping'
@@ -80,28 +81,21 @@ export function ReportPage() {
 }
 
 function CliCommand({ jobId }: { jobId: string }) {
-  const [copied, setCopied] = useState(false)
+  const { isCopied, copy } = useClipboard()
   const command = `jji results show ${jobId} --json`
-
-  useEffect(() => {
-    if (!copied) return
-    const timer = setTimeout(() => setCopied(false), 2000)
-    return () => clearTimeout(timer)
-  }, [copied])
 
   return (
     <p className="flex items-center gap-1.5">
       CLI:{' '}
       <code className="font-mono bg-background-offset px-1.5 py-0.5 rounded">{command}</code>
       <button
-        onClick={() => {
-          if (!navigator.clipboard?.writeText) return
-          void navigator.clipboard.writeText(command).then(() => setCopied(true)).catch(() => {})
-        }}
+        type="button"
+        onClick={() => copy(command)}
         className="inline-flex items-center hover:text-text-secondary transition-colors"
         title="Copy CLI command"
+        aria-label={isCopied() ? 'CLI command copied' : 'Copy CLI command'}
       >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        {isCopied() ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
       </button>
     </p>
   )

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api, ApiError } from '@/lib/api'
+import { useClipboard } from '@/lib/useClipboard'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -26,17 +27,7 @@ import { formatTimestamp } from '@/lib/utils'
 import type { AdminUser, CreateUserResponse, RotateKeyResponse, ChangeRoleResponse } from '@/types'
 
 function CopyableKey({ label, value }: { label: string; value: string }) {
-  const [copied, setCopied] = useState(false)
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // fallback: select text
-    }
-  }
+  const { isCopied, copy } = useClipboard()
 
   return (
     <div className="space-y-1.5">
@@ -45,11 +36,11 @@ function CopyableKey({ label, value }: { label: string; value: string }) {
         <code className="flex-1 break-all font-mono text-xs text-text-primary">{value}</code>
         <button
           type="button"
-          onClick={handleCopy}
+          onClick={() => copy(value)}
           className="shrink-0 rounded p-1 text-text-tertiary transition-colors hover:text-text-secondary"
           aria-label="Copy to clipboard"
         >
-          {copied ? <Check className="h-4 w-4 text-signal-green" /> : <Copy className="h-4 w-4" />}
+          {isCopied() ? <Check className="h-4 w-4 text-signal-green" /> : <Copy className="h-4 w-4" />}
         </button>
       </div>
       <p className="text-xs text-signal-amber">

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react'
+import { useState, useMemo, type ReactNode } from 'react'
+import { useClipboard } from '@/lib/useClipboard'
 import type { GroupedFailure } from '@/types'
 import { buildFileUrl, buildRepoUrls, isSafeHref, matchRepo, type RepoUrl } from '@/lib/autoLink'
 import { isCommentInScope } from '@/lib/grouping'
@@ -80,30 +81,12 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const [selectedProvider, setSelectedProvider] = useState(result?.ai_provider ?? '')
   const [selectedModel, setSelectedModel] = useState(result?.ai_model ?? '')
   const [includeLinks, setIncludeLinks] = useState(false)
-  const [copiedSection, setCopiedSection] = useState<string | null>(null)
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const { copiedKey: copiedSection, copy: copyToClipboard } = useClipboard()
 
   const repoUrls = useMemo<RepoUrl[]>(
     () => buildRepoUrls(result?.request_params),
     [result?.request_params],
   )
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
-    }
-  }, [])
-
-  function copyToClipboard(text: string, section: string) {
-    if (!navigator.clipboard?.writeText) return
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopiedSection(section)
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
-      copyTimeoutRef.current = setTimeout(() => setCopiedSection(null), 2000)
-    }).catch(() => {
-      setCopiedSection(null)
-    })
-  }
 
   function getModelsForProvider(provider: string) {
     return [...new Set(aiConfigs.filter((c) => c.ai_provider === provider).map((c) => c.ai_model))]

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -201,9 +201,18 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
           >
             {expanded ? <ChevronDown className="h-4 w-4 shrink-0 text-text-tertiary" /> : <ChevronRight className="h-4 w-4 shrink-0 text-text-tertiary" />}
             <div className="min-w-0 flex-1">
-              <p className="truncate font-display text-sm font-medium text-text-primary">{rep.test_name}</p>
+              <p className="truncate font-display text-sm font-medium text-text-primary" title={rep.test_name}>{rep.test_name}</p>
               {group.count > 1 && <span className="text-xs text-text-tertiary">+{group.count - 1} more with same error</span>}
             </div>
+          </button>
+          <button
+            type="button"
+            className="text-text-tertiary hover:text-text-primary transition-colors shrink-0"
+            onClick={(e) => { e.stopPropagation(); copyToClipboard(rep.test_name, 'test-name') }}
+            title={copiedSection === 'test-name' ? 'Copied test name' : 'Copy test name to clipboard'}
+            aria-label={copiedSection === 'test-name' ? 'Copied test name' : 'Copy test name to clipboard'}
+          >
+            {copiedSection === 'test-name' ? <Check className="h-3 w-3 text-signal-green" /> : <Copy className="h-3 w-3" />}
           </button>
           <div className="flex items-center gap-2 shrink-0">
             <ClassificationBadge classification={classification} />
@@ -259,7 +268,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                 <div className="space-y-1">
                   {group.tests.map((t) => (
                     <div key={t.test_name} className="flex items-center justify-between gap-2">
-                      <p className="font-mono text-xs text-text-secondary truncate">{t.test_name}</p>
+                      <p className="font-mono text-xs text-text-secondary truncate" title={t.test_name}>{t.test_name}</p>
                       <ReviewToggle jobId={jobId} testName={t.test_name} childJobName={scopedChildJobName} childBuildNumber={scopedChildBuildNumber} disabled={reviewingAll} />
                     </div>
                   ))}


### PR DESCRIPTION
## Summary

Three easy-win UI improvements bundled into one PR.

### #144 — Fix failure card long test names (unreadable and uncopyable)

- Added `title` attribute to truncated test names so the full name appears on hover
- Added a clipboard copy button (📋) next to the test name header that copies the full test name **without** triggering the expand/collapse toggle
- Also added `title` attribute to test names in the "Affected Tests" list within grouped failure cards

### #146 — Show JJI CLI command on report page

- Added a `CliCommand` component in the report page footer showing the `jji results show <job_id> --json` command
- Includes a copy-to-clipboard button with checkmark feedback
- Compact and consistent with existing footer styling

### #143 — Diagram text too small / poor contrast

Filed upstream at https://github.com/myk-org/docsfy/issues/62 since docs HTML is generated by docsfy. Issue #143 closed with a comment pointing to the upstream issue.

## Testing

- All tests pass (`tox`: 1,195 backend + 92 frontend)
- Visually verified in the running dev container

Closes #144, closes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-click copy for CLI result commands with visual confirmation.
  * One-click copy buttons for test names and keys across pages.
  * Hover tooltips reveal full test names and commands for truncated items.

* **Refactor**
  * Unified clipboard behavior across the app for consistent copy/confirmation UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->