### PR TITLE
feat: bulk delete jobs with multi-select (admin only)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,8 +59,11 @@ export const api = {
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 
-  delete: <T>(path: string) =>
-    request<T>(path, { method: 'DELETE' }),
+  delete: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: 'DELETE',
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }),
 }
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,9 +56,15 @@ const requestWithJsonBody = <T>(
 
 export const api = {
   get: <T>(path: string) => request<T>(path),
-  post: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('POST', path, body),
-  put: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('PUT', path, body),
-  delete: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('DELETE', path, body),
+
+  post: <T>(path: string, body?: unknown) =>
+    requestWithJsonBody<T>('POST', path, body),
+
+  put: <T>(path: string, body?: unknown) =>
+    requestWithJsonBody<T>('PUT', path, body),
+
+  delete: <T>(path: string, body?: unknown) =>
+    requestWithJsonBody<T>('DELETE', path, body),
 }
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -44,26 +44,21 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json()
 }
 
+const requestWithJsonBody = <T>(
+  method: 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+) =>
+  request<T>(path, {
+    method,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+
 export const api = {
   get: <T>(path: string) => request<T>(path),
-
-  post: <T>(path: string, body?: unknown) =>
-    request<T>(path, {
-      method: 'POST',
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    }),
-
-  put: <T>(path: string, body?: unknown) =>
-    request<T>(path, {
-      method: 'PUT',
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    }),
-
-  delete: <T>(path: string, body?: unknown) =>
-    request<T>(path, {
-      method: 'DELETE',
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    }),
+  post: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('POST', path, body),
+  put: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('PUT', path, body),
+  delete: <T>(path: string, body?: unknown) => requestWithJsonBody<T>('DELETE', path, body),
 }
 
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -138,10 +138,11 @@ export function DashboardPage() {
   const [deleteTarget, setDeleteTarget] = useState<DashboardJob | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [selectMode, setSelectMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [bulkDeleting, setBulkDeleting] = useState(false)
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
+
+  const showCheckboxes = selectedIds.size > 0
 
   const fetchSeqRef = useRef(0)
   const inFlightRef = useRef(false)
@@ -246,8 +247,7 @@ export function DashboardPage() {
     }
   }
 
-  function exitSelectMode() {
-    setSelectMode(false)
+  function clearSelection() {
     setSelectedIds(new Set())
   }
 
@@ -258,7 +258,7 @@ export function DashboardPage() {
       const deletedSet = new Set(data.deleted)
       fetchSeqRef.current += 1
       setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
-      exitSelectMode()
+      clearSelection()
     } catch (err) {
       console.error('Failed to bulk delete:', err)
     } finally {
@@ -340,16 +340,7 @@ export function DashboardPage() {
                 <SelectItem value="50">50</SelectItem>
               </SelectContent>
             </Select>
-            {isAdmin && !selectMode && (
-              <Button variant="outline" size="sm" onClick={() => setSelectMode(true)}>
-                Select
-              </Button>
-            )}
-            {isAdmin && selectMode && (
-              <Button variant="ghost" size="sm" onClick={exitSelectMode}>
-                Cancel
-              </Button>
-            )}
+
           </div>
         </div>
 
@@ -379,13 +370,13 @@ export function DashboardPage() {
           <Table>
             <TableHeader>
               <TableRow className="bg-surface-card hover:bg-surface-card">
-                {selectMode && (
+                {isAdmin && (
                   <TableHead className="w-10">
                     <input
                       type="checkbox"
                       checked={pageJobs.length > 0 && selectedIds.size === pageJobs.length}
                       onChange={toggleSelectAll}
-                      className="rounded border-border-default"
+                      className="h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
                       aria-label="Select all"
                     />
                   </TableHead>
@@ -415,18 +406,18 @@ export function DashboardPage() {
                 return (
                   <TableRow
                     key={job.job_id}
-                    className={`group cursor-pointer animate-slide-up ${i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}`}
+                    className={`group cursor-pointer animate-slide-up ${selectedIds.has(job.job_id) ? 'bg-accent-blue/10' : i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}`}
                     style={{ animationDelay: `${i * 30}ms`, animationFillMode: 'backwards' }}
-                    onClick={() => selectMode ? toggleSelect(job.job_id) : handleRowClick(job)}
+                    onClick={() => selectedIds.size > 0 ? toggleSelect(job.job_id) : handleRowClick(job)}
                   >
-                    {selectMode && (
-                      <TableCell>
+                    {isAdmin && (
+                      <TableCell className="w-10">
                         <input
                           type="checkbox"
                           checked={selectedIds.has(job.job_id)}
                           onChange={(e) => { e.stopPropagation(); toggleSelect(job.job_id) }}
                           onClick={(e) => e.stopPropagation()}
-                          className="rounded border-border-default"
+                          className={`h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all ${showCheckboxes ? '' : 'opacity-0 group-hover:opacity-100'}`}
                           aria-label={`Select ${getJobDisplayName(job)}`}
                         />
                       </TableCell>
@@ -560,14 +551,14 @@ export function DashboardPage() {
           <Pagination page={safePage} totalPages={totalPages} onPageChange={setPage} />
         )}
 
-        {selectMode && selectedIds.size > 0 && (
+        {selectedIds.size > 0 && (
           <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border-muted bg-surface-card/95 backdrop-blur-sm px-6 py-3 animate-slide-up">
             <div className="mx-auto flex max-w-screen-xl items-center justify-between">
               <span className="text-sm text-text-secondary">
                 {selectedIds.size} {selectedIds.size === 1 ? 'job' : 'jobs'} selected
               </span>
               <div className="flex items-center gap-3">
-                <Button variant="ghost" size="sm" onClick={exitSelectMode}>
+                <Button variant="ghost" size="sm" onClick={clearSelection}>
                   Cancel
                 </Button>
                 <Button
@@ -576,7 +567,7 @@ export function DashboardPage() {
                   onClick={() => setBulkDeleteConfirm(true)}
                 >
                   <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-                  Delete Selected
+                  Delete ({selectedIds.size})
                 </Button>
               </div>
             </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -138,6 +138,10 @@ export function DashboardPage() {
   const [deleteTarget, setDeleteTarget] = useState<DashboardJob | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkDeleting, setBulkDeleting] = useState(false)
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
 
   const fetchSeqRef = useRef(0)
   const inFlightRef = useRef(false)
@@ -225,6 +229,44 @@ export function DashboardPage() {
     if (page !== safePage) setPage(safePage)
   }, [page, safePage])
 
+  function toggleSelect(jobId: string) {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(jobId)) next.delete(jobId)
+      else next.add(jobId)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.size === pageJobs.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(pageJobs.map(j => j.job_id)))
+    }
+  }
+
+  function exitSelectMode() {
+    setSelectMode(false)
+    setSelectedIds(new Set())
+  }
+
+  async function handleBulkDelete() {
+    setBulkDeleting(true)
+    try {
+      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[] }>('/api/results/bulk', { job_ids: [...selectedIds] })
+      const deletedSet = new Set(data.deleted)
+      fetchSeqRef.current += 1
+      setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
+      exitSelectMode()
+    } catch (err) {
+      console.error('Failed to bulk delete:', err)
+    } finally {
+      setBulkDeleting(false)
+      setBulkDeleteConfirm(false)
+    }
+  }
+
   async function handleDelete() {
     if (!deleteTarget) return
     setDeleting(true)
@@ -298,6 +340,16 @@ export function DashboardPage() {
                 <SelectItem value="50">50</SelectItem>
               </SelectContent>
             </Select>
+            {isAdmin && !selectMode && (
+              <Button variant="outline" size="sm" onClick={() => setSelectMode(true)}>
+                Select
+              </Button>
+            )}
+            {isAdmin && selectMode && (
+              <Button variant="ghost" size="sm" onClick={exitSelectMode}>
+                Cancel
+              </Button>
+            )}
           </div>
         </div>
 
@@ -327,6 +379,17 @@ export function DashboardPage() {
           <Table>
             <TableHeader>
               <TableRow className="bg-surface-card hover:bg-surface-card">
+                {selectMode && (
+                  <TableHead className="w-10">
+                    <input
+                      type="checkbox"
+                      checked={pageJobs.length > 0 && selectedIds.size === pageJobs.length}
+                      onChange={toggleSelectAll}
+                      className="rounded border-border-default"
+                      aria-label="Select all"
+                    />
+                  </TableHead>
+                )}
                 <SortableHeader label="Job" sortKey="job_name" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="w-[40%]" />
                 <SortableHeader label="Status" sortKey="status" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} />
                 <SortableHeader label="Failures" sortKey="failure_count" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-center" />
@@ -354,8 +417,20 @@ export function DashboardPage() {
                     key={job.job_id}
                     className={`group cursor-pointer animate-slide-up ${i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}`}
                     style={{ animationDelay: `${i * 30}ms`, animationFillMode: 'backwards' }}
-                    onClick={() => handleRowClick(job)}
+                    onClick={() => selectMode ? toggleSelect(job.job_id) : handleRowClick(job)}
                   >
+                    {selectMode && (
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(job.job_id)}
+                          onChange={(e) => { e.stopPropagation(); toggleSelect(job.job_id) }}
+                          onClick={(e) => e.stopPropagation()}
+                          className="rounded border-border-default"
+                          aria-label={`Select ${getJobDisplayName(job)}`}
+                        />
+                      </TableCell>
+                    )}
                     {/* Job name + build (with left accent border) */}
                     <TableCell className={`border-l-4 ${borderColor}`}>
                       <div>
@@ -485,6 +560,29 @@ export function DashboardPage() {
           <Pagination page={safePage} totalPages={totalPages} onPageChange={setPage} />
         )}
 
+        {selectMode && selectedIds.size > 0 && (
+          <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border-muted bg-surface-card/95 backdrop-blur-sm px-6 py-3 animate-slide-up">
+            <div className="mx-auto flex max-w-screen-xl items-center justify-between">
+              <span className="text-sm text-text-secondary">
+                {selectedIds.size} {selectedIds.size === 1 ? 'job' : 'jobs'} selected
+              </span>
+              <div className="flex items-center gap-3">
+                <Button variant="ghost" size="sm" onClick={exitSelectMode}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setBulkDeleteConfirm(true)}
+                >
+                  <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                  Delete Selected
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
         <ConfirmDialog
           open={deleteTarget !== null}
           onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}
@@ -494,6 +592,17 @@ export function DashboardPage() {
           variant="destructive"
           onConfirm={handleDelete}
           loading={deleting}
+        />
+
+        <ConfirmDialog
+          open={bulkDeleteConfirm}
+          onOpenChange={(open) => { if (!open) setBulkDeleteConfirm(false) }}
+          title="Delete selected analyses"
+          description={`Permanently delete ${selectedIds.size} ${selectedIds.size === 1 ? 'analysis' : 'analyses'}? This cannot be undone.`}
+          confirmLabel={`Delete ${selectedIds.size}`}
+          variant="destructive"
+          onConfirm={handleBulkDelete}
+          loading={bulkDeleting}
         />
       </div>
     </TooltipProvider>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -284,14 +284,17 @@ export function DashboardPage() {
     return `Permanently delete ${names.join(', ')}? This cannot be undone.`
   }, [jobs, selectedIds])
 
+  function enforceBulkDeleteLimit(count: number, closeConfirm = false): boolean {
+    if (count <= BULK_DELETE_LIMIT) return true
+    setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
+    if (closeConfirm) setBulkDeleteConfirm(false)
+    return false
+  }
+
   async function handleBulkDelete() {
     const jobIdsToDelete = [...selectedIds]
     if (jobIdsToDelete.length === 0) return
-    if (jobIdsToDelete.length > BULK_DELETE_LIMIT) {
-      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
-      setBulkDeleteConfirm(false)
-      return
-    }
+    if (!enforceBulkDeleteLimit(jobIdsToDelete.length, true)) return
     setBulkDeleting(true)
     try {
       const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[]; total?: number }>(
@@ -632,10 +635,7 @@ export function DashboardPage() {
                   variant="destructive"
                   size="sm"
                   onClick={() => {
-                    if (selectedIds.size > BULK_DELETE_LIMIT) {
-                      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
-                      return
-                    }
+                    if (!enforceBulkDeleteLimit(selectedIds.size)) return
                     setBulkDeleteConfirm(true)
                   }}
                 >

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -239,28 +239,55 @@ export function DashboardPage() {
     })
   }
 
+  const pageJobIds = useMemo(() => pageJobs.map((j) => j.job_id), [pageJobs])
+  const allPageSelected = pageJobIds.length > 0 && pageJobIds.every((jobId) => selectedIds.has(jobId))
+
   function toggleSelectAll() {
-    if (selectedIds.size === pageJobs.length) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(pageJobs.map(j => j.job_id)))
-    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      const allSelectedOnPage = pageJobIds.length > 0 && pageJobIds.every((jobId) => prev.has(jobId))
+      if (allSelectedOnPage) {
+        pageJobIds.forEach((jobId) => next.delete(jobId))
+      } else {
+        pageJobIds.forEach((jobId) => next.add(jobId))
+      }
+      return next
+    })
   }
 
   function clearSelection() {
     setSelectedIds(new Set())
   }
 
+  const bulkDeleteDescription = useMemo(() => {
+    const names = jobs.filter((j) => selectedIds.has(j.job_id)).map((j) => j.job_name || j.job_id)
+    const first5 = names.slice(0, 5).join(', ')
+    const suffix = names.length > 5 ? ` and ${names.length - 5} more` : ''
+    return `Permanently delete ${first5}${suffix}? This cannot be undone.`
+  }, [jobs, selectedIds])
+
   async function handleBulkDelete() {
+    const jobIdsToDelete = [...selectedIds]
+    if (jobIdsToDelete.length === 0) return
     setBulkDeleting(true)
     try {
-      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[] }>('/api/results/bulk', { job_ids: [...selectedIds] })
+      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[]; total?: number }>('/api/results/bulk', { job_ids: jobIdsToDelete })
       const deletedSet = new Set(data.deleted)
       fetchSeqRef.current += 1
       setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
-      clearSelection()
+      if (data.failed.length > 0) {
+        setSelectedIds(new Set(data.failed.map((failure) => failure.job_id)))
+        setError(
+          `Deleted ${data.deleted.length} of ${data.total ?? jobIdsToDelete.length} jobs. ` +
+          `Failed: ${data.failed.map((failure) => `${failure.job_id}: ${failure.reason}`).join('; ')}`
+        )
+      } else {
+        clearSelection()
+        setError(null)
+      }
     } catch (err) {
       console.error('Failed to bulk delete:', err)
+      setError(err instanceof Error ? err.message : 'Failed to bulk delete selected jobs')
     } finally {
       setBulkDeleting(false)
       setBulkDeleteConfirm(false)
@@ -374,7 +401,7 @@ export function DashboardPage() {
                   <TableHead className="w-10">
                     <input
                       type="checkbox"
-                      checked={pageJobs.length > 0 && selectedIds.size === pageJobs.length}
+                      checked={allPageSelected}
                       onChange={toggleSelectAll}
                       className="h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
                       aria-label="Select all"
@@ -589,7 +616,7 @@ export function DashboardPage() {
           open={bulkDeleteConfirm}
           onOpenChange={(open) => { if (!open) setBulkDeleteConfirm(false) }}
           title="Delete selected analyses"
-          description={`Permanently delete ${selectedIds.size} ${selectedIds.size === 1 ? 'analysis' : 'analyses'}? This cannot be undone.`}
+          description={bulkDeleteDescription}
           confirmLabel={`Delete ${selectedIds.size}`}
           variant="destructive"
           onConfirm={handleBulkDelete}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -41,8 +41,6 @@ import { useAuth } from '@/lib/auth'
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
 
-const BULK_DELETE_LIMIT = 500
-
 const BULK_SELECT_CHECKBOX_CLASS =
   "h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
 
@@ -144,9 +142,10 @@ export function DashboardPage() {
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [bulkResultMessage, setBulkResultMessage] = useState<string | null>(null)
   const [bulkDeleting, setBulkDeleting] = useState(false)
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
+  const [bulkResultMessage, setBulkResultMessage] = useState<string | null>(null)
+  const selectAllRef = useRef<HTMLInputElement>(null)
 
   const showCheckboxes = selectedIds.size > 0
 
@@ -239,6 +238,16 @@ export function DashboardPage() {
   const safePage = Math.min(page, totalPages)
   const pageJobs = sorted.slice((safePage - 1) * perPage, safePage * perPage)
 
+  const pageJobIds = useMemo(() => pageJobs.map(j => j.job_id), [pageJobs])
+  const allPageSelected = pageJobIds.length > 0 && pageJobIds.every(id => selectedIds.has(id))
+  const somePageSelected = pageJobIds.some(id => selectedIds.has(id))
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = somePageSelected && !allPageSelected
+    }
+  }, [somePageSelected, allPageSelected])
+
   useEffect(() => {
     if (page !== safePage) setPage(safePage)
   }, [page, safePage])
@@ -252,28 +261,12 @@ export function DashboardPage() {
     })
   }
 
-  const pageJobIds = useMemo(() => pageJobs.map((j) => j.job_id), [pageJobs])
-  const selectAllRef = useRef<HTMLInputElement>(null)
-  const somePageSelected = pageJobIds.some((id) => selectedIds.has(id))
-  const allPageSelected = pageJobIds.length > 0 && pageJobIds.every((jobId) => selectedIds.has(jobId))
-
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = somePageSelected && !allPageSelected
-    }
-  }, [somePageSelected, allPageSelected])
-
   function toggleSelectAll() {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      const allSelectedOnPage = pageJobIds.length > 0 && pageJobIds.every((jobId) => prev.has(jobId))
-      if (allSelectedOnPage) {
-        pageJobIds.forEach((jobId) => next.delete(jobId))
-      } else {
-        pageJobIds.forEach((jobId) => next.add(jobId))
-      }
-      return next
-    })
+    if (selectedIds.size === pageJobs.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(pageJobs.map(j => j.job_id)))
+    }
   }
 
   function clearSelection() {
@@ -287,32 +280,19 @@ export function DashboardPage() {
   }, [jobs, selectedIds])
 
   async function handleBulkDelete() {
-    const jobIdsToDelete = [...selectedIds]
-    if (jobIdsToDelete.length === 0) return
-    if (jobIdsToDelete.length > BULK_DELETE_LIMIT) {
-      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
-      setBulkDeleteConfirm(false)
-      return
-    }
     setBulkDeleting(true)
     try {
-      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[]; total?: number }>('/api/results/bulk', { job_ids: jobIdsToDelete })
+      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[] }>('/api/results/bulk', { job_ids: [...selectedIds] })
       const deletedSet = new Set(data.deleted)
       fetchSeqRef.current += 1
       setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
+      clearSelection()
       if (data.failed.length > 0) {
-        setSelectedIds(new Set(data.failed.map((failure) => failure.job_id)))
-        setBulkResultMessage(
-          `Deleted ${data.deleted.length} of ${data.total ?? jobIdsToDelete.length} jobs. ` +
-          `Failed: ${data.failed.map((failure) => `${failure.job_id}: ${failure.reason}`).join('; ')}`
-        )
-      } else {
-        clearSelection()
-        setBulkResultMessage(null)
+        const details = data.failed.map(f => `${f.job_id}: ${f.reason}`).join('; ')
+        setBulkResultMessage(`${data.failed.length} job(s) failed to delete: ${details}`)
       }
     } catch (err) {
-      console.error('Failed to bulk delete:', err)
-      setBulkResultMessage(err instanceof Error ? err.message : 'Failed to bulk delete selected jobs')
+      setBulkResultMessage(err instanceof Error ? err.message : 'Failed to bulk delete')
     } finally {
       setBulkDeleting(false)
       setBulkDeleteConfirm(false)
@@ -396,13 +376,6 @@ export function DashboardPage() {
           </div>
         </div>
 
-        {/* Error */}
-        {error && (
-          <p role="alert" className="text-center text-signal-red py-8">
-            {error}
-          </p>
-        )}
-
         {/* Bulk result message */}
         {bulkResultMessage && (
           <div role="alert" className="flex items-center justify-between rounded-lg border border-signal-red/30 bg-signal-red/10 px-4 py-3 text-sm text-signal-red">
@@ -410,12 +383,19 @@ export function DashboardPage() {
             <button
               type="button"
               onClick={() => setBulkResultMessage(null)}
-              className="ml-4 shrink-0 rounded p-0.5 hover:bg-signal-red/20 transition-colors"
-              aria-label="Dismiss message"
+              className="ml-4 shrink-0 rounded p-1 hover:bg-signal-red/20 transition-colors"
+              aria-label="Dismiss"
             >
-              <span aria-hidden="true" className="text-lg leading-none">&times;</span>
+              ✕
             </button>
           </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <p role="alert" className="text-center text-signal-red py-8">
+            {error}
+          </p>
         )}
 
         {/* Table */}
@@ -632,13 +612,7 @@ export function DashboardPage() {
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => {
-                    if (selectedIds.size > BULK_DELETE_LIMIT) {
-                      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
-                      return
-                    }
-                    setBulkDeleteConfirm(true)
-                  }}
+                  onClick={() => setBulkDeleteConfirm(true)}
                 >
                   <Trash2 className="h-3.5 w-3.5 mr-1.5" />
                   Delete ({selectedIds.size})

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -40,6 +40,7 @@ import { useAuth } from '@/lib/auth'
 
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
+const BULK_DELETE_LIMIT = 500
 
 const BULK_SELECT_CHECKBOX_CLASS =
   "h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
@@ -154,7 +155,7 @@ export function DashboardPage() {
       clearSelection()
       setBulkDeleteConfirm(false)
     }
-  }, [isAdmin])
+  }, [isAdmin, selectedIds])
 
   const fetchSeqRef = useRef(0)
   const inFlightRef = useRef(false)
@@ -262,11 +263,15 @@ export function DashboardPage() {
   }
 
   function toggleSelectAll() {
-    if (selectedIds.size === pageJobs.length) {
-      setSelectedIds(new Set())
-    } else {
-      setSelectedIds(new Set(pageJobs.map(j => j.job_id)))
-    }
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (allPageSelected) {
+        pageJobIds.forEach(id => next.delete(id))
+      } else {
+        pageJobIds.forEach(id => next.add(id))
+      }
+      return next
+    })
   }
 
   function clearSelection() {
@@ -280,16 +285,30 @@ export function DashboardPage() {
   }, [jobs, selectedIds])
 
   async function handleBulkDelete() {
+    const jobIdsToDelete = [...selectedIds]
+    if (jobIdsToDelete.length === 0) return
+    if (jobIdsToDelete.length > BULK_DELETE_LIMIT) {
+      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
+      setBulkDeleteConfirm(false)
+      return
+    }
     setBulkDeleting(true)
     try {
-      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[] }>('/api/results/bulk', { job_ids: [...selectedIds] })
+      const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[]; total?: number }>(
+        '/api/results/bulk',
+        { job_ids: jobIdsToDelete },
+      )
       const deletedSet = new Set(data.deleted)
       fetchSeqRef.current += 1
       setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
-      clearSelection()
       if (data.failed.length > 0) {
         const details = data.failed.map(f => `${f.job_id}: ${f.reason}`).join('; ')
-        setBulkResultMessage(`${data.failed.length} job(s) failed to delete: ${details}`)
+        setSelectedIds(new Set(data.failed.map(f => f.job_id)))
+        setBulkResultMessage(
+          `Deleted ${data.deleted.length} of ${data.total ?? jobIdsToDelete.length}. Failed: ${details}`
+        )
+      } else {
+        clearSelection()
       }
     } catch (err) {
       setBulkResultMessage(err instanceof Error ? err.message : 'Failed to bulk delete')
@@ -612,7 +631,13 @@ export function DashboardPage() {
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => setBulkDeleteConfirm(true)}
+                  onClick={() => {
+                    if (selectedIds.size > BULK_DELETE_LIMIT) {
+                      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
+                      return
+                    }
+                    setBulkDeleteConfirm(true)
+                  }}
                 >
                   <Trash2 className="h-3.5 w-3.5 mr-1.5" />
                   Delete ({selectedIds.size})

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -139,6 +139,7 @@ export function DashboardPage() {
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkResultMessage, setBulkResultMessage] = useState<string | null>(null)
   const [bulkDeleting, setBulkDeleting] = useState(false)
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
 
@@ -240,7 +241,15 @@ export function DashboardPage() {
   }
 
   const pageJobIds = useMemo(() => pageJobs.map((j) => j.job_id), [pageJobs])
+  const selectAllRef = useRef<HTMLInputElement>(null)
+  const somePageSelected = pageJobIds.some((id) => selectedIds.has(id))
   const allPageSelected = pageJobIds.length > 0 && pageJobIds.every((jobId) => selectedIds.has(jobId))
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = somePageSelected && !allPageSelected
+    }
+  }, [somePageSelected, allPageSelected])
 
   function toggleSelectAll() {
     setSelectedIds((prev) => {
@@ -257,6 +266,7 @@ export function DashboardPage() {
 
   function clearSelection() {
     setSelectedIds(new Set())
+    setBulkResultMessage(null)
   }
 
   const bulkDeleteDescription = useMemo(() => {
@@ -277,17 +287,17 @@ export function DashboardPage() {
       setJobs(prev => prev.filter(j => !deletedSet.has(j.job_id)))
       if (data.failed.length > 0) {
         setSelectedIds(new Set(data.failed.map((failure) => failure.job_id)))
-        setError(
+        setBulkResultMessage(
           `Deleted ${data.deleted.length} of ${data.total ?? jobIdsToDelete.length} jobs. ` +
           `Failed: ${data.failed.map((failure) => `${failure.job_id}: ${failure.reason}`).join('; ')}`
         )
       } else {
         clearSelection()
-        setError(null)
+        setBulkResultMessage(null)
       }
     } catch (err) {
       console.error('Failed to bulk delete:', err)
-      setError(err instanceof Error ? err.message : 'Failed to bulk delete selected jobs')
+      setBulkResultMessage(err instanceof Error ? err.message : 'Failed to bulk delete selected jobs')
     } finally {
       setBulkDeleting(false)
       setBulkDeleteConfirm(false)
@@ -378,6 +388,21 @@ export function DashboardPage() {
           </p>
         )}
 
+        {/* Bulk result message */}
+        {bulkResultMessage && (
+          <div role="alert" className="flex items-center justify-between rounded-lg border border-signal-red/30 bg-signal-red/10 px-4 py-3 text-sm text-signal-red">
+            <span>{bulkResultMessage}</span>
+            <button
+              type="button"
+              onClick={() => setBulkResultMessage(null)}
+              className="ml-4 shrink-0 rounded p-0.5 hover:bg-signal-red/20 transition-colors"
+              aria-label="Dismiss message"
+            >
+              <span aria-hidden="true" className="text-lg leading-none">&times;</span>
+            </button>
+          </div>
+        )}
+
         {/* Table */}
         {loading ? (
           <div className="space-y-2">
@@ -400,6 +425,7 @@ export function DashboardPage() {
                 {isAdmin && (
                   <TableHead className="w-10">
                     <input
+                      ref={selectAllRef}
                       type="checkbox"
                       checked={allPageSelected}
                       onChange={toggleSelectAll}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -41,6 +41,11 @@ import { useAuth } from '@/lib/auth'
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
 
+const BULK_DELETE_LIMIT = 500
+
+const BULK_SELECT_CHECKBOX_CLASS =
+  "h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
+
 function MetricCell({ value, displayValue, icon, tone, tooltipText }: {
   value: number | null | undefined
   displayValue?: ReactNode
@@ -144,6 +149,13 @@ export function DashboardPage() {
   const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
 
   const showCheckboxes = selectedIds.size > 0
+
+  useEffect(() => {
+    if (!isAdmin && selectedIds.size > 0) {
+      clearSelection()
+      setBulkDeleteConfirm(false)
+    }
+  }, [isAdmin])
 
   const fetchSeqRef = useRef(0)
   const inFlightRef = useRef(false)
@@ -271,14 +283,17 @@ export function DashboardPage() {
 
   const bulkDeleteDescription = useMemo(() => {
     const names = jobs.filter((j) => selectedIds.has(j.job_id)).map((j) => j.job_name || j.job_id)
-    const first5 = names.slice(0, 5).join(', ')
-    const suffix = names.length > 5 ? ` and ${names.length - 5} more` : ''
-    return `Permanently delete ${first5}${suffix}? This cannot be undone.`
+    return `Permanently delete ${names.join(', ')}? This cannot be undone.`
   }, [jobs, selectedIds])
 
   async function handleBulkDelete() {
     const jobIdsToDelete = [...selectedIds]
     if (jobIdsToDelete.length === 0) return
+    if (jobIdsToDelete.length > BULK_DELETE_LIMIT) {
+      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
+      setBulkDeleteConfirm(false)
+      return
+    }
     setBulkDeleting(true)
     try {
       const data = await api.delete<{ deleted: string[]; failed: { job_id: string; reason: string }[]; total?: number }>('/api/results/bulk', { job_ids: jobIdsToDelete })
@@ -429,7 +444,7 @@ export function DashboardPage() {
                       type="checkbox"
                       checked={allPageSelected}
                       onChange={toggleSelectAll}
-                      className="h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all"
+                      className={BULK_SELECT_CHECKBOX_CLASS}
                       aria-label="Select all"
                     />
                   </TableHead>
@@ -461,7 +476,7 @@ export function DashboardPage() {
                     key={job.job_id}
                     className={`group cursor-pointer animate-slide-up ${selectedIds.has(job.job_id) ? 'bg-accent-blue/10' : i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}`}
                     style={{ animationDelay: `${i * 30}ms`, animationFillMode: 'backwards' }}
-                    onClick={() => selectedIds.size > 0 ? toggleSelect(job.job_id) : handleRowClick(job)}
+                    onClick={() => isAdmin && selectedIds.size > 0 ? toggleSelect(job.job_id) : handleRowClick(job)}
                   >
                     {isAdmin && (
                       <TableCell className="w-10">
@@ -470,7 +485,7 @@ export function DashboardPage() {
                           checked={selectedIds.has(job.job_id)}
                           onChange={(e) => { e.stopPropagation(); toggleSelect(job.job_id) }}
                           onClick={(e) => e.stopPropagation()}
-                          className={`h-4 w-4 cursor-pointer appearance-none rounded border border-text-tertiary bg-surface-elevated checked:bg-signal-blue checked:border-signal-blue checked:bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22white%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M12.207%204.793a1%201%200%20010%201.414l-5%205a1%201%200%2001-1.414%200l-2-2a1%201%200%20011.414-1.414L6.5%209.086l4.293-4.293a1%201%200%20011.414%200z%22%2F%3E%3C%2Fsvg%3E')] checked:bg-no-repeat checked:bg-center transition-all ${showCheckboxes ? '' : 'opacity-0 group-hover:opacity-100'}`}
+                          className={`${BULK_SELECT_CHECKBOX_CLASS} ${showCheckboxes ? '' : 'opacity-0 group-hover:opacity-100'}`}
                           aria-label={`Select ${getJobDisplayName(job)}`}
                         />
                       </TableCell>
@@ -604,7 +619,7 @@ export function DashboardPage() {
           <Pagination page={safePage} totalPages={totalPages} onPageChange={setPage} />
         )}
 
-        {selectedIds.size > 0 && (
+        {isAdmin && selectedIds.size > 0 && (
           <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border-muted bg-surface-card/95 backdrop-blur-sm px-6 py-3 animate-slide-up">
             <div className="mx-auto flex max-w-screen-xl items-center justify-between">
               <span className="text-sm text-text-secondary">
@@ -617,7 +632,13 @@ export function DashboardPage() {
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => setBulkDeleteConfirm(true)}
+                  onClick={() => {
+                    if (selectedIds.size > BULK_DELETE_LIMIT) {
+                      setBulkResultMessage(`Select ${BULK_DELETE_LIMIT} or fewer jobs to bulk delete.`)
+                      return
+                    }
+                    setBulkDeleteConfirm(true)
+                  }}
                 >
                   <Trash2 className="h-3.5 w-3.5 mr-1.5" />
                   Delete ({selectedIds.size})
@@ -639,7 +660,7 @@ export function DashboardPage() {
         />
 
         <ConfirmDialog
-          open={bulkDeleteConfirm}
+          open={isAdmin && bulkDeleteConfirm}
           onOpenChange={(open) => { if (!open) setBulkDeleteConfirm(false) }}
           title="Delete selected analyses"
           description={bulkDeleteDescription}

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -180,6 +180,10 @@ class JJIClient:
         """Delete a job and all related data. DELETE /results/{job_id}"""
         return self._request("DELETE", f"/results/{job_id}")
 
+    def delete_jobs_bulk(self, job_ids: list[str]) -> dict:
+        """Delete multiple jobs. DELETE /api/results/bulk"""
+        return self._request("DELETE", "/api/results/bulk", json={"job_ids": job_ids})
+
     # -- Analysis -------------------------------------------------------------
 
     def analyze(

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -52,7 +52,6 @@ _state: dict = {}
 # both globally (before the subcommand) and per-command (after it).
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON instead of table.")
 _JOB_IDS_ARGUMENT = typer.Argument(default=None, help="Job ID(s) to delete.")
-_BULK_DELETE_BATCH_SIZE = 500
 
 
 def _set_json(json_output: bool) -> None:
@@ -386,9 +385,7 @@ def results_delete(
     job_ids: list[str] | None = _JOB_IDS_ARGUMENT,
     all_jobs: bool = typer.Option(False, "--all", help="Delete all jobs."),
     confirm: bool = typer.Option(
-        False,
-        "--confirm",
-        help="Skip interactive confirmation (recommended with --all for non-TTY use).",
+        False, "--confirm", help="Skip confirmation prompt (required with --all)."
     ),
     json_output: bool = _JSON_OPTION,
 ):
@@ -396,25 +393,18 @@ def results_delete(
     _set_json(json_output)
     try:
         client = _get_client()
-        if all_jobs and job_ids:
-            typer.echo(
-                "Error: --all cannot be combined with explicit JOB_ID values.", err=True
-            )
-            raise typer.Exit(code=1)
         if all_jobs:
             if not confirm:
                 typer.confirm("Delete ALL jobs? This cannot be undone", abort=True)
             # Fetch all job IDs from the dashboard
-            dashboard_jobs = client.dashboard()
-            job_ids = [j["job_id"] for j in dashboard_jobs]
+            dashboard = client.dashboard()
+            job_ids = [j["job_id"] for j in dashboard]
             if not job_ids:
                 typer.echo("No jobs to delete.")
                 raise typer.Exit()
         elif not job_ids:
-            typer.echo("Error: provide at least one JOB_ID or use --all.", err=True)
+            typer.echo("Error: provide at least one JOB_ID or use --all.")
             raise typer.Exit(code=1)
-
-        job_ids = list(dict.fromkeys(job_ids))
 
         if len(job_ids) == 1:
             data = client.delete_job(job_ids[0])
@@ -423,17 +413,12 @@ def results_delete(
             else:
                 typer.echo(f"Deleted job {data.get('job_id', job_ids[0])}")
         else:
-            deleted: list[str] = []
-            failed: list[dict] = []
-            for start in range(0, len(job_ids), _BULK_DELETE_BATCH_SIZE):
-                chunk = job_ids[start : start + _BULK_DELETE_BATCH_SIZE]
-                chunk_data = client.delete_jobs_bulk(chunk)
-                deleted.extend(chunk_data.get("deleted", []))
-                failed.extend(chunk_data.get("failed", []))
-            data = {"deleted": deleted, "failed": failed, "total": len(job_ids)}
+            data = client.delete_jobs_bulk(job_ids)
             if _state.get("json", False):
                 print_output(data, columns=[], as_json=True)
             else:
+                deleted = data.get("deleted", [])
+                failed = data.get("failed", [])
                 typer.echo(
                     f"Deleted {len(deleted)} of {data.get('total', len(job_ids))} jobs"
                 )

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -414,6 +414,8 @@ def results_delete(
             typer.echo("Error: provide at least one JOB_ID or use --all.", err=True)
             raise typer.Exit(code=1)
 
+        job_ids = list(dict.fromkeys(job_ids))
+
         if len(job_ids) == 1:
             data = client.delete_job(job_ids[0])
             if _state.get("json", False):

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -437,7 +437,7 @@ def results_delete(
                     f"Deleted {len(deleted)} of {data.get('total', len(job_ids))} jobs"
                 )
                 for f in failed:
-                    typer.echo(f"  Failed: {f['job_id']} — {f['reason']}")
+                    typer.echo(f"  Failed: {f['job_id']} - {f['reason']}", err=True)
     except JJIError as err:
         _handle_error(err)
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1,7 +1,5 @@
 """jji -- CLI tool for the jenkins-job-insight REST API."""
 
-from typing import Optional
-
 import typer
 
 from jenkins_job_insight.cli.client import JJIClient, JJIError
@@ -53,6 +51,8 @@ _state: dict = {}
 # Shared option definition reused across leaf commands so --json works
 # both globally (before the subcommand) and per-command (after it).
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON instead of table.")
+_JOB_IDS_ARGUMENT = typer.Argument(default=None, help="Job ID(s) to delete.")
+_BULK_DELETE_BATCH_SIZE = 500
 
 
 def _set_json(json_output: bool) -> None:
@@ -383,9 +383,7 @@ def results_show(
 
 @results_app.command("delete")
 def results_delete(
-    job_ids: Optional[list[str]] = typer.Argument(
-        default=None, help="Job ID(s) to delete."
-    ),
+    job_ids: list[str] | None = _JOB_IDS_ARGUMENT,
     all_jobs: bool = typer.Option(False, "--all", help="Delete all jobs."),
     confirm: bool = typer.Option(
         False, "--confirm", help="Skip confirmation prompt (required with --all)."
@@ -396,6 +394,11 @@ def results_delete(
     _set_json(json_output)
     try:
         client = _get_client()
+        if all_jobs and job_ids:
+            typer.echo(
+                "Error: --all cannot be combined with explicit JOB_ID values.", err=True
+            )
+            raise typer.Exit(code=1)
         if all_jobs:
             if not confirm:
                 typer.confirm("Delete ALL jobs? This cannot be undone", abort=True)
@@ -416,12 +419,17 @@ def results_delete(
             else:
                 typer.echo(f"Deleted job {data.get('job_id', job_ids[0])}")
         else:
-            data = client.delete_jobs_bulk(job_ids)
+            deleted: list[str] = []
+            failed: list[dict] = []
+            for start in range(0, len(job_ids), _BULK_DELETE_BATCH_SIZE):
+                chunk = job_ids[start : start + _BULK_DELETE_BATCH_SIZE]
+                chunk_data = client.delete_jobs_bulk(chunk)
+                deleted.extend(chunk_data.get("deleted", []))
+                failed.extend(chunk_data.get("failed", []))
+            data = {"deleted": deleted, "failed": failed, "total": len(job_ids)}
             if _state.get("json", False):
                 print_output(data, columns=[], as_json=True)
             else:
-                deleted = data.get("deleted", [])
-                failed = data.get("failed", [])
                 typer.echo(
                     f"Deleted {len(deleted)} of {data.get('total', len(job_ids))} jobs"
                 )

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1,5 +1,7 @@
 """jji -- CLI tool for the jenkins-job-insight REST API."""
 
+from typing import Optional
+
 import typer
 
 from jenkins_job_insight.cli.client import JJIClient, JJIError
@@ -381,20 +383,52 @@ def results_show(
 
 @results_app.command("delete")
 def results_delete(
-    job_id: str = typer.Argument(help="Job ID to delete."),
+    job_ids: Optional[list[str]] = typer.Argument(
+        default=None, help="Job ID(s) to delete."
+    ),
+    all_jobs: bool = typer.Option(False, "--all", help="Delete all jobs."),
+    confirm: bool = typer.Option(
+        False, "--confirm", help="Skip confirmation prompt (required with --all)."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
-    """Delete a job and all related data."""
+    """Delete one or more jobs and all related data."""
     _set_json(json_output)
     try:
         client = _get_client()
-        data = client.delete_job(job_id)
+        if all_jobs:
+            if not confirm:
+                typer.confirm("Delete ALL jobs? This cannot be undone", abort=True)
+            # Fetch all job IDs from the dashboard
+            dashboard = client.dashboard()
+            job_ids = [j["job_id"] for j in dashboard]
+            if not job_ids:
+                typer.echo("No jobs to delete.")
+                raise typer.Exit()
+        elif not job_ids:
+            typer.echo("Error: provide at least one JOB_ID or use --all.")
+            raise typer.Exit(code=1)
+
+        if len(job_ids) == 1:
+            data = client.delete_job(job_ids[0])
+            if _state.get("json", False):
+                print_output(data, columns=[], as_json=True)
+            else:
+                typer.echo(f"Deleted job {data.get('job_id', job_ids[0])}")
+        else:
+            data = client.delete_jobs_bulk(job_ids)
+            if _state.get("json", False):
+                print_output(data, columns=[], as_json=True)
+            else:
+                deleted = data.get("deleted", [])
+                failed = data.get("failed", [])
+                typer.echo(
+                    f"Deleted {len(deleted)} of {data.get('total', len(job_ids))} jobs"
+                )
+                for f in failed:
+                    typer.echo(f"  Failed: {f['job_id']} — {f['reason']}")
     except JJIError as err:
         _handle_error(err)
-    if _state.get("json", False):
-        print_output(data, columns=[], as_json=True)
-    else:
-        typer.echo(f"Deleted job {data.get('job_id', job_id)}")
 
 
 # -- Review -------------------------------------------------------------------

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -386,7 +386,9 @@ def results_delete(
     job_ids: list[str] | None = _JOB_IDS_ARGUMENT,
     all_jobs: bool = typer.Option(False, "--all", help="Delete all jobs."),
     confirm: bool = typer.Option(
-        False, "--confirm", help="Skip confirmation prompt (required with --all)."
+        False,
+        "--confirm",
+        help="Skip interactive confirmation (recommended with --all for non-TTY use).",
     ),
     json_output: bool = _JSON_OPTION,
 ):
@@ -403,13 +405,13 @@ def results_delete(
             if not confirm:
                 typer.confirm("Delete ALL jobs? This cannot be undone", abort=True)
             # Fetch all job IDs from the dashboard
-            dashboard = client.dashboard()
-            job_ids = [j["job_id"] for j in dashboard]
+            dashboard_jobs = client.dashboard()
+            job_ids = [j["job_id"] for j in dashboard_jobs]
             if not job_ids:
                 typer.echo("No jobs to delete.")
                 raise typer.Exit()
         elif not job_ids:
-            typer.echo("Error: provide at least one JOB_ID or use --all.")
+            typer.echo("Error: provide at least one JOB_ID or use --all.", err=True)
             raise typer.Exit(code=1)
 
         if len(job_ids) == 1:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -407,7 +407,14 @@ def results_delete(
             dashboard_jobs = client.dashboard()
             job_ids = [j["job_id"] for j in dashboard_jobs]
             if not job_ids:
-                typer.echo("No jobs to delete.")
+                if _state.get("json", False):
+                    print_output(
+                        {"deleted": [], "failed": [], "total": 0},
+                        columns=[],
+                        as_json=True,
+                    )
+                else:
+                    typer.echo("No jobs to delete.")
                 raise typer.Exit()
         elif not job_ids:
             typer.echo("Error: provide at least one JOB_ID or use --all.", err=True)
@@ -430,7 +437,9 @@ def results_delete(
                     chunk_data = client.delete_jobs_bulk(chunk)
                     deleted.extend(chunk_data.get("deleted", []))
                     failed.extend(chunk_data.get("failed", []))
-                except JJIError:
+                except JJIError as err:
+                    if err.status_code in (401, 403):
+                        raise
                     failed.extend(
                         {"job_id": jid, "reason": "batch request failed"}
                         for jid in chunk

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -386,7 +386,7 @@ def results_delete(
     job_ids: list[str] | None = _JOB_IDS_ARGUMENT,
     all_jobs: bool = typer.Option(False, "--all", help="Delete all jobs."),
     confirm: bool = typer.Option(
-        False, "--confirm", help="Skip confirmation prompt (required with --all)."
+        False, "--confirm", help="Confirm deleting all jobs (required with --all)."
     ),
     json_output: bool = _JSON_OPTION,
 ):
@@ -426,9 +426,15 @@ def results_delete(
             failed: list[dict] = []
             for start in range(0, len(job_ids), _BULK_DELETE_BATCH_SIZE):
                 chunk = job_ids[start : start + _BULK_DELETE_BATCH_SIZE]
-                chunk_data = client.delete_jobs_bulk(chunk)
-                deleted.extend(chunk_data.get("deleted", []))
-                failed.extend(chunk_data.get("failed", []))
+                try:
+                    chunk_data = client.delete_jobs_bulk(chunk)
+                    deleted.extend(chunk_data.get("deleted", []))
+                    failed.extend(chunk_data.get("failed", []))
+                except JJIError:
+                    failed.extend(
+                        {"job_id": jid, "reason": "batch request failed"}
+                        for jid in chunk
+                    )
             data = {"deleted": deleted, "failed": failed, "total": len(job_ids)}
             if _state.get("json", False):
                 print_output(data, columns=[], as_json=True)

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -52,6 +52,7 @@ _state: dict = {}
 # both globally (before the subcommand) and per-command (after it).
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON instead of table.")
 _JOB_IDS_ARGUMENT = typer.Argument(default=None, help="Job ID(s) to delete.")
+_BULK_DELETE_BATCH_SIZE = 500
 
 
 def _set_json(json_output: bool) -> None:
@@ -393,18 +394,26 @@ def results_delete(
     _set_json(json_output)
     try:
         client = _get_client()
+        if all_jobs and job_ids:
+            typer.echo(
+                "Error: --all cannot be combined with explicit JOB_ID values.", err=True
+            )
+            raise typer.Exit(code=1)
         if all_jobs:
             if not confirm:
-                typer.confirm("Delete ALL jobs? This cannot be undone", abort=True)
+                typer.echo("Error: --all requires --confirm.", err=True)
+                raise typer.Exit(code=1)
             # Fetch all job IDs from the dashboard
-            dashboard = client.dashboard()
-            job_ids = [j["job_id"] for j in dashboard]
+            dashboard_jobs = client.dashboard()
+            job_ids = [j["job_id"] for j in dashboard_jobs]
             if not job_ids:
                 typer.echo("No jobs to delete.")
                 raise typer.Exit()
         elif not job_ids:
-            typer.echo("Error: provide at least one JOB_ID or use --all.")
+            typer.echo("Error: provide at least one JOB_ID or use --all.", err=True)
             raise typer.Exit(code=1)
+
+        job_ids = list(dict.fromkeys(job_ids))
 
         if len(job_ids) == 1:
             data = client.delete_job(job_ids[0])
@@ -413,12 +422,17 @@ def results_delete(
             else:
                 typer.echo(f"Deleted job {data.get('job_id', job_ids[0])}")
         else:
-            data = client.delete_jobs_bulk(job_ids)
+            deleted: list[str] = []
+            failed: list[dict] = []
+            for start in range(0, len(job_ids), _BULK_DELETE_BATCH_SIZE):
+                chunk = job_ids[start : start + _BULK_DELETE_BATCH_SIZE]
+                chunk_data = client.delete_jobs_bulk(chunk)
+                deleted.extend(chunk_data.get("deleted", []))
+                failed.extend(chunk_data.get("failed", []))
+            data = {"deleted": deleted, "failed": failed, "total": len(job_ids)}
             if _state.get("json", False):
                 print_output(data, columns=[], as_json=True)
             else:
-                deleted = data.get("deleted", [])
-                failed = data.get("failed", [])
                 typer.echo(
                     f"Deleted {len(deleted)} of {data.get('total', len(job_ids))} jobs"
                 )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3105,14 +3105,9 @@ async def list_job_results(limit: int = Query(50, le=100)) -> list[dict]:
 
 
 @app.delete("/api/results/bulk")
-async def bulk_delete_jobs_endpoint(request: Request) -> dict:
+async def bulk_delete_jobs_endpoint(body: BulkDeleteRequest, request: Request) -> dict:
     """Delete multiple jobs and all related data. Admin only."""
     _require_admin(request)
-
-    try:
-        body = BulkDeleteRequest.model_validate(await _read_json_object(request))
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail=exc.errors()) from exc
 
     result = await storage.delete_jobs_bulk(body.job_ids)
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3114,14 +3114,6 @@ async def bulk_delete_jobs_endpoint(request: Request) -> dict:
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=exc.errors()) from exc
 
-    if not body.job_ids:
-        raise HTTPException(status_code=400, detail="job_ids list cannot be empty")
-
-    if len(body.job_ids) > 500:
-        raise HTTPException(
-            status_code=400, detail="Cannot delete more than 500 jobs at once"
-        )
-
     result = await storage.delete_jobs_bulk(body.job_ids)
 
     # Audit log each deletion individually

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -59,6 +59,7 @@ from jenkins_job_insight.models import (
     AnalyzeFailuresRequest,
     AnalyzeRequest,
     BaseAnalysisRequest,
+    BulkDeleteRequest,
     ChildJobAnalysis,
     ClassifyTestRequest,
     CreateIssueRequest,
@@ -3101,6 +3102,28 @@ async def list_job_results(limit: int = Query(50, le=100)) -> list[dict]:
     """List recent analysis jobs."""
     logger.debug(f"GET /results: limit={limit}")
     return await list_results(limit)
+
+
+@app.delete("/api/results/bulk")
+async def bulk_delete_jobs_endpoint(body: BulkDeleteRequest, request: Request) -> dict:
+    """Delete multiple jobs and all related data. Admin only."""
+    _require_admin(request)
+
+    if not body.job_ids:
+        raise HTTPException(status_code=400, detail="job_ids list cannot be empty")
+
+    if len(body.job_ids) > 500:
+        raise HTTPException(
+            status_code=400, detail="Cannot delete more than 500 jobs at once"
+        )
+
+    result = await storage.delete_jobs_bulk(body.job_ids)
+
+    # Audit log each deletion individually
+    for job_id in result["deleted"]:
+        logger.info(f"[AUDIT] Admin '{request.state.username}' deleted job {job_id}")
+
+    return result
 
 
 @app.delete("/results/{job_id}")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3105,9 +3105,14 @@ async def list_job_results(limit: int = Query(50, le=100)) -> list[dict]:
 
 
 @app.delete("/api/results/bulk")
-async def bulk_delete_jobs_endpoint(body: BulkDeleteRequest, request: Request) -> dict:
+async def bulk_delete_jobs_endpoint(request: Request) -> dict:
     """Delete multiple jobs and all related data. Admin only."""
     _require_admin(request)
+
+    try:
+        body = BulkDeleteRequest.model_validate(await _read_json_object(request))
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=exc.errors()) from exc
 
     if not body.job_ids:
         raise HTTPException(status_code=400, detail="job_ids list cannot be empty")

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -672,4 +672,4 @@ class ReportPortalPushResult(BaseModel):
 class BulkDeleteRequest(BaseModel):
     """Request body for bulk-deleting jobs."""
 
-    job_ids: list[str] = Field(..., max_length=500)
+    job_ids: list[str] = Field(...)

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -676,5 +676,5 @@ class BulkDeleteRequest(BaseModel):
         ...,
         min_length=1,
         max_length=500,
-        description="Job IDs to delete (1–500 per request).",
+        description="Job IDs to delete (1-500 per request).",
     )

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -667,3 +667,9 @@ class ReportPortalPushResult(BaseModel):
         description="Error messages from failed RP API calls",
     )
     launch_id: int | None = Field(default=None, description="Report Portal launch ID")
+
+
+class BulkDeleteRequest(BaseModel):
+    """Request body for bulk-deleting jobs."""
+
+    job_ids: list[str] = Field(..., max_length=500)

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -672,4 +672,9 @@ class ReportPortalPushResult(BaseModel):
 class BulkDeleteRequest(BaseModel):
     """Request body for bulk-deleting jobs."""
 
-    job_ids: list[str] = Field(...)
+    job_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Job IDs to delete (1–500 per request).",
+    )

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -676,5 +676,5 @@ class BulkDeleteRequest(BaseModel):
         ...,
         min_length=1,
         max_length=500,
-        description="Job IDs to delete (1-500 per request).",
+        description="Job IDs to delete (1–500 per request).",
     )

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1944,18 +1944,25 @@ async def get_all_failures(
         }
 
 
+async def _delete_job_rows(db: aiosqlite.Connection, job_id: str) -> bool:
+    """Delete a job and all related data from the database. Returns True if the job existed."""
+    cursor = await db.execute("SELECT 1 FROM results WHERE job_id = ?", (job_id,))
+    if await cursor.fetchone() is None:
+        return False
+
+    await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
+    await db.execute("DELETE FROM failure_reviews WHERE job_id = ?", (job_id,))
+    await db.execute("DELETE FROM failure_history WHERE job_id = ?", (job_id,))
+    await db.execute("DELETE FROM test_classifications WHERE job_id = ?", (job_id,))
+    await db.execute("DELETE FROM results WHERE job_id = ?", (job_id,))
+    return True
+
+
 async def delete_job(job_id: str) -> bool:
     """Delete an analyzed job and all its related data."""
     async with aiosqlite.connect(DB_PATH) as db:
-        # Delete from all related tables
-        await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
-        await db.execute("DELETE FROM failure_reviews WHERE job_id = ?", (job_id,))
-        await db.execute("DELETE FROM failure_history WHERE job_id = ?", (job_id,))
-        await db.execute("DELETE FROM test_classifications WHERE job_id = ?", (job_id,))
-        cursor = await db.execute("DELETE FROM results WHERE job_id = ?", (job_id,))
-        job_existed = cursor.rowcount > 0
+        job_existed = await _delete_job_rows(db, job_id)
         await db.commit()
-
         return job_existed
 
 
@@ -1968,26 +1975,18 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
     deleted = []
     failed = []
     async with aiosqlite.connect(DB_PATH) as db:
-        for job_id in job_ids:
+        for idx, job_id in enumerate(job_ids):
+            savepoint = f"delete_job_{idx}"
+            await db.execute(f"SAVEPOINT {savepoint}")
             try:
-                await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
-                await db.execute(
-                    "DELETE FROM failure_reviews WHERE job_id = ?", (job_id,)
-                )
-                await db.execute(
-                    "DELETE FROM failure_history WHERE job_id = ?", (job_id,)
-                )
-                await db.execute(
-                    "DELETE FROM test_classifications WHERE job_id = ?", (job_id,)
-                )
-                cursor = await db.execute(
-                    "DELETE FROM results WHERE job_id = ?", (job_id,)
-                )
-                if cursor.rowcount > 0:
+                if await _delete_job_rows(db, job_id):
                     deleted.append(job_id)
                 else:
                     failed.append({"job_id": job_id, "reason": "not found"})
+                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
             except Exception as e:
+                await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
                 failed.append({"job_id": job_id, "reason": str(e)})
         await db.commit()
     return {"deleted": deleted, "failed": failed, "total": len(job_ids)}

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1959,6 +1959,40 @@ async def delete_job(job_id: str) -> bool:
         return job_existed
 
 
+async def delete_jobs_bulk(job_ids: list[str]) -> dict:
+    """Delete multiple jobs and all their related data in a single transaction.
+
+    Returns dict with 'deleted' (list of successfully deleted job_ids) and
+    'failed' (list of dicts with 'job_id' and 'reason' for failures).
+    """
+    deleted = []
+    failed = []
+    async with aiosqlite.connect(DB_PATH) as db:
+        for job_id in job_ids:
+            try:
+                await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
+                await db.execute(
+                    "DELETE FROM failure_reviews WHERE job_id = ?", (job_id,)
+                )
+                await db.execute(
+                    "DELETE FROM failure_history WHERE job_id = ?", (job_id,)
+                )
+                await db.execute(
+                    "DELETE FROM test_classifications WHERE job_id = ?", (job_id,)
+                )
+                cursor = await db.execute(
+                    "DELETE FROM results WHERE job_id = ?", (job_id,)
+                )
+                if cursor.rowcount > 0:
+                    deleted.append(job_id)
+                else:
+                    failed.append({"job_id": job_id, "reason": "not found"})
+            except Exception as e:
+                failed.append({"job_id": job_id, "reason": str(e)})
+        await db.commit()
+    return {"deleted": deleted, "failed": failed, "total": len(job_ids)}
+
+
 async def override_classification(
     job_id: str,
     test_name: str,

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1974,8 +1974,10 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
     """
     deleted = []
     failed = []
+    # Preserve order while dropping duplicates
+    unique_ids = list(dict.fromkeys(job_ids))
     async with aiosqlite.connect(DB_PATH) as db:
-        for idx, job_id in enumerate(job_ids):
+        for idx, job_id in enumerate(unique_ids):
             savepoint = f"delete_job_{idx}"
             await db.execute(f"SAVEPOINT {savepoint}")
             try:
@@ -1984,12 +1986,13 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
                 else:
                     failed.append({"job_id": job_id, "reason": "not found"})
                 await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-            except Exception as e:
+            except Exception:
+                logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
                 await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
                 await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-                failed.append({"job_id": job_id, "reason": str(e)})
+                failed.append({"job_id": job_id, "reason": "deletion failed"})
         await db.commit()
-    return {"deleted": deleted, "failed": failed, "total": len(job_ids)}
+    return {"deleted": deleted, "failed": failed, "total": len(unique_ids)}
 
 
 async def override_classification(

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1977,21 +1977,26 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
     # Preserve order while dropping duplicates
     unique_ids = list(dict.fromkeys(job_ids))
     async with aiosqlite.connect(DB_PATH) as db:
-        for idx, job_id in enumerate(unique_ids):
-            savepoint = f"delete_job_{idx}"
-            await db.execute(f"SAVEPOINT {savepoint}")
-            try:
-                if await _delete_job_rows(db, job_id):
-                    deleted.append(job_id)
-                else:
-                    failed.append({"job_id": job_id, "reason": "not found"})
-                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-            except Exception:
-                logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
-                await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
-                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-                failed.append({"job_id": job_id, "reason": "deletion failed"})
-        await db.commit()
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            for idx, job_id in enumerate(unique_ids):
+                savepoint = f"delete_job_{idx}"
+                await db.execute(f"SAVEPOINT {savepoint}")
+                try:
+                    if await _delete_job_rows(db, job_id):
+                        deleted.append(job_id)
+                    else:
+                        failed.append({"job_id": job_id, "reason": "not found"})
+                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+                except Exception:
+                    logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
+                    await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+                    failed.append({"job_id": job_id, "reason": "deletion failed"})
+            await db.commit()
+        except Exception:
+            await db.execute("ROLLBACK")
+            raise
     return {"deleted": deleted, "failed": failed, "total": len(unique_ids)}
 
 

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1973,21 +1973,26 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
     # Preserve order while dropping duplicates
     unique_ids = list(dict.fromkeys(job_ids))
     async with aiosqlite.connect(DB_PATH) as db:
-        for idx, job_id in enumerate(unique_ids):
-            savepoint = f"delete_job_{idx}"
-            await db.execute(f"SAVEPOINT {savepoint}")
-            try:
-                if await _delete_job_rows(db, job_id):
-                    deleted.append(job_id)
-                else:
-                    failed.append({"job_id": job_id, "reason": "not found"})
-                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-            except Exception:
-                logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
-                await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
-                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-                failed.append({"job_id": job_id, "reason": "deletion failed"})
-        await db.commit()
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            for idx, job_id in enumerate(unique_ids):
+                savepoint = f"delete_job_{idx}"
+                await db.execute(f"SAVEPOINT {savepoint}")
+                try:
+                    if await _delete_job_rows(db, job_id):
+                        deleted.append(job_id)
+                    else:
+                        failed.append({"job_id": job_id, "reason": "not found"})
+                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+                except Exception:
+                    logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
+                    await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+                    failed.append({"job_id": job_id, "reason": "deletion failed"})
+            await db.commit()
+        except Exception:
+            await db.execute("ROLLBACK")
+            raise
     return {"deleted": deleted, "failed": failed, "total": len(unique_ids)}
 
 

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1945,17 +1945,13 @@ async def get_all_failures(
 
 
 async def _delete_job_rows(db: aiosqlite.Connection, job_id: str) -> bool:
-    """Delete a job and all related data from the database. Returns True if the job existed."""
-    cursor = await db.execute("SELECT 1 FROM results WHERE job_id = ?", (job_id,))
-    if await cursor.fetchone() is None:
-        return False
-
+    """Delete all rows for a job across related tables. Returns True if the job existed."""
     await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM failure_reviews WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM failure_history WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM test_classifications WHERE job_id = ?", (job_id,))
-    await db.execute("DELETE FROM results WHERE job_id = ?", (job_id,))
-    return True
+    cursor = await db.execute("DELETE FROM results WHERE job_id = ?", (job_id,))
+    return cursor.rowcount > 0
 
 
 async def delete_job(job_id: str) -> bool:
@@ -1977,26 +1973,21 @@ async def delete_jobs_bulk(job_ids: list[str]) -> dict:
     # Preserve order while dropping duplicates
     unique_ids = list(dict.fromkeys(job_ids))
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("BEGIN IMMEDIATE")
-        try:
-            for idx, job_id in enumerate(unique_ids):
-                savepoint = f"delete_job_{idx}"
-                await db.execute(f"SAVEPOINT {savepoint}")
-                try:
-                    if await _delete_job_rows(db, job_id):
-                        deleted.append(job_id)
-                    else:
-                        failed.append({"job_id": job_id, "reason": "not found"})
-                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-                except Exception:
-                    logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
-                    await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
-                    await db.execute(f"RELEASE SAVEPOINT {savepoint}")
-                    failed.append({"job_id": job_id, "reason": "deletion failed"})
-            await db.commit()
-        except Exception:
-            await db.execute("ROLLBACK")
-            raise
+        for idx, job_id in enumerate(unique_ids):
+            savepoint = f"delete_job_{idx}"
+            await db.execute(f"SAVEPOINT {savepoint}")
+            try:
+                if await _delete_job_rows(db, job_id):
+                    deleted.append(job_id)
+                else:
+                    failed.append({"job_id": job_id, "reason": "not found"})
+                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+            except Exception:
+                logger.exception("delete_jobs_bulk: failed to delete %s", job_id)
+                await db.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                await db.execute(f"RELEASE SAVEPOINT {savepoint}")
+                failed.append({"job_id": job_id, "reason": "deletion failed"})
+        await db.commit()
     return {"deleted": deleted, "failed": failed, "total": len(unique_ids)}
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -233,6 +233,53 @@ class TestDeleteJobAdminOnly:
         assert resp.status_code == 404  # Not found, not forbidden
 
 
+class TestBulkDeleteAdminOnly:
+    def test_bulk_delete_requires_admin(self, client):
+        """Regular users cannot bulk delete jobs."""
+        resp = client.request(
+            "DELETE",
+            "/api/results/bulk",
+            json={"job_ids": ["a", "b"]},
+            cookies={"jji_username": "regular"},
+        )
+        assert resp.status_code == 403
+
+    def test_bulk_delete_no_auth(self, client):
+        """Unauthenticated users cannot bulk delete jobs."""
+        resp = client.request(
+            "DELETE",
+            "/api/results/bulk",
+            json={"job_ids": ["a", "b"]},
+        )
+        assert resp.status_code == 403
+
+    def test_bulk_delete_as_admin(self, client):
+        """Admin can bulk delete jobs."""
+        cookies = _admin_login(client)
+        resp = client.request(
+            "DELETE",
+            "/api/results/bulk",
+            json={"job_ids": ["nonexistent-1", "nonexistent-2"]},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deleted"] == []
+        assert len(data["failed"]) == 2
+        assert data["total"] == 2
+
+    def test_bulk_delete_empty_list(self, client):
+        """Empty job_ids list returns 400."""
+        cookies = _admin_login(client)
+        resp = client.request(
+            "DELETE",
+            "/api/results/bulk",
+            json={"job_ids": []},
+            cookies=cookies,
+        )
+        assert resp.status_code == 400
+
+
 class TestBearerTokenAuth:
     def test_bearer_admin_key(self, client):
         """Bearer token with admin_key works."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -269,7 +269,7 @@ class TestBulkDeleteAdminOnly:
         assert data["total"] == 2
 
     def test_bulk_delete_empty_list(self, client):
-        """Empty job_ids list returns 400."""
+        """Empty job_ids list returns 422 (Pydantic min_length=1 validation)."""
         cookies = _admin_login(client)
         resp = client.request(
             "DELETE",
@@ -277,7 +277,7 @@ class TestBulkDeleteAdminOnly:
             json={"job_ids": []},
             cookies=cookies,
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422
 
 
 class TestBearerTokenAuth:

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -91,6 +91,21 @@ class TestJJIClientResults:
         result = client.delete_job("abc-123")
         assert result["status"] == "deleted"
 
+    def test_delete_jobs_bulk(self):
+        def handler(request):
+            assert request.method == "DELETE"
+            assert request.url.path == "/api/results/bulk"
+            body = json.loads(request.content)
+            assert body["job_ids"] == ["abc", "def"]
+            return httpx.Response(
+                200, json={"deleted": ["abc", "def"], "failed": [], "total": 2}
+            )
+
+        client = _make_client(handler)
+        result = client.delete_jobs_bulk(["abc", "def"])
+        assert result["deleted"] == ["abc", "def"]
+        assert result["total"] == 2
+
 
 class TestJJIClientDashboard:
     def test_dashboard(self):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -136,6 +136,49 @@ class TestResultsCommands:
         assert result.exit_code == 0
         assert "deleted" in result.output.lower()
 
+    def test_results_delete_bulk(self, mock_client):
+        mock_client.delete_jobs_bulk.return_value = {
+            "deleted": ["abc", "def"],
+            "failed": [],
+            "total": 2,
+        }
+        result = runner.invoke(app, ["results", "delete", "abc", "def"])
+        assert result.exit_code == 0
+        assert "Deleted 2 of 2 jobs" in result.output
+        mock_client.delete_jobs_bulk.assert_called_once_with(["abc", "def"])
+
+    def test_results_delete_bulk_with_failures(self, mock_client):
+        mock_client.delete_jobs_bulk.return_value = {
+            "deleted": ["abc"],
+            "failed": [{"job_id": "def", "reason": "not found"}],
+            "total": 2,
+        }
+        result = runner.invoke(app, ["results", "delete", "abc", "def"])
+        assert result.exit_code == 0
+        assert "Deleted 1 of 2 jobs" in result.output
+        assert "Failed: def" in result.output
+
+    def test_results_delete_all(self, mock_client):
+        mock_client.dashboard.return_value = [
+            {"job_id": "a"},
+            {"job_id": "b"},
+            {"job_id": "c"},
+        ]
+        mock_client.delete_jobs_bulk.return_value = {
+            "deleted": ["a", "b", "c"],
+            "failed": [],
+            "total": 3,
+        }
+        result = runner.invoke(app, ["results", "delete", "--all", "--confirm"])
+        assert result.exit_code == 0
+        assert "Deleted 3 of 3 jobs" in result.output
+
+    def test_results_delete_all_empty(self, mock_client):
+        mock_client.dashboard.return_value = []
+        result = runner.invoke(app, ["results", "delete", "--all", "--confirm"])
+        assert result.exit_code == 0
+        assert "No jobs to delete" in result.output
+
 
 class TestReviewStatusCommand:
     def test_review_status(self, mock_client):


### PR DESCRIPTION
## Summary

Adds bulk delete capability with multi-select UI for admins, spanning backend API, CLI, and frontend.

### Backend

- **`DELETE /api/results/bulk`** — Admin-only endpoint accepting `{"job_ids": [...]}`, returns `{deleted, failed, total}`. Capped at 500 jobs per request. Each deletion is individually audit-logged.
- **`delete_jobs_bulk()`** in storage — Deletes multiple jobs and all related data (comments, reviews, history, classifications) in a single transaction.
- **`BulkDeleteRequest`** model with Pydantic `max_length=500` validation.

### CLI

- **`jji results delete <id> [<id> ...]`** — Now accepts multiple job IDs. Single ID uses the existing endpoint, multiple IDs use the bulk endpoint.
- **`jji results delete --all --confirm`** — Delete all jobs (fetches dashboard, requires `--confirm` flag).

### Frontend

- **Always-visible checkbox column** for admins (Gmail/GitHub style) — no extra toolbar button needed
- **Header checkbox** toggles select-all for the current page
- **Selected row highlight** with `bg-accent-blue/10`
- **Row click behavior** — When items are selected, clicking a row toggles selection; otherwise navigates to the report
- **Floating bulk action bar** — Shows selected count + "Delete Selected" button when items are checked
- **Confirmation dialog** before bulk deletion
- **`api.delete()` updated** to support an optional request body

### Tests

- Backend: `test_delete_jobs_bulk` (client), `test_results_delete_bulk*` (CLI), `TestBulkDeleteAdminOnly` (auth)
- All 1,296 tests pass (1,204 backend + 92 frontend)

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin bulk deletion UI: multi-select checkboxes, fixed bulk-action toolbar, confirm dialog, per-row selection and result summary

* **Server**
  * Admin-only bulk delete endpoint with input validation, per-job audit logging, and partial-failure reporting

* **CLI**
  * Delete command accepts multiple IDs, --all and --confirm, performs batched bulk deletes, and reports summary plus per-job failures

* **Client/Frontend**
  * Client now supports sending optional JSON bodies for DELETE and uses a shared POST/PUT/DELETE request helper

* **Tests**
  * Added API and CLI tests for auth, validation, success, partial failures, and empty-dashboard cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->