### PR TITLE
feat: Add confirmation dialog before deleting comments (fixes #153)

### DIFF
--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -263,7 +263,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
         open={deleteTarget !== null}
         onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}
         title="Delete comment"
-        description="Are you sure you want to delete this comment?"
+        description="Are you sure you want to delete this comment? This action cannot be undone."
         confirmLabel="Delete"
         variant="destructive"
         onConfirm={() => { if (deleteTarget !== null) handleDelete(deleteTarget) }}

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -8,6 +8,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { LinkedText } from '@/components/shared/LinkedText'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { Trash2, MessageSquare } from 'lucide-react'
 import type { Comment } from '@/types'
 
@@ -145,6 +146,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
   }
 
   const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set())
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null)
 
   async function handleDelete(id: number) {
     if (deletingIds.has(id)) return
@@ -156,6 +158,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Failed to delete comment')
     } finally {
+      setDeleteTarget(null)
       setDeletingIds((prev) => {
         const next = new Set(prev)
         next.delete(id)
@@ -214,7 +217,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
                   <button
                     type="button"
                     aria-label="Delete comment"
-                    onClick={() => handleDelete(c.id)}
+                    onClick={() => setDeleteTarget(c.id)}
                     disabled={deletingIds.has(c.id)}
                     className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal-blue disabled:opacity-50"
                     title="Delete comment"
@@ -255,6 +258,17 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
           </span>
         )}
       </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}
+        title="Delete comment"
+        description="Are you sure you want to delete this comment?"
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={() => { if (deleteTarget !== null) handleDelete(deleteTarget) }}
+        loading={deleteTarget !== null && deletingIds.has(deleteTarget)}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { CommentsSection } from '../CommentsSection'
+import { ReportProvider, useReportDispatch } from '../ReportContext'
+import type { Comment } from '@/types'
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mockUsername = 'testuser'
+
+vi.mock('@/lib/cookies', () => ({
+  getUsername: () => mockUsername,
+}))
+
+const mockDelete = vi.fn()
+const mockPost = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    delete: (...args: unknown[]) => mockDelete(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 1,
+    job_id: 'job-1',
+    test_name: 'test-a',
+    child_job_name: '',
+    child_build_number: 0,
+    comment: 'A test comment',
+    username: mockUsername,
+    created_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * Helper child that injects comments into ReportContext, then renders CommentsSection.
+ */
+function Injector({ comments }: { comments: Comment[] }) {
+  const dispatch = useReportDispatch()
+  useEffect(() => {
+    dispatch({
+      type: 'SET_COMMENTS_AND_REVIEWS',
+      payload: { comments, reviews: {} },
+    })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  return (
+    <CommentsSection
+      jobId="job-1"
+      testNames={['test-a']}
+    />
+  )
+}
+
+function renderWithComments(comments: Comment[]) {
+  return render(
+    <ReportProvider>
+      <Injector comments={comments} />
+    </ReportProvider>,
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDelete.mockResolvedValue({})
+  mockPost.mockResolvedValue({ enrichments: {} })
+})
+
+describe('CommentsSection – delete confirmation', () => {
+  it('shows a confirmation dialog when the delete button is clicked', async () => {
+    renderWithComments([makeComment()])
+
+    const deleteBtn = screen.getByRole('button', { name: 'Delete comment' })
+    fireEvent.click(deleteBtn)
+
+    expect(screen.getByText('Are you sure you want to delete this comment?')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined()
+  })
+
+  it('does not call the API when cancel is clicked', async () => {
+    renderWithComments([makeComment()])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete comment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('calls the delete API when confirm is clicked', async () => {
+    renderWithComments([makeComment({ id: 42 })])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete comment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('/results/job-1/comments/42')
+    })
+  })
+
+  it('closes the dialog after successful deletion', async () => {
+    renderWithComments([makeComment()])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete comment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Are you sure you want to delete this comment?')).toBeNull()
+    })
+  })
+
+  it('does not show delete button for comments by other users', () => {
+    renderWithComments([makeComment({ username: 'other-user' })])
+
+    expect(screen.queryByRole('button', { name: 'Delete comment' })).toBeNull()
+  })
+
+  it('shows an error when deletion fails', async () => {
+    mockDelete.mockRejectedValueOnce(new Error('Network error'))
+    renderWithComments([makeComment()])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete comment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined()
+      expect(screen.getByText('Network error')).toBeDefined()
+    })
+  })
+})

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -87,7 +87,7 @@ describe('CommentsSection – delete confirmation', () => {
     const deleteBtn = screen.getByRole('button', { name: 'Delete comment' })
     fireEvent.click(deleteBtn)
 
-    expect(screen.getByText('Are you sure you want to delete this comment?')).toBeDefined()
+    expect(screen.getByText('Are you sure you want to delete this comment? This action cannot be undone.')).toBeDefined()
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDefined()
   })
@@ -119,7 +119,7 @@ describe('CommentsSection – delete confirmation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
-      expect(screen.queryByText('Are you sure you want to delete this comment?')).toBeNull()
+      expect(screen.queryByText('Are you sure you want to delete this comment? This action cannot be undone.')).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Summary

Adds a confirmation dialog before deleting comments to prevent accidental deletions.

Closes #153

## Changes

- Reused existing `ConfirmDialog` shared component in `CommentsSection.tsx`
- Added `deleteTarget` state to gate deletion behind a confirmation dialog
- Dialog uses destructive variant with title **"Delete comment"** and message **"Are you sure you want to delete this comment? This action cannot be undone."**

## Tests

6 new tests covering the confirmation flow:
- Dialog appears when delete button is clicked
- Cancel dismisses the dialog without deleting
- Confirm triggers the actual delete API call
- Dialog closes after successful deletion
- Delete button is hidden for other users (no dialog triggered)
- Error handling when deletion fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog for comment deletion with "Delete" and "Cancel" buttons to prevent accidental removals.
  * Shows a loading state while deletion is processed.
  * Displays error alerts when deletion fails.
  * Hides delete controls for comments not authored by the current user.

* **Tests**
  * Added tests covering the delete-confirmation flow, cancel behavior, success/failure handling, and permission visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->