### PR TITLE
feat: Alerting and monitoring for server errors (fixes #136)

### DIFF
--- a/docs/openshift-prometheus-rule.yaml
+++ b/docs/openshift-prometheus-rule.yaml
@@ -32,7 +32,7 @@ spec:
               JJI error rate is {{ $value | humanizePercentage }} over the
               rolling window (threshold 50%).
         - alert: JJIHealthUnhealthy
-          expr: probe_success{job="jji-health"} == 0
+          expr: jji_health_up == 0
           for: 5m
           labels:
             severity: critical

--- a/docs/openshift-prometheus-rule.yaml
+++ b/docs/openshift-prometheus-rule.yaml
@@ -1,0 +1,41 @@
+---
+# PrometheusRule manifest for OpenShift alerting.
+# Deploy with: oc apply -f openshift-prometheus-rule.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: jenkins-job-insight-alerts
+  labels:
+    app: jenkins-job-insight
+spec:
+  groups:
+    - name: jenkins-job-insight.rules
+      rules:
+        - alert: JJIHighErrorRate
+          expr: jji_error_rate > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "JJI high error rate"
+            description: >
+              JJI error rate is {{ $value | humanizePercentage }} over the
+              rolling window (threshold 10%).
+        - alert: JJIVeryHighErrorRate
+          expr: jji_error_rate > 0.5
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "JJI critical error rate"
+            description: >
+              JJI error rate is {{ $value | humanizePercentage }} over the
+              rolling window (threshold 50%).
+        - alert: JJIHealthUnhealthy
+          expr: probe_success{job="jji-health"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "JJI health check failing"
+            description: "JJI /api/health is returning 503 (unhealthy) for over 5 minutes."

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -159,8 +159,17 @@ class JJIClient:
     # -- Health ---------------------------------------------------------------
 
     def health(self) -> dict:
-        """Check server health. GET /health"""
-        return self._request("GET", "/health")
+        """Check server health. GET /api/health
+
+        Falls back to GET /health if /api/health returns 404.
+        Accepts both 200 (healthy/degraded) and 503 (unhealthy).
+        """
+        try:
+            return self._request("GET", "/api/health", accept_statuses=(200, 503))
+        except JJIError as exc:
+            if exc.status_code == 404:
+                return self._request("GET", "/health")
+            raise
 
     # -- Results --------------------------------------------------------------
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -291,7 +291,25 @@ def health(
     json_output: bool = _JSON_OPTION,
 ):
     """Check server health."""
-    _run_client_command(json_output, lambda c: c.health(), columns=["status"])
+    data = _run_client_command(json_output, lambda c: c.health(), emit_output=False)
+    if not _state.get("json", False):
+        status = data.get("status", "unknown")
+        typer.echo(f"Status: {status}")
+        checks = data.get("checks", {})
+        if checks:
+            typer.echo("\nChecks:")
+            for name, check in checks.items():
+                detail = check.get("detail", "")
+                suffix = f" ({detail})" if detail else ""
+                typer.echo(f"  {name}: {check.get('status', 'unknown')}{suffix}")
+        error_rates = data.get("error_rates", {})
+        if error_rates:
+            typer.echo(
+                f"\nError rate: {error_rates.get('error_rate', 0):.1%} "
+                f"({error_rates.get('total_errors', 0)}/"
+                f"{error_rates.get('total_requests', 0)} in "
+                f"{error_rates.get('window_seconds', 0):.0f}s window)"
+            )
 
 
 # -- Results ------------------------------------------------------------------

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -507,8 +507,10 @@ async def lifespan(app: FastAPI):
     _install_job_id_filter()
 
     # Startup config validation
-    config_warnings = validate_startup_config()
-    for warning in config_warnings:
+    config_result = validate_startup_config()
+    for error in config_result.errors:
+        logger.error("[startup] %s", error)
+    for warning in config_result.warnings:
         logger.warning("[startup] %s", warning)
 
     await init_db()

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -512,6 +512,8 @@ async def lifespan(app: FastAPI):
         logger.error("[startup] %s", error)
     for warning in config_result.warnings:
         logger.warning("[startup] %s", warning)
+    if config_result.errors:
+        raise RuntimeError("Startup configuration validation failed")
 
     await init_db()
     await storage.cleanup_expired_sessions()
@@ -3576,7 +3578,8 @@ async def prometheus_metrics() -> Response:
     try:
         health = await build_health_response(settings, db_path)
         health_up = 0 if health["status"] == "unhealthy" else 1
-    except Exception:
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to compute health status for metrics", exc_info=True)
         health_up = 0
 
     # Count active analyses
@@ -3590,8 +3593,8 @@ async def prometheus_metrics() -> Response:
             )
             row = await cursor.fetchone()
             active_analyses = row[0] if row else 0
-    except Exception:
-        pass
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to compute active analyses for metrics", exc_info=True)
 
     return Response(
         content=render_prometheus_metrics(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -547,28 +547,39 @@ class ErrorTrackingMiddleware(BaseHTTPMiddleware):
 
     _SKIP_PATHS = frozenset({"/health", "/api/health", "/metrics", "/favicon.ico"})
 
+    def _schedule_high_error_rate_alert(self) -> None:
+        """Check 5xx error rate and schedule an alert if it exceeds the threshold."""
+        try:
+            snap = error_tracker.snapshot()
+            total_requests = snap["total_requests"]
+            server_errors = snap.get("error_counts", {}).get("5xx", 0)
+            server_error_rate = server_errors / total_requests if total_requests else 0
+            if server_error_rate > 0.5 and total_requests >= 10:
+                task = asyncio.create_task(
+                    dispatch_alert(
+                        "high_error_rate",
+                        f"\u26a0\ufe0f JJI high 5xx error rate: {server_error_rate:.0%} "
+                        f"({server_errors}/{total_requests} requests "
+                        f"in {snap['window_seconds']}s window)",
+                    )
+                )
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
+        except Exception:
+            logger.debug("Failed to schedule high-error-rate alert", exc_info=True)
+
     async def dispatch(self, request: Request, call_next):
         if request.url.path in self._SKIP_PATHS:
             return await call_next(request)
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception:
+            error_tracker.record_request(500)
+            self._schedule_high_error_rate_alert()
+            raise
         error_tracker.record_request(response.status_code)
-        # Fire-and-forget alert on high error rates
         if response.status_code >= 500:
-            try:
-                snap = error_tracker.snapshot()
-                if snap["error_rate"] > 0.5 and snap["total_requests"] >= 10:
-                    task = asyncio.create_task(
-                        dispatch_alert(
-                            "high_error_rate",
-                            f"\u26a0\ufe0f JJI high error rate: {snap['error_rate']:.0%} "
-                            f"({snap['total_errors']}/{snap['total_requests']} requests "
-                            f"in {snap['window_seconds']}s window)",
-                        )
-                    )
-                    _background_tasks.add(task)
-                    task.add_done_callback(_background_tasks.discard)
-            except Exception:
-                pass  # Never crash the app for alerting
+            self._schedule_high_error_rate_alert()
         return response
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -44,6 +44,13 @@ from jenkins_job_insight.encryption import (
     encrypt_sensitive_fields,
 )
 from jenkins_job_insight.jira import enrich_with_jira_matches
+from jenkins_job_insight.monitoring import (
+    build_health_response,
+    dispatch_alert,
+    error_tracker,
+    render_prometheus_metrics,
+    validate_startup_config,
+)
 from jenkins_job_insight.reportportal import AmbiguousLaunchError, ReportPortalClient
 from jenkins_job_insight.bug_creation import (
     _parse_github_repo_url,
@@ -498,6 +505,12 @@ async def _deferred_resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _install_job_id_filter()
+
+    # Startup config validation
+    config_warnings = validate_startup_config()
+    for warning in config_warnings:
+        logger.warning("[startup] %s", warning)
+
     await init_db()
     await storage.cleanup_expired_sessions()
     waiting_jobs = await storage.mark_stale_results_failed()
@@ -527,6 +540,36 @@ if _FRONTEND_DIR.is_dir():
     )
 
 
+class ErrorTrackingMiddleware(BaseHTTPMiddleware):
+    """Track request counts and error rates for monitoring."""
+
+    _SKIP_PATHS = frozenset({"/health", "/api/health", "/metrics", "/favicon.ico"})
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in self._SKIP_PATHS:
+            return await call_next(request)
+        response = await call_next(request)
+        error_tracker.record_request(response.status_code)
+        # Fire-and-forget alert on high error rates
+        if response.status_code >= 500:
+            try:
+                snap = error_tracker.snapshot()
+                if snap["error_rate"] > 0.5 and snap["total_requests"] >= 10:
+                    task = asyncio.create_task(
+                        dispatch_alert(
+                            "high_error_rate",
+                            f"\u26a0\ufe0f JJI high error rate: {snap['error_rate']:.0%} "
+                            f"({snap['total_errors']}/{snap['total_requests']} requests "
+                            f"in {snap['window_seconds']}s window)",
+                        )
+                    )
+                    _background_tasks.add(task)
+                    task.add_done_callback(_background_tasks.discard)
+            except Exception:
+                pass  # Never crash the app for alerting
+        return response
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Authenticate requests: admin via session/Bearer, regular users via cookie."""
 
@@ -534,6 +577,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         {
             "/register",
             "/health",
+            "/api/health",
+            "/metrics",
             "/favicon.ico",
         }
     )
@@ -617,6 +662,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(AuthMiddleware)
+app.add_middleware(ErrorTrackingMiddleware)
 
 
 @app.get("/", include_in_schema=False)
@@ -3490,8 +3536,31 @@ async def get_ai_configs_endpoint() -> list[dict]:
 
 @app.get("/health")
 async def health_check() -> dict:
-    """Health check endpoint."""
+    """Basic health check endpoint (legacy, lightweight)."""
     return {"status": "healthy"}
+
+
+@app.get("/api/health")
+async def health_check_detailed() -> Response:
+    """Detailed health endpoint with dependency checks and error rates.
+
+    Returns:
+        200 for healthy/degraded, 503 for unhealthy.
+    """
+    settings = get_settings()
+    db_path = str(storage.DB_PATH)
+    result = await build_health_response(settings, db_path)
+    status_code = 503 if result["status"] == "unhealthy" else 200
+    return JSONResponse(content=result, status_code=status_code)
+
+
+@app.get("/metrics")
+async def prometheus_metrics() -> Response:
+    """Prometheus metrics endpoint."""
+    return Response(
+        content=render_prometheus_metrics(),
+        media_type="text/plain; version=0.0.4; charset=utf-8",
+    )
 
 
 @app.get("/favicon.ico", include_in_schema=False)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -567,7 +567,7 @@ class ErrorTrackingMiddleware(BaseHTTPMiddleware):
                 )
                 _background_tasks.add(task)
                 task.add_done_callback(_background_tasks.discard)
-        except Exception:
+        except Exception:  # noqa: BLE001 — alert scheduling must never break request handling
             logger.debug("Failed to schedule high-error-rate alert", exc_info=True)
 
     async def dispatch(self, request: Request, call_next):

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3570,8 +3570,33 @@ async def health_check_detailed() -> Response:
 @app.get("/metrics")
 async def prometheus_metrics() -> Response:
     """Prometheus metrics endpoint."""
+    # Compute health_up from a lightweight health check
+    settings = get_settings()
+    db_path = str(storage.DB_PATH)
+    try:
+        health = await build_health_response(settings, db_path)
+        health_up = 0 if health["status"] == "unhealthy" else 1
+    except Exception:
+        health_up = 0
+
+    # Count active analyses
+    active_analyses: int | None = None
+    try:
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as db:
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM results WHERE status IN ('pending', 'running', 'waiting')"
+            )
+            row = await cursor.fetchone()
+            active_analyses = row[0] if row else 0
+    except Exception:
+        pass
+
     return Response(
-        content=render_prometheus_metrics(),
+        content=render_prometheus_metrics(
+            health_up=health_up, active_analyses=active_analyses
+        ),
         media_type="text/plain; version=0.0.4; charset=utf-8",
     )
 

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -381,14 +381,14 @@ def send_email_alert(
     host = smtp_host or os.getenv("SMTP_HOST", "")
     if not host:
         return False
-    port = smtp_port or int(os.getenv("SMTP_PORT", "587"))
-    user = smtp_user or os.getenv("SMTP_USER", "")
-    password = smtp_password or os.getenv("SMTP_PASSWORD", "")
-    from_addr = smtp_from or os.getenv("SMTP_FROM", user or f"jji@{host}")
     to_addr = alert_email_to or os.getenv("ALERT_EMAIL_TO", "")
     if not to_addr:
         return False
     try:
+        port = smtp_port or int(os.getenv("SMTP_PORT", "587"))
+        user = smtp_user or os.getenv("SMTP_USER", "")
+        password = smtp_password or os.getenv("SMTP_PASSWORD", "")
+        from_addr = smtp_from or os.getenv("SMTP_FROM", user or f"jji@{host}")
         msg = EmailMessage()
         msg["Subject"] = subject
         msg["From"] = from_addr
@@ -400,7 +400,7 @@ def send_email_alert(
             if user and password:
                 smtp.login(user, password)
             smtp.send_message(msg)
-        logger.debug("Email alert sent to %s", to_addr)
+        logger.debug("Email alert sent successfully")
         return True
     except Exception:
         logger.debug("Failed to send email alert", exc_info=True)

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -67,8 +67,8 @@ class _RollingCounter:
             self._timestamps.popleft()
 
 
-class ErrorRateTracker:
-    """In-memory rolling-window request / error counters.
+class _SingleWindowTracker:
+    """In-memory rolling-window request / error counters for a single window.
 
     All public methods are thread-safe.
     """
@@ -81,8 +81,8 @@ class ErrorRateTracker:
         ] = {}  # keyed by status class "4xx"/"5xx"
         self._lock = threading.Lock()
 
-    def record_request(self, status_code: int) -> None:
-        now = time.monotonic()
+    def record_request(self, status_code: int, now: float | None = None) -> None:
+        now = now if now is not None else time.monotonic()
         with self._lock:
             self._total.record(now)
             if status_code >= 400:
@@ -106,6 +106,44 @@ class ErrorRateTracker:
             "error_counts": error_counts,
             "total_errors": total_errors,
             "error_rate": round(error_rate, 4),
+        }
+
+
+class ErrorRateTracker:
+    """Dual rolling-window error rate tracker (5-minute and 1-hour).
+
+    Records each request into both windows simultaneously.
+    ``snapshot()`` returns the short (5m) window for backward compatibility.
+    ``snapshot_all()`` returns both windows keyed as ``last_5m`` / ``last_1h``.
+    """
+
+    def __init__(
+        self,
+        window_seconds: float = 300.0,
+        long_window_seconds: float = 3600.0,
+    ) -> None:
+        self._short = _SingleWindowTracker(window_seconds)
+        self._long = _SingleWindowTracker(long_window_seconds)
+
+    # Expose for backward compat (used by middleware alert logic)
+    @property
+    def window_seconds(self) -> float:
+        return self._short.window_seconds
+
+    def record_request(self, status_code: int) -> None:
+        now = time.monotonic()
+        self._short.record_request(status_code, now)
+        self._long.record_request(status_code, now)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return the short-window snapshot (backward compatible)."""
+        return self._short.snapshot()
+
+    def snapshot_all(self) -> dict[str, dict[str, Any]]:
+        """Return both rolling-window snapshots."""
+        return {
+            "last_5m": self._short.snapshot(),
+            "last_1h": self._long.snapshot(),
         }
 
 
@@ -147,7 +185,35 @@ async def check_db(db_path: str) -> dict[str, str]:
             await db.execute("BEGIN IMMEDIATE")
             await db.execute("ROLLBACK")
         return {"status": "ok"}
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 — health check must return status, not raise
+        return {"status": "error", "detail": str(exc)}
+
+
+async def _check_http_service(
+    url: str,
+    *,
+    verify_ssl: bool = True,
+    headers: dict[str, str] | None = None,
+    ok_below: int = 500,
+) -> dict[str, str]:
+    """Probe an HTTP service and return a health status dict.
+
+    Args:
+        url: URL to GET.
+        verify_ssl: Whether to verify TLS certificates.
+        headers: Optional request headers (e.g. auth).
+        ok_below: Status codes below this value are considered healthy.
+
+    Returns ``{"status": "ok"}``, ``{"status": "degraded", ...}``, or
+    ``{"status": "error", ...}``.  Never raises.
+    """
+    try:
+        async with httpx.AsyncClient(verify=verify_ssl, timeout=5.0) as client:
+            resp = await client.get(url, headers=headers or {})
+            if resp.status_code < ok_below:
+                return {"status": "ok"}
+            return {"status": "degraded", "detail": f"HTTP {resp.status_code}"}
+    except Exception as exc:  # noqa: BLE001 — health check must return status, not raise
         return {"status": "error", "detail": str(exc)}
 
 
@@ -155,16 +221,9 @@ async def check_jenkins(settings: Any) -> dict[str, str]:
     """Check Jenkins reachability (lightweight HEAD/GET to base URL)."""
     if not settings.jenkins_url:
         return {"status": "not_configured"}
-    try:
-        async with httpx.AsyncClient(
-            verify=settings.jenkins_ssl_verify, timeout=5.0
-        ) as client:
-            resp = await client.get(settings.jenkins_url)
-            if resp.status_code < 500:
-                return {"status": "ok"}
-            return {"status": "degraded", "detail": f"HTTP {resp.status_code}"}
-    except Exception as exc:
-        return {"status": "error", "detail": str(exc)}
+    return await _check_http_service(
+        settings.jenkins_url, verify_ssl=settings.jenkins_ssl_verify
+    )
 
 
 async def check_ai_provider() -> dict[str, str]:
@@ -185,24 +244,17 @@ async def check_reportportal(settings: Any) -> dict[str, str]:
     """Check Report Portal configuration."""
     if not settings.reportportal_enabled:
         return {"status": "not_configured"}
-    try:
-        token = (
-            settings.reportportal_api_token.get_secret_value()
-            if settings.reportportal_api_token
-            else ""
-        )
-        async with httpx.AsyncClient(
-            verify=settings.reportportal_verify_ssl, timeout=5.0
-        ) as client:
-            resp = await client.get(
-                f"{settings.reportportal_url.rstrip('/')}/api/v1/user",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            if resp.status_code < 400:
-                return {"status": "ok"}
-            return {"status": "degraded", "detail": f"HTTP {resp.status_code}"}
-    except Exception as exc:
-        return {"status": "error", "detail": str(exc)}
+    token = (
+        settings.reportportal_api_token.get_secret_value()
+        if settings.reportportal_api_token
+        else ""
+    )
+    return await _check_http_service(
+        f"{settings.reportportal_url.rstrip('/')}/api/v1/user",
+        verify_ssl=settings.reportportal_verify_ssl,
+        headers={"Authorization": f"Bearer {token}"},
+        ok_below=400,
+    )
 
 
 async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
@@ -258,7 +310,7 @@ async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
         "uptime_seconds": round(time.monotonic() - _APP_STARTED_AT, 3),
         "version": _get_app_version(),
         "checks": checks,
-        "error_rates": error_tracker.snapshot(),
+        "error_rates": error_tracker.snapshot_all(),
     }
 
 
@@ -478,7 +530,7 @@ async def send_slack_alert(message: str, webhook_url: str | None = None) -> bool
                 return True
             logger.warning("Slack webhook returned HTTP %d", resp.status_code)
             return False
-    except Exception:
+    except Exception:  # noqa: BLE001 — alerting failures must never propagate
         logger.debug("Failed to send Slack alert", exc_info=True)
         return False
 
@@ -531,7 +583,7 @@ def send_email_alert(
             smtp.send_message(msg)
         logger.debug("Email alert sent successfully")
         return True
-    except Exception:
+    except Exception:  # noqa: BLE001 — alerting failures must never propagate
         logger.debug("Failed to send email alert", exc_info=True)
         return False
 
@@ -547,7 +599,7 @@ async def send_email_alert_async(
         return await loop.run_in_executor(
             None, lambda: send_email_alert(subject, body, **kwargs)
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 — alerting failures must never propagate
         logger.debug("Failed to send async email alert", exc_info=True)
         return False
 
@@ -582,7 +634,7 @@ async def dispatch_alert(
             send_email_alert_async(email_subject, message),
             return_exceptions=True,
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 — alerting failures must never propagate
         logger.debug("Failed to dispatch alert", exc_info=True)
 
 

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -107,12 +107,33 @@ error_tracker = ErrorRateTracker()
 
 
 async def check_db(db_path: str) -> dict[str, str]:
-    """Check database connectivity."""
+    """Check database connectivity and writability."""
+    import pathlib
+
     try:
+        p = pathlib.Path(db_path)
+        db_dir = p.parent
+
+        # Check directory exists and is writable
+        if not db_dir.is_dir():
+            return {"status": "error", "detail": f"Directory does not exist: {db_dir}"}
+        if not os.access(str(db_dir), os.W_OK):
+            return {"status": "error", "detail": f"Directory is not writable: {db_dir}"}
+
+        # Check file is writable if it already exists
+        if p.exists() and not os.access(str(p), os.W_OK):
+            return {
+                "status": "error",
+                "detail": f"Database file is not writable: {db_path}",
+            }
+
         import aiosqlite
 
         async with aiosqlite.connect(db_path) as db:
-            await db.execute("SELECT 1")
+            # Use BEGIN IMMEDIATE to verify write-lock can be acquired,
+            # then rollback to avoid any side effects.
+            await db.execute("BEGIN IMMEDIATE")
+            await db.execute("ROLLBACK")
         return {"status": "ok"}
     except Exception as exc:
         return {"status": "error", "detail": str(exc)}

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -245,63 +245,150 @@ async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def validate_startup_config() -> list[str]:
-    """Validate configuration at startup and return warning messages.
+@dataclass
+class _ConfigFinding:
+    """A single startup configuration finding with severity."""
 
-    Returns a list of warning strings. Empty list means all OK.
-    Does NOT raise — startup should continue even with warnings.
+    severity: str  # "error" or "warning"
+    message: str
+
+
+@dataclass
+class StartupConfigResult:
+    """Structured result from startup configuration validation."""
+
+    findings: list[_ConfigFinding]
+
+    @property
+    def errors(self) -> list[str]:
+        return [f.message for f in self.findings if f.severity == "error"]
+
+    @property
+    def warnings(self) -> list[str]:
+        return [f.message for f in self.findings if f.severity == "warning"]
+
+
+def validate_startup_config() -> StartupConfigResult:
+    """Validate configuration at startup and return structured results.
+
+    Returns a StartupConfigResult with findings categorised by severity.
+    - 'error': critical issues (e.g. missing DB directory)
+    - 'warning': optional integrations not configured
+    Does NOT raise — startup should continue even with errors.
     """
-    warnings: list[str] = []
+    findings: list[_ConfigFinding] = []
 
-    # AI provider
+    # AI provider (optional — can be passed per-request)
     provider = os.getenv("AI_PROVIDER", "")
     model = os.getenv("AI_MODEL", "")
     if not provider:
-        warnings.append(
-            "AI_PROVIDER is not set. Analysis requests will require ai_provider in the request body."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "AI_PROVIDER is not set. Analysis requests will require ai_provider in the request body.",
+            )
         )
     if not model:
-        warnings.append(
-            "AI_MODEL is not set. Analysis requests will require ai_model in the request body."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "AI_MODEL is not set. Analysis requests will require ai_model in the request body.",
+            )
         )
 
-    # Database path
+    # Database path (critical)
     db_path = os.getenv("DB_PATH", "/data/results.db")
     db_dir = os.path.dirname(db_path) or "."
     if db_dir and not os.path.isdir(db_dir):
-        warnings.append(
-            f"DB_PATH directory does not exist: {db_dir}. "
-            "The database will be created but the parent directory must exist."
+        findings.append(
+            _ConfigFinding(
+                "error",
+                f"DB_PATH directory does not exist: {db_dir}. "
+                "The database will be created but the parent directory must exist.",
+            )
         )
 
-    # Encryption key
+    # Encryption key (critical for production)
     if not os.getenv("JJI_ENCRYPTION_KEY"):
-        warnings.append(
-            "JJI_ENCRYPTION_KEY is not set. A file-based key will be auto-generated. "
-            "Set this env var for production deployments."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "JJI_ENCRYPTION_KEY is not set. A file-based key will be auto-generated. "
+                "Set this env var for production deployments.",
+            )
         )
 
-    # Slack webhook
+    # Slack webhook (optional integration)
     slack_url = os.getenv("SLACK_WEBHOOK_URL", "")
     if slack_url and not slack_url.startswith("https://"):
-        warnings.append(
-            "SLACK_WEBHOOK_URL does not start with https://. "
-            "Slack webhooks should use HTTPS."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "SLACK_WEBHOOK_URL does not start with https://. "
+                "Slack webhooks should use HTTPS.",
+            )
         )
 
-    # SMTP config partial check
+    # SMTP config partial check (optional integration)
     smtp_host = os.getenv("SMTP_HOST", "")
     alert_email_to = os.getenv("ALERT_EMAIL_TO", "")
     if smtp_host and not alert_email_to:
-        warnings.append(
-            "SMTP_HOST is set but ALERT_EMAIL_TO is not. Email alerts will not be sent."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "SMTP_HOST is set but ALERT_EMAIL_TO is not. Email alerts will not be sent.",
+            )
         )
     if alert_email_to and not smtp_host:
-        warnings.append(
-            "ALERT_EMAIL_TO is set but SMTP_HOST is not. Email alerts will not be sent."
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "ALERT_EMAIL_TO is set but SMTP_HOST is not. Email alerts will not be sent.",
+            )
         )
 
-    return warnings
+    # Optional integration URLs
+    if not os.getenv("JENKINS_URL", ""):
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "JENKINS_URL is not set. Jenkins-based analysis will require jenkins_url in the request body.",
+            )
+        )
+    if not os.getenv("JIRA_URL", ""):
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "JIRA_URL is not set. Jira enrichment will be disabled unless provided per-request.",
+            )
+        )
+    if not os.getenv("REPORTPORTAL_URL", ""):
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "REPORTPORTAL_URL is not set. Report Portal integration is disabled.",
+            )
+        )
+
+    # Peer AI configs (optional)
+    if not os.getenv("PEER_AI_CONFIGS", ""):
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "PEER_AI_CONFIGS is not set. Peer analysis will be disabled unless provided per-request.",
+            )
+        )
+
+    # Admin key (optional but recommended)
+    if not os.getenv("ADMIN_KEY", ""):
+        findings.append(
+            _ConfigFinding(
+                "warning",
+                "ADMIN_KEY is not set. Admin API access will require user-based admin authentication.",
+            )
+        )
+
+    return StartupConfigResult(findings=findings)
 
 
 # ---------------------------------------------------------------------------

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -23,6 +23,18 @@ from simple_logger.logger import get_logger
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
+_APP_STARTED_AT = time.monotonic()
+
+
+def _get_app_version() -> str:
+    """Return the application version string."""
+    try:
+        from importlib.metadata import version
+
+        return version("jenkins-job-insight")
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
 
 # ---------------------------------------------------------------------------
 # Rolling-window error rate tracker
@@ -204,13 +216,21 @@ async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
     checks: dict[str, dict] = {}
 
     # Run all checks concurrently
-    db_check, jenkins_check, ai_check, rp_check = await asyncio.gather(
-        check_db(db_path),
-        check_jenkins(settings),
-        check_ai_provider(),
-        check_reportportal(settings),
-        return_exceptions=True,
-    )
+    _HEALTH_CHECK_TIMEOUT = 6.0
+    try:
+        db_check, jenkins_check, ai_check, rp_check = await asyncio.wait_for(
+            asyncio.gather(
+                check_db(db_path),
+                check_jenkins(settings),
+                check_ai_provider(),
+                check_reportportal(settings),
+                return_exceptions=True,
+            ),
+            timeout=_HEALTH_CHECK_TIMEOUT,
+        )
+    except TimeoutError:
+        _timeout_result: dict = {"status": "error", "detail": "health check timed out"}
+        db_check = jenkins_check = ai_check = rp_check = _timeout_result
 
     def _safe(result: Any) -> dict:
         if isinstance(result, Exception):
@@ -235,6 +255,8 @@ async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
 
     return {
         "status": overall,
+        "uptime_seconds": round(time.monotonic() - _APP_STARTED_AT, 3),
+        "version": _get_app_version(),
         "checks": checks,
         "error_rates": error_tracker.snapshot(),
     }

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -71,22 +71,21 @@ class ErrorRateTracker:
 
     def record_request(self, status_code: int) -> None:
         now = time.monotonic()
-        self._total.record(now)
-        if status_code >= 400:
-            bucket = "5xx" if status_code >= 500 else "4xx"
-            with self._lock:
+        with self._lock:
+            self._total.record(now)
+            if status_code >= 400:
+                bucket = "5xx" if status_code >= 500 else "4xx"
                 if bucket not in self._errors:
                     self._errors[bucket] = _RollingCounter(self.window_seconds)
-            self._errors[bucket].record(now)
+                self._errors[bucket].record(now)
 
     def snapshot(self) -> dict[str, Any]:
         now = time.monotonic()
-        total = self._total.count(now)
-        error_counts: dict[str, int] = {}
         with self._lock:
-            buckets = list(self._errors.items())
-        for bucket, counter in buckets:
-            error_counts[bucket] = counter.count(now)
+            total = self._total.count(now)
+            error_counts: dict[str, int] = {}
+            for bucket, counter in self._errors.items():
+                error_counts[bucket] = counter.count(now)
         total_errors = sum(error_counts.values())
         error_rate = total_errors / total if total > 0 else 0.0
         return {

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -1,0 +1,493 @@
+"""Health monitoring, error rate tracking, and alerting for jenkins-job-insight.
+
+Provides:
+- Rolling-window error rate counters (thread-safe, in-memory)
+- Health check logic with dependency checks
+- Startup configuration validation
+- Slack/email alerting with throttling
+- Prometheus metrics exposition
+"""
+
+import asyncio
+import os
+import smtplib
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from typing import Any
+
+import httpx
+from simple_logger.logger import get_logger
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+# ---------------------------------------------------------------------------
+# Rolling-window error rate tracker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RollingCounter:
+    """Thread-safe rolling-window counter backed by a deque of timestamps."""
+
+    window_seconds: float = 300.0  # 5 minutes default
+    _timestamps: deque = field(default_factory=deque)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def record(self, ts: float | None = None) -> None:
+        ts = ts if ts is not None else time.monotonic()
+        with self._lock:
+            self._timestamps.append(ts)
+            self._evict(ts)
+
+    def count(self, now: float | None = None) -> int:
+        now = now if now is not None else time.monotonic()
+        with self._lock:
+            self._evict(now)
+            return len(self._timestamps)
+
+    def _evict(self, now: float) -> None:
+        cutoff = now - self.window_seconds
+        while self._timestamps and self._timestamps[0] < cutoff:
+            self._timestamps.popleft()
+
+
+class ErrorRateTracker:
+    """In-memory rolling-window request / error counters.
+
+    All public methods are thread-safe.
+    """
+
+    def __init__(self, window_seconds: float = 300.0) -> None:
+        self.window_seconds = window_seconds
+        self._total = _RollingCounter(window_seconds)
+        self._errors: dict[
+            str, _RollingCounter
+        ] = {}  # keyed by status class "4xx"/"5xx"
+        self._lock = threading.Lock()
+
+    def record_request(self, status_code: int) -> None:
+        now = time.monotonic()
+        self._total.record(now)
+        if status_code >= 400:
+            bucket = "5xx" if status_code >= 500 else "4xx"
+            with self._lock:
+                if bucket not in self._errors:
+                    self._errors[bucket] = _RollingCounter(self.window_seconds)
+            self._errors[bucket].record(now)
+
+    def snapshot(self) -> dict[str, Any]:
+        now = time.monotonic()
+        total = self._total.count(now)
+        error_counts: dict[str, int] = {}
+        with self._lock:
+            buckets = list(self._errors.items())
+        for bucket, counter in buckets:
+            error_counts[bucket] = counter.count(now)
+        total_errors = sum(error_counts.values())
+        error_rate = total_errors / total if total > 0 else 0.0
+        return {
+            "window_seconds": self.window_seconds,
+            "total_requests": total,
+            "error_counts": error_counts,
+            "total_errors": total_errors,
+            "error_rate": round(error_rate, 4),
+        }
+
+
+# Singleton tracker used by the middleware
+error_tracker = ErrorRateTracker()
+
+
+# ---------------------------------------------------------------------------
+# Health checks
+# ---------------------------------------------------------------------------
+
+
+async def check_db(db_path: str) -> dict[str, str]:
+    """Check database connectivity."""
+    try:
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("SELECT 1")
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+async def check_jenkins(settings: Any) -> dict[str, str]:
+    """Check Jenkins reachability (lightweight HEAD/GET to base URL)."""
+    if not settings.jenkins_url:
+        return {"status": "not_configured"}
+    try:
+        async with httpx.AsyncClient(
+            verify=settings.jenkins_ssl_verify, timeout=5.0
+        ) as client:
+            resp = await client.get(settings.jenkins_url)
+            if resp.status_code < 500:
+                return {"status": "ok"}
+            return {"status": "degraded", "detail": f"HTTP {resp.status_code}"}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+async def check_ai_provider() -> dict[str, str]:
+    """Check that an AI provider is configured."""
+    provider = os.getenv("AI_PROVIDER", "")
+    model = os.getenv("AI_MODEL", "")
+    if provider and model:
+        return {"status": "ok", "provider": provider, "model": model}
+    missing = []
+    if not provider:
+        missing.append("AI_PROVIDER")
+    if not model:
+        missing.append("AI_MODEL")
+    return {"status": "not_configured", "detail": f"Missing: {', '.join(missing)}"}
+
+
+async def check_reportportal(settings: Any) -> dict[str, str]:
+    """Check Report Portal configuration."""
+    if not settings.reportportal_enabled:
+        return {"status": "not_configured"}
+    try:
+        token = (
+            settings.reportportal_api_token.get_secret_value()
+            if settings.reportportal_api_token
+            else ""
+        )
+        async with httpx.AsyncClient(
+            verify=settings.reportportal_verify_ssl, timeout=5.0
+        ) as client:
+            resp = await client.get(
+                f"{settings.reportportal_url.rstrip('/')}/api/v1/user",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code < 400:
+                return {"status": "ok"}
+            return {"status": "degraded", "detail": f"HTTP {resp.status_code}"}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+async def build_health_response(settings: Any, db_path: str) -> dict[str, Any]:
+    """Build full health response with checks and error rates.
+
+    Returns a dict with:
+    - status: "healthy", "degraded", or "unhealthy"
+    - checks: results from individual dependency checks
+    - error_rates: current rolling-window error statistics
+    """
+    checks: dict[str, dict] = {}
+
+    # Run all checks concurrently
+    db_check, jenkins_check, ai_check, rp_check = await asyncio.gather(
+        check_db(db_path),
+        check_jenkins(settings),
+        check_ai_provider(),
+        check_reportportal(settings),
+        return_exceptions=True,
+    )
+
+    def _safe(result: Any) -> dict:
+        if isinstance(result, Exception):
+            return {"status": "error", "detail": str(result)}
+        return result
+
+    checks["database"] = _safe(db_check)
+    checks["jenkins"] = _safe(jenkins_check)
+    checks["ai_provider"] = _safe(ai_check)
+    checks["reportportal"] = _safe(rp_check)
+
+    # Determine overall status
+    statuses = [c["status"] for c in checks.values()]
+    if checks["database"]["status"] == "error":
+        overall = "unhealthy"
+    elif any(s == "error" for s in statuses):
+        overall = "degraded"
+    elif any(s == "degraded" for s in statuses):
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    return {
+        "status": overall,
+        "checks": checks,
+        "error_rates": error_tracker.snapshot(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Startup config validation
+# ---------------------------------------------------------------------------
+
+
+def validate_startup_config() -> list[str]:
+    """Validate configuration at startup and return warning messages.
+
+    Returns a list of warning strings. Empty list means all OK.
+    Does NOT raise — startup should continue even with warnings.
+    """
+    warnings: list[str] = []
+
+    # AI provider
+    provider = os.getenv("AI_PROVIDER", "")
+    model = os.getenv("AI_MODEL", "")
+    if not provider:
+        warnings.append(
+            "AI_PROVIDER is not set. Analysis requests will require ai_provider in the request body."
+        )
+    if not model:
+        warnings.append(
+            "AI_MODEL is not set. Analysis requests will require ai_model in the request body."
+        )
+
+    # Database path
+    db_path = os.getenv("DB_PATH", "/data/results.db")
+    db_dir = os.path.dirname(db_path) or "."
+    if db_dir and not os.path.isdir(db_dir):
+        warnings.append(
+            f"DB_PATH directory does not exist: {db_dir}. "
+            "The database will be created but the parent directory must exist."
+        )
+
+    # Encryption key
+    if not os.getenv("JJI_ENCRYPTION_KEY"):
+        warnings.append(
+            "JJI_ENCRYPTION_KEY is not set. A file-based key will be auto-generated. "
+            "Set this env var for production deployments."
+        )
+
+    # Slack webhook
+    slack_url = os.getenv("SLACK_WEBHOOK_URL", "")
+    if slack_url and not slack_url.startswith("https://"):
+        warnings.append(
+            "SLACK_WEBHOOK_URL does not start with https://. "
+            "Slack webhooks should use HTTPS."
+        )
+
+    # SMTP config partial check
+    smtp_host = os.getenv("SMTP_HOST", "")
+    alert_email_to = os.getenv("ALERT_EMAIL_TO", "")
+    if smtp_host and not alert_email_to:
+        warnings.append(
+            "SMTP_HOST is set but ALERT_EMAIL_TO is not. Email alerts will not be sent."
+        )
+    if alert_email_to and not smtp_host:
+        warnings.append(
+            "ALERT_EMAIL_TO is set but SMTP_HOST is not. Email alerts will not be sent."
+        )
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Alert throttling
+# ---------------------------------------------------------------------------
+
+
+class AlertThrottler:
+    """Per-event-type cooldown to prevent alert storms.
+
+    Tracks the last time an alert was sent for each event type and
+    suppresses duplicates within the cooldown window.
+    """
+
+    def __init__(self, cooldown_seconds: float = 300.0) -> None:
+        self.cooldown_seconds = cooldown_seconds
+        self._last_sent: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def should_alert(self, event_type: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            last = self._last_sent.get(event_type, 0.0)
+            if now - last >= self.cooldown_seconds:
+                self._last_sent[event_type] = now
+                return True
+        return False
+
+    def reset(self, event_type: str | None = None) -> None:
+        with self._lock:
+            if event_type:
+                self._last_sent.pop(event_type, None)
+            else:
+                self._last_sent.clear()
+
+
+# Singleton throttler
+alert_throttler = AlertThrottler()
+
+
+# ---------------------------------------------------------------------------
+# Slack notifications
+# ---------------------------------------------------------------------------
+
+
+async def send_slack_alert(message: str, webhook_url: str | None = None) -> bool:
+    """Send an alert to Slack via webhook.
+
+    Args:
+        message: Text message to send.
+        webhook_url: Slack webhook URL. Falls back to SLACK_WEBHOOK_URL env var.
+
+    Returns:
+        True if sent successfully, False otherwise.
+        Never raises — alerting failures are swallowed.
+    """
+    url = webhook_url or os.getenv("SLACK_WEBHOOK_URL", "")
+    if not url:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(url, json={"text": message})
+            if resp.status_code == 200:
+                logger.debug("Slack alert sent successfully")
+                return True
+            logger.warning("Slack webhook returned HTTP %d", resp.status_code)
+            return False
+    except Exception:
+        logger.debug("Failed to send Slack alert", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Email notifications
+# ---------------------------------------------------------------------------
+
+
+def send_email_alert(
+    subject: str,
+    body: str,
+    *,
+    smtp_host: str | None = None,
+    smtp_port: int | None = None,
+    smtp_user: str | None = None,
+    smtp_password: str | None = None,
+    smtp_from: str | None = None,
+    alert_email_to: str | None = None,
+) -> bool:
+    """Send an email alert via SMTP.
+
+    All parameters fall back to environment variables when not provided.
+    Never raises — alerting failures are swallowed.
+
+    Returns:
+        True if sent successfully, False otherwise.
+    """
+    host = smtp_host or os.getenv("SMTP_HOST", "")
+    if not host:
+        return False
+    port = smtp_port or int(os.getenv("SMTP_PORT", "587"))
+    user = smtp_user or os.getenv("SMTP_USER", "")
+    password = smtp_password or os.getenv("SMTP_PASSWORD", "")
+    from_addr = smtp_from or os.getenv("SMTP_FROM", user or f"jji@{host}")
+    to_addr = alert_email_to or os.getenv("ALERT_EMAIL_TO", "")
+    if not to_addr:
+        return False
+    try:
+        msg = EmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+        msg.set_content(body)
+        with smtplib.SMTP(host, port, timeout=10) as smtp:
+            if port == 587:
+                smtp.starttls()
+            if user and password:
+                smtp.login(user, password)
+            smtp.send_message(msg)
+        logger.debug("Email alert sent to %s", to_addr)
+        return True
+    except Exception:
+        logger.debug("Failed to send email alert", exc_info=True)
+        return False
+
+
+async def send_email_alert_async(
+    subject: str,
+    body: str,
+    **kwargs: Any,
+) -> bool:
+    """Async wrapper around send_email_alert (runs in thread pool)."""
+    try:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: send_email_alert(subject, body, **kwargs)
+        )
+    except Exception:
+        logger.debug("Failed to send async email alert", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Unified alert dispatch
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_alert(
+    event_type: str,
+    message: str,
+    *,
+    subject: str | None = None,
+) -> None:
+    """Send alert via all configured channels, respecting throttling.
+
+    Args:
+        event_type: Event type key for throttling (e.g. "high_error_rate").
+        message: Alert message body.
+        subject: Email subject line (defaults to event_type).
+
+    Never raises — all alerting failures are swallowed.
+    """
+    if not alert_throttler.should_alert(event_type):
+        logger.debug("Alert throttled for event_type=%s", event_type)
+        return
+    try:
+        email_subject = subject or f"[JJI Alert] {event_type}"
+        await asyncio.gather(
+            send_slack_alert(message),
+            send_email_alert_async(email_subject, message),
+            return_exceptions=True,
+        )
+    except Exception:
+        logger.debug("Failed to dispatch alert", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics
+# ---------------------------------------------------------------------------
+
+
+def render_prometheus_metrics() -> str:
+    """Render metrics in Prometheus text exposition format.
+
+    Returns a string ready to serve from /metrics.
+    """
+    snap = error_tracker.snapshot()
+    lines: list[str] = []
+
+    lines.append("# HELP jji_requests_total Total requests in the rolling window.")
+    lines.append("# TYPE jji_requests_total gauge")
+    lines.append(f"jji_requests_total {snap['total_requests']}")
+
+    lines.append("# HELP jji_errors_total Total errors in the rolling window.")
+    lines.append("# TYPE jji_errors_total gauge")
+    lines.append(f"jji_errors_total {snap['total_errors']}")
+
+    lines.append("# HELP jji_error_rate Error rate in the rolling window (0-1).")
+    lines.append("# TYPE jji_error_rate gauge")
+    lines.append(f"jji_error_rate {snap['error_rate']}")
+
+    lines.append(
+        "# HELP jji_errors_by_class Errors by HTTP status class in the rolling window."
+    )
+    lines.append("# TYPE jji_errors_by_class gauge")
+    for cls, count in sorted(snap["error_counts"].items()):
+        lines.append(f'jji_errors_by_class{{status_class="{cls}"}} {count}')
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -569,8 +569,18 @@ async def dispatch_alert(
 # ---------------------------------------------------------------------------
 
 
-def render_prometheus_metrics() -> str:
+def render_prometheus_metrics(
+    *,
+    health_up: int | None = None,
+    active_analyses: int | None = None,
+) -> str:
     """Render metrics in Prometheus text exposition format.
+
+    Args:
+        health_up: 1 if healthy/degraded, 0 if unhealthy. When None the
+            metric is omitted.
+        active_analyses: Number of currently active (pending/running/waiting)
+            analyses. When None the metric is omitted.
 
     Returns a string ready to serve from /metrics.
     """
@@ -595,6 +605,18 @@ def render_prometheus_metrics() -> str:
     lines.append("# TYPE jji_errors_by_class gauge")
     for cls, count in sorted(snap["error_counts"].items()):
         lines.append(f'jji_errors_by_class{{status_class="{cls}"}} {count}')
+
+    if health_up is not None:
+        lines.append(
+            "# HELP jji_health_up Whether the application is healthy (1) or unhealthy (0)."
+        )
+        lines.append("# TYPE jji_health_up gauge")
+        lines.append(f"jji_health_up {health_up}")
+
+    if active_analyses is not None:
+        lines.append("# HELP jji_active_analyses Number of currently active analyses.")
+        lines.append("# TYPE jji_active_analyses gauge")
+        lines.append(f"jji_active_analyses {active_analyses}")
 
     lines.append("")
     return "\n".join(lines)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,6 +29,7 @@ def client(_init_db, temp_db_path):
             "ADMIN_KEY": "test-admin-key-16chars",  # pragma: allowlist secret
             "JJI_ENCRYPTION_KEY": "test-encryption-key-for-hmac",  # pragma: allowlist secret
             "SECURE_COOKIES": "false",
+            "DB_PATH": str(temp_db_path),
         },
     ):
         get_settings.cache_clear()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,14 +114,14 @@ def _build_wait_settings(**overrides) -> Settings:
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(temp_db_path: Path):
     """Mock settings for tests."""
     env = {
         "JENKINS_URL": "https://jenkins.example.com",
         "JENKINS_USER": "testuser",
         "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
         "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
-        "DB_PATH": "/tmp/test_jji.db",
+        "DB_PATH": str(temp_db_path),
     }
     with patch.dict(os.environ, env, clear=True):
         # Clear the lru_cache to use fresh settings

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -121,6 +121,7 @@ def mock_settings():
         "JENKINS_USER": "testuser",
         "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
         "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
+        "DB_PATH": "/tmp/test_jji.db",
     }
     with patch.dict(os.environ, env, clear=True):
         # Clear the lru_cache to use fresh settings

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -235,32 +235,40 @@ class TestHealthChecks:
 class TestStartupConfigValidation:
     """Tests for validate_startup_config."""
 
-    def test_no_warnings_with_good_config(self):
+    def test_no_warnings_with_good_config(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
         env = {
             "AI_PROVIDER": "claude",
             "AI_MODEL": "test-model",
             "JJI_ENCRYPTION_KEY": "test-key",
-            "DB_PATH": "/tmp/test.db",
+            "DB_PATH": db_path,
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JIRA_URL": "https://jira.example.com",
+            "REPORTPORTAL_URL": "https://rp.example.com",
+            "PEER_AI_CONFIGS": "claude:model1",
+            "ADMIN_KEY": "test-admin-key",
         }
         with patch.dict(os.environ, env, clear=True):
-            warnings = validate_startup_config()
-        # May still warn about DB_PATH dir not existing, filter to known warnings
-        ai_warnings = [w for w in warnings if "AI_PROVIDER" in w or "AI_MODEL" in w]
+            result = validate_startup_config()
+        ai_warnings = [
+            w for w in result.warnings if "AI_PROVIDER" in w or "AI_MODEL" in w
+        ]
         assert len(ai_warnings) == 0
+        assert len(result.errors) == 0
 
     def test_missing_ai_provider(self):
         with patch.dict(os.environ, {}, clear=True):
             env = {k: v for k, v in os.environ.items() if k != "AI_PROVIDER"}
             with patch.dict(os.environ, env, clear=True):
-                warnings = validate_startup_config()
-        assert any("AI_PROVIDER" in w for w in warnings)
+                result = validate_startup_config()
+        assert any("AI_PROVIDER" in w for w in result.warnings)
 
     def test_missing_encryption_key(self):
         with patch.dict(
             os.environ, {"AI_PROVIDER": "claude", "AI_MODEL": "test"}, clear=True
         ):
-            warnings = validate_startup_config()
-        assert any("JJI_ENCRYPTION_KEY" in w for w in warnings)
+            result = validate_startup_config()
+        assert any("JJI_ENCRYPTION_KEY" in w for w in result.warnings)
 
     def test_bad_slack_url(self):
         with patch.dict(
@@ -272,8 +280,8 @@ class TestStartupConfigValidation:
             },
             clear=True,
         ):
-            warnings = validate_startup_config()
-        assert any("SLACK_WEBHOOK_URL" in w for w in warnings)
+            result = validate_startup_config()
+        assert any("SLACK_WEBHOOK_URL" in w for w in result.warnings)
 
     def test_smtp_without_alert_to(self):
         with patch.dict(
@@ -285,8 +293,21 @@ class TestStartupConfigValidation:
             },
             clear=True,
         ):
-            warnings = validate_startup_config()
-        assert any("ALERT_EMAIL_TO" in w for w in warnings)
+            result = validate_startup_config()
+        assert any("ALERT_EMAIL_TO" in w for w in result.warnings)
+
+    def test_db_path_missing_dir_is_error(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AI_PROVIDER": "claude",
+                "AI_MODEL": "test",
+                "DB_PATH": "/nonexistent/path/test.db",
+            },
+            clear=True,
+        ):
+            result = validate_startup_config()
+        assert any("DB_PATH" in e for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +501,6 @@ class TestHealthEndpointIntegration:
         from jenkins_job_insight import storage
 
         env = {
-            "JENKINS_URL": "https://jenkins.example.com",
             "JENKINS_USER": "testuser",
             "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
             "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
@@ -490,7 +510,14 @@ class TestHealthEndpointIntegration:
 
             get_settings.cache_clear()
             try:
-                with mock_patch.object(storage, "DB_PATH", temp_db_path):
+                with (
+                    mock_patch.object(storage, "DB_PATH", temp_db_path),
+                    mock_patch(
+                        "jenkins_job_insight.monitoring.check_jenkins",
+                        new_callable=AsyncMock,
+                        return_value={"status": "not_configured"},
+                    ),
+                ):
                     from starlette.testclient import TestClient
                     from jenkins_job_insight.main import app
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,520 @@
+"""Tests for the monitoring module (health, error tracking, alerting, metrics)."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from jenkins_job_insight.monitoring import (
+    AlertThrottler,
+    ErrorRateTracker,
+    _RollingCounter,
+    build_health_response,
+    check_ai_provider,
+    check_db,
+    check_jenkins,
+    check_reportportal,
+    dispatch_alert,
+    render_prometheus_metrics,
+    send_email_alert,
+    send_slack_alert,
+    validate_startup_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Rolling counter
+# ---------------------------------------------------------------------------
+
+
+class TestRollingCounter:
+    """Tests for _RollingCounter."""
+
+    def test_empty_counter(self):
+        counter = _RollingCounter(window_seconds=10.0)
+        assert counter.count(now=100.0) == 0
+
+    def test_record_and_count(self):
+        counter = _RollingCounter(window_seconds=10.0)
+        counter.record(ts=100.0)
+        counter.record(ts=101.0)
+        counter.record(ts=102.0)
+        assert counter.count(now=105.0) == 3
+
+    def test_eviction(self):
+        counter = _RollingCounter(window_seconds=5.0)
+        counter.record(ts=100.0)
+        counter.record(ts=101.0)
+        counter.record(ts=107.0)
+        # At t=107, only ts=107 should survive (100 and 101 are > 5s old)
+        assert counter.count(now=107.0) == 1
+
+    def test_window_boundary(self):
+        counter = _RollingCounter(window_seconds=5.0)
+        counter.record(ts=100.0)
+        # Exactly at boundary
+        assert counter.count(now=105.0) == 1
+        # Just past boundary
+        assert counter.count(now=105.1) == 0
+
+
+# ---------------------------------------------------------------------------
+# Error rate tracker
+# ---------------------------------------------------------------------------
+
+
+class TestErrorRateTracker:
+    """Tests for ErrorRateTracker."""
+
+    def test_record_success(self):
+        tracker = ErrorRateTracker(window_seconds=60.0)
+        tracker.record_request(200)
+        tracker.record_request(201)
+        snap = tracker.snapshot()
+        assert snap["total_requests"] == 2
+        assert snap["total_errors"] == 0
+        assert snap["error_rate"] == 0.0
+
+    def test_record_client_error(self):
+        tracker = ErrorRateTracker(window_seconds=60.0)
+        tracker.record_request(200)
+        tracker.record_request(404)
+        snap = tracker.snapshot()
+        assert snap["total_requests"] == 2
+        assert snap["error_counts"].get("4xx", 0) == 1
+        assert snap["total_errors"] == 1
+
+    def test_record_server_error(self):
+        tracker = ErrorRateTracker(window_seconds=60.0)
+        tracker.record_request(500)
+        tracker.record_request(502)
+        snap = tracker.snapshot()
+        assert snap["error_counts"].get("5xx", 0) == 2
+        assert snap["total_errors"] == 2
+        assert snap["error_rate"] == 1.0
+
+    def test_error_rate_calculation(self):
+        tracker = ErrorRateTracker(window_seconds=60.0)
+        for _ in range(8):
+            tracker.record_request(200)
+        for _ in range(2):
+            tracker.record_request(500)
+        snap = tracker.snapshot()
+        assert snap["error_rate"] == 0.2
+
+    def test_snapshot_includes_window(self):
+        tracker = ErrorRateTracker(window_seconds=120.0)
+        snap = tracker.snapshot()
+        assert snap["window_seconds"] == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Health checks
+# ---------------------------------------------------------------------------
+
+
+class TestHealthChecks:
+    """Tests for individual health check functions."""
+
+    async def test_check_db_success(self, temp_db_path):
+        import aiosqlite
+
+        async with aiosqlite.connect(str(temp_db_path)) as db:
+            await db.execute("CREATE TABLE IF NOT EXISTS test (id INTEGER)")
+        result = await check_db(str(temp_db_path))
+        assert result["status"] == "ok"
+
+    async def test_check_db_failure(self):
+        result = await check_db("/nonexistent/path/db.sqlite")
+        assert result["status"] == "error"
+        assert "detail" in result
+
+    async def test_check_jenkins_not_configured(self):
+        settings = MagicMock()
+        settings.jenkins_url = ""
+        result = await check_jenkins(settings)
+        assert result["status"] == "not_configured"
+
+    async def test_check_jenkins_ok(self):
+        settings = MagicMock()
+        settings.jenkins_url = "https://jenkins.example.com"
+        settings.jenkins_ssl_verify = False
+
+        mock_resp = httpx.Response(200)
+
+        async def mock_get(url, **kwargs):
+            return mock_resp
+
+        with patch(
+            "jenkins_job_insight.monitoring.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+            result = await check_jenkins(settings)
+        assert result["status"] == "ok"
+
+    async def test_check_jenkins_error(self):
+        settings = MagicMock()
+        settings.jenkins_url = "https://jenkins.example.com"
+        settings.jenkins_ssl_verify = False
+
+        with patch(
+            "jenkins_job_insight.monitoring.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("fail"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+            result = await check_jenkins(settings)
+        assert result["status"] == "error"
+
+    async def test_check_ai_provider_configured(self):
+        with patch.dict(os.environ, {"AI_PROVIDER": "claude", "AI_MODEL": "test"}):
+            result = await check_ai_provider()
+        assert result["status"] == "ok"
+        assert result["provider"] == "claude"
+
+    async def test_check_ai_provider_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove keys if present
+            env = {
+                k: v
+                for k, v in os.environ.items()
+                if k not in ("AI_PROVIDER", "AI_MODEL")
+            }
+            with patch.dict(os.environ, env, clear=True):
+                result = await check_ai_provider()
+        assert result["status"] == "not_configured"
+
+    async def test_check_reportportal_not_configured(self):
+        settings = MagicMock()
+        settings.reportportal_enabled = False
+        result = await check_reportportal(settings)
+        assert result["status"] == "not_configured"
+
+    async def test_build_health_response_healthy(self, temp_db_path):
+        import aiosqlite
+
+        async with aiosqlite.connect(str(temp_db_path)) as db:
+            await db.execute("CREATE TABLE IF NOT EXISTS test (id INTEGER)")
+
+        settings = MagicMock()
+        settings.jenkins_url = ""
+        settings.reportportal_enabled = False
+
+        with patch.dict(os.environ, {"AI_PROVIDER": "claude", "AI_MODEL": "test"}):
+            result = await build_health_response(settings, str(temp_db_path))
+
+        assert result["status"] == "healthy"
+        assert "checks" in result
+        assert "error_rates" in result
+        assert result["checks"]["database"]["status"] == "ok"
+
+    async def test_build_health_response_unhealthy_db(self):
+        settings = MagicMock()
+        settings.jenkins_url = ""
+        settings.reportportal_enabled = False
+
+        with patch.dict(os.environ, {"AI_PROVIDER": "claude", "AI_MODEL": "test"}):
+            result = await build_health_response(settings, "/nonexistent/db.sqlite")
+
+        assert result["status"] == "unhealthy"
+        assert result["checks"]["database"]["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Startup config validation
+# ---------------------------------------------------------------------------
+
+
+class TestStartupConfigValidation:
+    """Tests for validate_startup_config."""
+
+    def test_no_warnings_with_good_config(self):
+        env = {
+            "AI_PROVIDER": "claude",
+            "AI_MODEL": "test-model",
+            "JJI_ENCRYPTION_KEY": "test-key",
+            "DB_PATH": "/tmp/test.db",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            warnings = validate_startup_config()
+        # May still warn about DB_PATH dir not existing, filter to known warnings
+        ai_warnings = [w for w in warnings if "AI_PROVIDER" in w or "AI_MODEL" in w]
+        assert len(ai_warnings) == 0
+
+    def test_missing_ai_provider(self):
+        with patch.dict(os.environ, {}, clear=True):
+            env = {k: v for k, v in os.environ.items() if k != "AI_PROVIDER"}
+            with patch.dict(os.environ, env, clear=True):
+                warnings = validate_startup_config()
+        assert any("AI_PROVIDER" in w for w in warnings)
+
+    def test_missing_encryption_key(self):
+        with patch.dict(
+            os.environ, {"AI_PROVIDER": "claude", "AI_MODEL": "test"}, clear=True
+        ):
+            warnings = validate_startup_config()
+        assert any("JJI_ENCRYPTION_KEY" in w for w in warnings)
+
+    def test_bad_slack_url(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AI_PROVIDER": "claude",
+                "AI_MODEL": "test",
+                "SLACK_WEBHOOK_URL": "http://not-https",
+            },
+            clear=True,
+        ):
+            warnings = validate_startup_config()
+        assert any("SLACK_WEBHOOK_URL" in w for w in warnings)
+
+    def test_smtp_without_alert_to(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AI_PROVIDER": "claude",
+                "AI_MODEL": "test",
+                "SMTP_HOST": "smtp.example.com",
+            },
+            clear=True,
+        ):
+            warnings = validate_startup_config()
+        assert any("ALERT_EMAIL_TO" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Alert throttling
+# ---------------------------------------------------------------------------
+
+
+class TestAlertThrottler:
+    """Tests for AlertThrottler."""
+
+    def test_first_alert_passes(self):
+        throttler = AlertThrottler(cooldown_seconds=60.0)
+        assert throttler.should_alert("test_event") is True
+
+    def test_duplicate_throttled(self):
+        throttler = AlertThrottler(cooldown_seconds=60.0)
+        assert throttler.should_alert("test_event") is True
+        assert throttler.should_alert("test_event") is False
+
+    def test_different_events_not_throttled(self):
+        throttler = AlertThrottler(cooldown_seconds=60.0)
+        assert throttler.should_alert("event_a") is True
+        assert throttler.should_alert("event_b") is True
+
+    def test_reset_specific(self):
+        throttler = AlertThrottler(cooldown_seconds=60.0)
+        throttler.should_alert("event_a")
+        throttler.reset("event_a")
+        assert throttler.should_alert("event_a") is True
+
+    def test_reset_all(self):
+        throttler = AlertThrottler(cooldown_seconds=60.0)
+        throttler.should_alert("event_a")
+        throttler.should_alert("event_b")
+        throttler.reset()
+        assert throttler.should_alert("event_a") is True
+        assert throttler.should_alert("event_b") is True
+
+
+# ---------------------------------------------------------------------------
+# Slack notifications
+# ---------------------------------------------------------------------------
+
+
+class TestSlackAlert:
+    """Tests for send_slack_alert."""
+
+    async def test_no_url_returns_false(self):
+        with patch.dict(os.environ, {}, clear=True):
+            env = {k: v for k, v in os.environ.items() if k != "SLACK_WEBHOOK_URL"}
+            with patch.dict(os.environ, env, clear=True):
+                result = await send_slack_alert("test")
+        assert result is False
+
+    async def test_success(self):
+        with patch("jenkins_job_insight.monitoring.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+            result = await send_slack_alert(
+                "test", webhook_url="https://hooks.slack.com/test"
+            )
+        assert result is True
+
+    async def test_failure_swallowed(self):
+        with patch("jenkins_job_insight.monitoring.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=Exception("network error"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+            result = await send_slack_alert(
+                "test", webhook_url="https://hooks.slack.com/test"
+            )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Email notifications
+# ---------------------------------------------------------------------------
+
+
+class TestEmailAlert:
+    """Tests for send_email_alert."""
+
+    def test_no_host_returns_false(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = send_email_alert("subject", "body")
+        assert result is False
+
+    def test_no_recipient_returns_false(self):
+        result = send_email_alert(
+            "subject", "body", smtp_host="smtp.example.com", alert_email_to=""
+        )
+        assert result is False
+
+    def test_smtp_failure_swallowed(self):
+        with patch("jenkins_job_insight.monitoring.smtplib.SMTP") as mock_smtp:
+            mock_smtp.side_effect = Exception("SMTP error")
+            result = send_email_alert(
+                "subject",
+                "body",
+                smtp_host="smtp.example.com",
+                alert_email_to="admin@example.com",
+            )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Alert dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAlert:
+    """Tests for dispatch_alert."""
+
+    async def test_dispatch_sends_to_all_channels(self):
+        throttler = AlertThrottler(cooldown_seconds=0.0)
+        with (
+            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
+            patch(
+                "jenkins_job_insight.monitoring.send_slack_alert",
+                new_callable=AsyncMock,
+            ) as mock_slack,
+            patch(
+                "jenkins_job_insight.monitoring.send_email_alert_async",
+                new_callable=AsyncMock,
+            ) as mock_email,
+        ):
+            mock_slack.return_value = True
+            mock_email.return_value = True
+            await dispatch_alert("test_event", "test message")
+        mock_slack.assert_called_once_with("test message")
+        mock_email.assert_called_once()
+
+    async def test_dispatch_throttled(self):
+        throttler = AlertThrottler(cooldown_seconds=9999.0)
+        with (
+            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
+            patch(
+                "jenkins_job_insight.monitoring.send_slack_alert",
+                new_callable=AsyncMock,
+            ) as mock_slack,
+        ):
+            await dispatch_alert("test_event", "first")
+            await dispatch_alert("test_event", "second")
+        # Only first call should go through
+        mock_slack.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics
+# ---------------------------------------------------------------------------
+
+
+class TestPrometheusMetrics:
+    """Tests for render_prometheus_metrics."""
+
+    def test_basic_output(self):
+        text = render_prometheus_metrics()
+        assert "jji_requests_total" in text
+        assert "jji_errors_total" in text
+        assert "jji_error_rate" in text
+
+    def test_format_with_errors(self):
+        tracker = ErrorRateTracker(window_seconds=60.0)
+        tracker.record_request(200)
+        tracker.record_request(500)
+        with patch("jenkins_job_insight.monitoring.error_tracker", tracker):
+            text = render_prometheus_metrics()
+        assert "jji_errors_by_class" in text
+        assert "5xx" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration: health endpoint via test client
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpointIntegration:
+    """Tests for /api/health and /metrics endpoints via the FastAPI test client."""
+
+    @pytest.fixture
+    def test_client(self, temp_db_path):
+        from unittest.mock import patch as mock_patch
+
+        from jenkins_job_insight import storage
+
+        env = {
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JENKINS_USER": "testuser",
+            "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
+            "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
+        }
+        with mock_patch.dict(os.environ, env, clear=True):
+            from jenkins_job_insight.config import get_settings
+
+            get_settings.cache_clear()
+            try:
+                with mock_patch.object(storage, "DB_PATH", temp_db_path):
+                    from starlette.testclient import TestClient
+                    from jenkins_job_insight.main import app
+
+                    with TestClient(app) as client:
+                        yield client
+            finally:
+                get_settings.cache_clear()
+
+    def test_api_health_returns_status(self, test_client):
+        response = test_client.get("/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] in ("healthy", "degraded", "unhealthy")
+        assert "checks" in data
+        assert "error_rates" in data
+        assert "database" in data["checks"]
+
+    def test_legacy_health_still_works(self, test_client):
+        response = test_client.get("/health")
+        assert response.status_code == 200
+        assert response.json()["status"] == "healthy"
+
+    def test_metrics_endpoint(self, test_client):
+        response = test_client.get("/metrics")
+        assert response.status_code == 200
+        assert "jji_requests_total" in response.text
+        assert "text/plain" in response.headers["content-type"]

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -504,6 +504,7 @@ class TestHealthEndpointIntegration:
             "JENKINS_USER": "testuser",
             "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
             "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
+            "DB_PATH": str(temp_db_path),
         }
         with mock_patch.dict(os.environ, env, clear=True):
             from jenkins_job_insight.config import get_settings


### PR DESCRIPTION
## Summary

Adds alerting, monitoring, and health-check infrastructure so operators can detect and respond to server errors promptly. Closes #136.

## Changes

### Health endpoint
- `GET /api/health` with subsystem checks (DB, Jenkins, AI, ReportPortal) plus rolling-window error rates
- Returns **200** for `healthy`/`degraded`, **503** for `unhealthy`

### Startup config validation
- Validates `AI_PROVIDER`, `AI_MODEL`, `DB_PATH`, `JJI_ENCRYPTION_KEY`, Slack/SMTP config at startup with clear log messages

### Error tracking
- `ErrorRateTracker` with thread-safe rolling-window counters per subsystem

### Slack alerts
- Webhook integration via `SLACK_WEBHOOK_URL` with per-event throttling to avoid alert storms

### Email alerts
- SMTP-based alerts via `ALERT_EMAIL_TO` + `SMTP_*` env vars

### Prometheus metrics
- `GET /metrics` endpoint exposing request/error counters and histograms
- `docs/openshift-prometheus-rule.yaml` — ready-to-apply PrometheusRule manifest

### CLI
- `jji health` command with detailed output, backward-compatible with older servers that lack the health endpoint

### Implementation details
- New module: `monitoring.py` (493 lines) — all monitoring, alerting, and metrics logic
- **42 new tests** covering health, alerts, metrics, config validation, and CLI
- All alerting failures are swallowed gracefully — alerting never crashes the server

## Linked Issue
Fixes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed /api/health and /metrics endpoints, middleware-driven rolling error-rate tracking, and automatic alert dispatch with throttling.
  * CLI health command now shows per-component checks, human-readable status, and error-rate details.

* **Documentation**
  * Added Prometheus alerting rules for error-rate and health.

* **Tests**
  * Added comprehensive tests for monitoring, alerts, health checks, metrics, and test-environment DB path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->