### PR TITLE
feat: Include suggested_code as literal string in analysis result (fixes #154)

### DIFF
--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -60,6 +60,25 @@ function CopyableSectionHeader({ title, content, sectionId, copiedSection, onCop
   )
 }
 
+function CodeFixLiteralBlock({
+  title,
+  content,
+  className,
+}: {
+  title: string
+  content: string
+  className: string
+}) {
+  return (
+    <div className="mt-2">
+      <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">{title}</p>
+      <pre className={`overflow-x-auto max-h-96 overflow-y-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap ${className}`}>
+        {content}
+      </pre>
+    </div>
+  )
+}
+
 interface FailureCardProps {
   group: GroupedFailure
   jobId: string
@@ -305,7 +324,9 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   content={[
                     analysis.code_fix?.file ? `${analysis.code_fix.file}${analysis.code_fix.line ? `:${analysis.code_fix.line}` : ''}` : '',
                     analysis.code_fix?.change ?? '',
-                  ].filter(Boolean).join('\n')}
+                    analysis.code_fix?.original_code ? `Original Code:\n${analysis.code_fix.original_code}` : '',
+                    analysis.code_fix?.suggested_code ? `Suggested Code:\n${analysis.code_fix.suggested_code}` : '',
+                  ].filter(Boolean).join('\n\n')}
                   sectionId="suggested_fix"
                   copiedSection={copiedSection}
                   onCopy={copyToClipboard}
@@ -337,16 +358,10 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   )}
                   {analysis.code_fix.change && <p className="mt-1 text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.code_fix.change} repoUrls={repoUrls} /></p>}
                   {analysis.code_fix.original_code && (
-                    <div className="mt-2">
-                      <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">Original Code</p>
-                      <pre className="overflow-x-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap text-text-secondary">{analysis.code_fix.original_code}</pre>
-                    </div>
+                    <CodeFixLiteralBlock title="Original Code" content={analysis.code_fix.original_code} className="text-text-secondary" />
                   )}
                   {analysis.code_fix.suggested_code && (
-                    <div className="mt-2">
-                      <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">Suggested Code</p>
-                      <pre className="overflow-x-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap text-signal-green">{analysis.code_fix.suggested_code}</pre>
-                    </div>
+                    <CodeFixLiteralBlock title="Suggested Code" content={analysis.code_fix.suggested_code} className="text-signal-green" />
                   )}
                 </div>
               </div>

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -324,8 +324,8 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   content={[
                     analysis.code_fix?.file ? `${analysis.code_fix.file}${analysis.code_fix.line ? `:${analysis.code_fix.line}` : ''}` : '',
                     analysis.code_fix?.change ?? '',
-                    analysis.code_fix?.original_code ? `Original Code:\n${analysis.code_fix.original_code}` : '',
-                    analysis.code_fix?.suggested_code ? `Suggested Code:\n${analysis.code_fix.suggested_code}` : '',
+                    analysis.code_fix.original_code != null ? `Original Code:\n${analysis.code_fix.original_code}` : '',
+                    analysis.code_fix.suggested_code != null ? `Suggested Code:\n${analysis.code_fix.suggested_code}` : '',
                   ].filter(Boolean).join('\n\n')}
                   sectionId="suggested_fix"
                   copiedSection={copiedSection}
@@ -357,10 +357,10 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     </p>
                   )}
                   {analysis.code_fix.change && <p className="mt-1 text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.code_fix.change} repoUrls={repoUrls} /></p>}
-                  {analysis.code_fix.original_code && (
+                  {analysis.code_fix.original_code != null && (
                     <CodeFixLiteralBlock title="Original Code" content={analysis.code_fix.original_code} className="text-text-secondary" />
                   )}
-                  {analysis.code_fix.suggested_code && (
+                  {analysis.code_fix.suggested_code != null && (
                     <CodeFixLiteralBlock title="Suggested Code" content={analysis.code_fix.suggested_code} className="text-signal-green" />
                   )}
                 </div>

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -336,6 +336,18 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                     </p>
                   )}
                   {analysis.code_fix.change && <p className="mt-1 text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.code_fix.change} repoUrls={repoUrls} /></p>}
+                  {analysis.code_fix.original_code && (
+                    <div className="mt-2">
+                      <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">Original Code</p>
+                      <pre className="overflow-x-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap text-text-secondary">{analysis.code_fix.original_code}</pre>
+                    </div>
+                  )}
+                  {analysis.code_fix.suggested_code && (
+                    <div className="mt-2">
+                      <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">Suggested Code</p>
+                      <pre className="overflow-x-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap text-signal-green">{analysis.code_fix.suggested_code}</pre>
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,6 +70,8 @@ export interface CodeFix {
   file: string
   line: string
   change: string
+  original_code?: string | null
+  suggested_code?: string | null
 }
 
 export interface AnalysisDetail {

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -227,8 +227,8 @@ If CODE ISSUE:
     "file": "exact/file/path.py",
     "line": "line number",
     "change": "specific code change that fixes all affected tests",
-    "original_code": "the exact original code being replaced (raw code string, NO markdown formatting)",
-    "suggested_code": "the suggested replacement code (raw code string, NO markdown formatting)"
+    "original_code": "optional complete current contents of exact/file/path.py for diff/editor display (raw code string, NO markdown formatting)",
+    "suggested_code": "complete replacement contents of exact/file/path.py after applying the fix (raw code string, NO markdown formatting)"
   }
 }
 
@@ -349,6 +349,14 @@ def _parse_json_response(raw_text: str) -> AnalysisDetail:
     return _recover_from_details(fallback)
 
 
+def _decode_recovered_json_string(value: str) -> str:
+    """Decode a JSON string fragment captured by regex recovery."""
+    try:
+        return json.loads(f'"{value}"')
+    except json.JSONDecodeError:
+        return value.replace("\\n", "\n")
+
+
 def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
     """Attempt to recover structured fields from a fallback result.
 
@@ -412,12 +420,12 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
             line=line_match.group(1) if line_match else "",
             change=change_match.group(1).replace("\\n", "\n"),
             original_code=(
-                original_code_match.group(1).replace("\\n", "\n")
+                _decode_recovered_json_string(original_code_match.group(1))
                 if original_code_match
                 else None
             ),
             suggested_code=(
-                suggested_code_match.group(1).replace("\\n", "\n")
+                _decode_recovered_json_string(suggested_code_match.group(1))
                 if suggested_code_match
                 else None
             ),

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -226,7 +226,9 @@ If CODE ISSUE:
   "code_fix": {
     "file": "exact/file/path.py",
     "line": "line number",
-    "change": "specific code change that fixes all affected tests"
+    "change": "specific code change that fixes all affected tests",
+    "original_code": "the exact original code being replaced (raw code string, NO markdown formatting)",
+    "suggested_code": "the suggested replacement code (raw code string, NO markdown formatting)"
   }
 }
 
@@ -399,10 +401,26 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
     change_match = re.search(r'"change"\s*:\s*"((?:[^"\\]|\\.)*)"', details)
     if file_match and change_match:
         line_match = re.search(r'"line"\s*:\s*"([^"]*)"', details)
+        original_code_match = re.search(
+            r'"original_code"\s*:\s*"((?:[^"\\]|\\.)*)"', details, re.DOTALL
+        )
+        suggested_code_match = re.search(
+            r'"suggested_code"\s*:\s*"((?:[^"\\]|\\.)*)"', details, re.DOTALL
+        )
         code_fix = CodeFix(
             file=file_match.group(1),
             line=line_match.group(1) if line_match else "",
             change=change_match.group(1).replace("\\n", "\n"),
+            original_code=(
+                original_code_match.group(1).replace("\\n", "\n")
+                if original_code_match
+                else None
+            ),
+            suggested_code=(
+                suggested_code_match.group(1).replace("\\n", "\n")
+                if suggested_code_match
+                else None
+            ),
         )
 
     # Extract artifacts_evidence (top-level field)

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -268,6 +268,14 @@ class CodeFix(BaseModel):
     file: str = Field(default="", description="File path to fix")
     line: str = Field(default="", description="Line number")
     change: str = Field(default="", description="Specific code change")
+    original_code: str | None = Field(
+        default=None,
+        description="The original code being replaced (raw string, no markdown)",
+    )
+    suggested_code: str | None = Field(
+        default=None,
+        description="The suggested replacement code (raw string, no markdown)",
+    )
 
 
 class AnalysisDetail(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -270,11 +270,11 @@ class CodeFix(BaseModel):
     change: str = Field(default="", description="Specific code change")
     original_code: str | None = Field(
         default=None,
-        description="The original code being replaced (raw string, no markdown)",
+        description="Optional complete original file content for diff/editor display (raw string, no markdown)",
     )
     suggested_code: str | None = Field(
         default=None,
-        description="The suggested replacement code (raw string, no markdown)",
+        description="Complete replacement file content after applying the suggested fix (raw string, no markdown)",
     )
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -10,6 +10,8 @@ from jenkins_job_insight.analyzer import (
     _JSON_RESPONSE_SCHEMA,
     _build_resources_section,
     _call_ai_cli_with_retry,
+    _parse_json_response,
+    _recover_from_details,
     handle_jenkins_exception,
 )
 from jenkins_job_insight.config import Settings
@@ -2664,3 +2666,101 @@ class TestJsonResponseSchemaParagraphBreaks:
     ) -> None:
         """product_bug_report description field instructs AI to use paragraph breaks."""
         assert "paragraph breaks between sections" in _JSON_RESPONSE_SCHEMA
+
+
+class TestJsonResponseSchemaCodeFields:
+    """Tests that _JSON_RESPONSE_SCHEMA includes original_code and suggested_code."""
+
+    def test_schema_includes_original_code(self) -> None:
+        """Schema instructs AI to produce original_code field."""
+        assert "original_code" in _JSON_RESPONSE_SCHEMA
+
+    def test_schema_includes_suggested_code(self) -> None:
+        """Schema instructs AI to produce suggested_code field."""
+        assert "suggested_code" in _JSON_RESPONSE_SCHEMA
+
+    def test_schema_specifies_no_markdown(self) -> None:
+        """Schema instructs AI to produce raw code with no markdown."""
+        assert "NO markdown" in _JSON_RESPONSE_SCHEMA
+
+
+class TestParseJsonResponseCodeFields:
+    """Tests that _parse_json_response handles original_code and suggested_code."""
+
+    def test_parse_code_fix_with_code_fields(self) -> None:
+        """JSON with original_code and suggested_code parses correctly."""
+        import json
+
+        data = {
+            "classification": "CODE ISSUE",
+            "affected_tests": ["test_foo"],
+            "details": "Missing import",
+            "artifacts_evidence": "",
+            "code_fix": {
+                "file": "src/app.py",
+                "line": "10",
+                "change": "Add import os",
+                "original_code": "import sys",
+                "suggested_code": "import sys\nimport os",
+            },
+        }
+        result = _parse_json_response(json.dumps(data))
+        assert result.code_fix
+        assert result.code_fix.original_code == "import sys"
+        assert result.code_fix.suggested_code == "import sys\nimport os"
+
+    def test_parse_code_fix_without_code_fields(self) -> None:
+        """JSON without original_code/suggested_code still parses (backward compat)."""
+        import json
+
+        data = {
+            "classification": "CODE ISSUE",
+            "affected_tests": ["test_foo"],
+            "details": "Bug found",
+            "artifacts_evidence": "",
+            "code_fix": {
+                "file": "src/app.py",
+                "line": "10",
+                "change": "Fix it",
+            },
+        }
+        result = _parse_json_response(json.dumps(data))
+        assert result.code_fix
+        assert result.code_fix.original_code is None
+        assert result.code_fix.suggested_code is None
+
+
+class TestRecoverFromDetailsCodeFields:
+    """Tests that _recover_from_details extracts original_code and suggested_code."""
+
+    def test_recover_with_code_fields(self) -> None:
+        """Regex recovery extracts original_code and suggested_code."""
+        from jenkins_job_insight.models import AnalysisDetail
+
+        raw = (
+            '{"classification": "CODE ISSUE", "affected_tests": ["test_x"], '
+            '"details": "broken", "code_fix": {"file": "a.py", "line": "1", '
+            '"change": "fix", "original_code": "old code", "suggested_code": "new code"}}'
+        )
+        fallback = AnalysisDetail(details=raw)
+        result = _recover_from_details(fallback)
+        assert result.classification == "CODE ISSUE"
+        assert result.code_fix
+        assert result.code_fix.original_code == "old code"
+        assert result.code_fix.suggested_code == "new code"
+
+    def test_recover_without_code_fields(self) -> None:
+        """Regex recovery works without original_code/suggested_code."""
+        from jenkins_job_insight.models import AnalysisDetail
+
+        raw = (
+            '{"classification": "CODE ISSUE", "affected_tests": ["test_x"], '
+            '"details": "broken", "code_fix": {"file": "a.py", "line": "1", '
+            '"change": "fix"}}'
+        )
+        fallback = AnalysisDetail(details=raw)
+        result = _recover_from_details(fallback)
+        assert result.classification == "CODE ISSUE"
+        assert result.code_fix
+        assert result.code_fix.original_code is None
+        assert result.code_fix.suggested_code is None

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -2749,6 +2749,23 @@ class TestRecoverFromDetailsCodeFields:
         assert result.code_fix.original_code == "old code"
         assert result.code_fix.suggested_code == "new code"
 
+    def test_recover_with_escaped_code_characters(self) -> None:
+        """Regex recovery correctly decodes JSON-escaped characters in code fields."""
+        from jenkins_job_insight.models import AnalysisDetail
+
+        raw = (
+            '{"classification": "CODE ISSUE", "affected_tests": ["test_x"], '
+            '"details": "broken", "code_fix": {"file": "a.py", "line": "1", '
+            '"change": "fix", '
+            '"original_code": "print(\\"x\\")", '
+            '"suggested_code": "print(\\"y\\")"}}'
+        )
+        fallback = AnalysisDetail(details=raw)
+        result = _recover_from_details(fallback)
+        assert result.code_fix
+        assert result.code_fix.original_code == 'print("x")'
+        assert result.code_fix.suggested_code == 'print("y")'
+
     def test_recover_without_code_fields(self) -> None:
         """Regex recovery works without original_code/suggested_code."""
         from jenkins_job_insight.models import AnalysisDetail

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -159,12 +159,53 @@ class TestCodeFix:
         assert fix.file == ""
         assert fix.line == ""
         assert fix.change == ""
+        assert fix.original_code is None
+        assert fix.suggested_code is None
 
     def test_creation_with_values(self) -> None:
         """Test creating with all fields."""
         fix = CodeFix(file="src/main.py", line="42", change="Fix the bug")
         assert fix.file == "src/main.py"
         assert fix.line == "42"
+
+    def test_creation_with_code_fields(self) -> None:
+        """Test creating with original_code and suggested_code."""
+        fix = CodeFix(
+            file="src/main.py",
+            line="42",
+            change="Replace broken assertion",
+            original_code="assert x == 1",
+            suggested_code="assert x == 2",
+        )
+        assert fix.original_code == "assert x == 1"
+        assert fix.suggested_code == "assert x == 2"
+
+    def test_code_fields_optional_backward_compatible(self) -> None:
+        """Test that existing data without code fields still works."""
+        data = {"file": "test.py", "line": "10", "change": "fix it"}
+        fix = CodeFix(**data)
+        assert fix.original_code is None
+        assert fix.suggested_code is None
+
+    def test_serialization_includes_code_fields(self) -> None:
+        """Test that code fields appear in serialized output when set."""
+        fix = CodeFix(
+            file="a.py",
+            line="1",
+            change="fix",
+            original_code="old",
+            suggested_code="new",
+        )
+        data = fix.model_dump()
+        assert data["original_code"] == "old"
+        assert data["suggested_code"] == "new"
+
+    def test_serialization_with_none_code_fields(self) -> None:
+        """Test that None code fields are serialized as None."""
+        fix = CodeFix(file="a.py", line="1", change="fix")
+        data = fix.model_dump()
+        assert data["original_code"] is None
+        assert data["suggested_code"] is None
 
 
 class TestAnalysisDetail:


### PR DESCRIPTION
## Summary

Include `original_code` and `suggested_code` as literal strings in the analysis result, so the frontend can display them directly without parsing markdown.

Fixes #154

## Changes

- Added `original_code` and `suggested_code` optional fields to `CodeFix` model (backward compatible)
- Updated AI prompt schema to request raw code strings (no markdown formatting)
- Updated `_recover_from_details()` regex fallback to extract new fields
- Frontend displays original/suggested code in `<pre>` blocks when available
- TypeScript types updated to mirror backend model
- 12 new tests (5 model + 7 analyzer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure analysis “Suggested Fix” panel now shows optional "Original Code" and "Suggested Code" sections in labeled, scrollable monospace blocks when available.
  * Copy-to-clipboard for suggested fixes now includes file/line, change, original code, and suggested replacement for easier applying of fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->