### PR TITLE
feat: Support allow lists to restrict who can submit execution results (fixes #117)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,14 @@ LOG_LEVEL=INFO
 # ENABLE_GITHUB_ISSUES=true
 
 # ===================
+# Access Control (Optional)
+# ===================
+# Comma-separated list of usernames allowed to create/modify data
+# (submit analyses, add comments, set reviewed, override classifications, etc.)
+# Empty = open access (all users allowed). Admin users always bypass.
+# ALLOWED_USERS=alice,bob,carol
+
+# ===================
 # Development
 # ===================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ When adding a new analysis setting:
 
 Exceptions (server-level only, no payload equivalent):
 - `ADMIN_KEY` — server-only bootstrap secret for admin superuser authentication; never expose via request payloads, CLI flags, or shared config files. Rotating `ADMIN_KEY` only affects the bootstrap admin login — delegated admin API keys use `JJI_ENCRYPTION_KEY` for HMAC hashing and are not affected by `ADMIN_KEY` rotation.
+- `ALLOWED_USERS` — server-only comma-separated allow list of usernames permitted to create/modify data; empty = open access (backward compatible); admin users always bypass; never expose via request payloads or CLI flags (this is a security boundary)
 - `DEBUG` — server reload toggle
 - `ENABLE_GITHUB_ISSUES` — server capability toggle for GitHub issue creation
 - `ENABLE_REPORTPORTAL` — server capability toggle for Report Portal integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ When adding a new analysis setting:
 
 Exceptions (server-level only, no payload equivalent):
 - `ADMIN_KEY` — server-only bootstrap secret for admin superuser authentication; never expose via request payloads, CLI flags, or shared config files. Rotating `ADMIN_KEY` only affects the bootstrap admin login — delegated admin API keys use `JJI_ENCRYPTION_KEY` for HMAC hashing and are not affected by `ADMIN_KEY` rotation.
-- `ALLOWED_USERS` — server-only comma-separated allow list of usernames permitted to create/modify data; empty = open access (backward compatible); admin users always bypass; never expose via request payloads or CLI flags (this is a security boundary)
+- `ALLOWED_USERS` — server-only comma-separated allow list of usernames permitted to create/modify data; empty = open access (backward compatible); admin users always bypass; never expose via request payloads or CLI flags. Note: this is a trusted-network access guard, not a cryptographic security boundary — enforcement reads the client-supplied `jji_username` cookie, so protection relies on network-level trust rather than server-verified identity
 - `DEBUG` — server reload toggle
 - `ENABLE_GITHUB_ISSUES` — server capability toggle for GitHub issue creation
 - `ENABLE_REPORTPORTAL` — server capability toggle for Report Portal integration

--- a/docs/configuration-and-environment-reference.md
+++ b/docs/configuration-and-environment-reference.md
@@ -152,12 +152,14 @@ Bootstrap admin authentication, cookie security, and at-rest encryption.
 | Name | Type | Default | Loaded by | Description |
 | --- | --- | --- | --- | --- |
 | `ADMIN_KEY` | string | `""` | `Settings` | Bootstrap admin secret. `POST /api/auth/login` accepts it only with username `admin`. Bearer `Authorization: Bearer <ADMIN_KEY>` also authenticates as admin. |
+| `ALLOWED_USERS` | string | `""` | `Settings` | Comma-separated list of usernames allowed to create/modify data (analyses, comments, reviews, classifications). Empty = open access (all users allowed). Admin users always bypass. Case-insensitive. |
 | `SECURE_COOKIES` | boolean | `true` | `Settings` | `Secure` attribute for `jji_session` and `jji_username` cookies. |
 | `JJI_ENCRYPTION_KEY` | string | `unset` | `process env` | Secret used to encrypt stored sensitive values and HMAC-hash stored admin API keys. |
 | `XDG_DATA_HOME` | path | `~/.local/share` | `process env` | Base directory for the fallback encryption key file when `JJI_ENCRYPTION_KEY` is unset. |
 
 ```bash
 ADMIN_KEY=change-this-admin-secret
+ALLOWED_USERS=alice,bob,carol
 SECURE_COOKIES=true
 JJI_ENCRYPTION_KEY=change-this-encryption-secret
 XDG_DATA_HOME=/var/lib/jji

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -81,10 +81,17 @@ def _handle_error(err: JJIError) -> None:
             err=True,
         )
     elif err.status_code == 403:
-        typer.echo(
-            "Hint: This action requires admin access. Use --api-key or set JJI_API_KEY.",
-            err=True,
-        )
+        detail = err.detail.lower() if err.detail else ""
+        if "allow list" in detail:
+            typer.echo(
+                "Hint: Your user is not on the server's allow list. Contact an administrator.",
+                err=True,
+            )
+        else:
+            typer.echo(
+                "Hint: This action requires admin access. Use --api-key or set JJI_API_KEY.",
+                err=True,
+            )
     raise typer.Exit(code=1)
 
 

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -178,6 +178,16 @@ class Settings(BaseSettings):
     poll_interval_minutes: int = Field(default=2, gt=0)
     max_wait_minutes: int = Field(default=0, ge=0)
 
+    # Allow list — comma-separated usernames allowed to submit/modify data.
+    # Empty means open access (all users allowed). Admin users always bypass.
+    allowed_users: str = Field(
+        default="",
+        description=(
+            "Comma-separated list of usernames allowed to create/modify data. "
+            "Empty = open access (no restriction). Admin users always bypass."
+        ),
+    )
+
     # Admin authentication
     admin_key: str = Field(
         default="", repr=False
@@ -243,6 +253,18 @@ class Settings(BaseSettings):
                     SecretStr(stripped) if stripped else None,
                 )
         return self
+
+    @property
+    def allowed_users_set(self) -> frozenset[str]:
+        """Parse ALLOWED_USERS into a frozen set of lowercase usernames.
+
+        Returns an empty frozenset when unset (open access).
+        """
+        if not self.allowed_users or not self.allowed_users.strip():
+            return frozenset()
+        return frozenset(
+            u.strip().lower() for u in self.allowed_users.split(",") if u.strip()
+        )
 
     @property
     def jira_enabled(self) -> bool:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1292,6 +1292,7 @@ async def analyze(
 
     Returns immediately with a job_id. Poll /results/{job_id} for status.
     """
+    _check_allow_list(request)
     logger.debug(f"Starting analysis for {body.job_name} #{body.build_number}")
     base_url = _extract_base_url()
 
@@ -1325,6 +1326,7 @@ async def analyze_failures(
     When raw_xml is provided, failures are extracted from the XML and the enriched
     XML with analysis results is included in the response.
     """
+    _check_allow_list(request)
     logger.debug(
         f"POST /analyze-failures: failures_count={len(body.failures) if body.failures else 0}, has_raw_xml={body.raw_xml is not None}"
     )
@@ -1541,6 +1543,7 @@ async def re_analyze(
     overrides from the request body, and queues a new analysis with a
     fresh job_id.
     """
+    _check_allow_list(request)
     base_url = _extract_base_url()
 
     # Load the original result (with sensitive fields for credential reuse)
@@ -1791,6 +1794,7 @@ async def add_comment(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Add a comment to a test failure."""
+    _check_allow_list(request)
     logger.debug(f"POST /results/{job_id}/comments: test_name={body.test_name}")
     await _validate_test_name_in_result(
         job_id, body.test_name, body.child_job_name, body.child_build_number
@@ -1825,6 +1829,7 @@ async def delete_comment_endpoint(
     Admin users can delete any comment. Regular users can only delete
     their own comments (matched by username).
     """
+    _check_allow_list(request)
     logger.debug(f"DELETE /results/{job_id}/comments/{comment_id}")
     username = request.state.username
     if not username:
@@ -1852,6 +1857,7 @@ async def set_reviewed(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Toggle the reviewed state for a test failure."""
+    _check_allow_list(request)
     logger.debug(
         f"PUT /results/{job_id}/reviewed: test_name={body.test_name}, reviewed={body.reviewed}"
     )
@@ -1879,10 +1885,12 @@ async def set_reviewed(
 @app.post("/results/{job_id}/enrich-comments")
 async def enrich_comments(
     job_id: str,
+    request: Request,
     settings: Settings = Depends(get_settings),
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Fetch live statuses for GitHub PRs and Jira tickets found in comments."""
+    _check_allow_list(request)
     logger.debug(f"POST /results/{job_id}/enrich-comments")
     from jenkins_job_insight.comment_enrichment import (
         detect_github_issues,
@@ -2079,6 +2087,7 @@ async def preview_github_issue(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Generate preview content for a GitHub issue from a failure analysis."""
+    _check_allow_list(request)
     logger.debug(
         f"POST /results/{job_id}/preview-github-issue: test_name={body.test_name}"
     )
@@ -2150,6 +2159,7 @@ async def preview_jira_bug(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Generate preview content for a Jira bug from a failure analysis."""
+    _check_allow_list(request)
     logger.debug(f"POST /results/{job_id}/preview-jira-bug: test_name={body.test_name}")
     if not _jira_issue_creation_enabled(settings):
         raise HTTPException(
@@ -2363,6 +2373,7 @@ async def create_github_issue_endpoint(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Create a GitHub issue from a failure analysis."""
+    _check_allow_list(request)
     logger.debug(
         f"POST /results/{job_id}/create-github-issue: test_name={body.test_name}"
     )
@@ -2455,6 +2466,7 @@ async def create_jira_bug_endpoint(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Create a Jira bug from a failure analysis."""
+    _check_allow_list(request)
     logger.debug(f"POST /results/{job_id}/create-jira-bug: test_name={body.test_name}")
 
     if not _jira_issue_creation_enabled(settings):
@@ -2534,6 +2546,7 @@ async def create_jira_bug_endpoint(
 @app.post("/results/{job_id}/push-reportportal", response_model=ReportPortalPushResult)
 async def push_to_reportportal(
     job_id: str,
+    request: Request,
     child_job_name: str | None = Query(
         default=None, description="Child job name for pipeline child push"
     ),
@@ -2548,6 +2561,7 @@ async def push_to_reportportal(
     Finds the matching RP launch, matches failed items to JJI failures,
     and updates each item's defect type and comment.
     """
+    _check_allow_list(request)
     if not settings.reportportal_enabled:
         raise HTTPException(
             status_code=400,
@@ -3039,6 +3053,7 @@ async def override_classification_endpoint(
     _: None = Depends(_bind_job_id),
 ) -> dict:
     """Override the classification of a failure (CODE ISSUE, PRODUCT BUG, or INFRASTRUCTURE)."""
+    _check_allow_list(request)
     logger.debug(
         f"PUT /results/{job_id}/override-classification: test_name={body.test_name}, "
         f"classification={body.classification}"
@@ -3404,6 +3419,7 @@ async def get_job_stats_endpoint(
 @app.post("/history/classify", status_code=201)
 async def classify_test(request: Request, body: ClassifyTestRequest) -> dict:
     """Classify a test as FLAKY, REGRESSION, etc. Used by AI and humans."""
+    _check_allow_list(request)
     logger.debug(
         f"POST /history/classify: test_name={body.test_name!r}, classification={body.classification!r}"
     )
@@ -3530,6 +3546,26 @@ def _require_admin(request: Request) -> None:
     """Raise 403 if the request is not from an authenticated admin."""
     if not request.state.is_admin:
         raise HTTPException(status_code=403, detail="Admin access required")
+
+
+def _check_allow_list(request: Request) -> None:
+    """Raise 403 if the requesting user is not on the allow list.
+
+    When the allow list is empty (default), all users are permitted.
+    Admin users always bypass the allow list check.
+    """
+    settings = get_settings()
+    allowed = settings.allowed_users_set
+    if not allowed:
+        return  # Open access — no restriction
+    if request.state.is_admin:
+        return  # Admins always bypass
+    username = (request.state.username or "").strip().lower()
+    if not username or username not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail="User not allowed. Contact an administrator to be added to the allow list.",
+        )
 
 
 @app.post("/api/auth/login")

--- a/tests/test_allow_list.py
+++ b/tests/test_allow_list.py
@@ -1,0 +1,261 @@
+"""Tests for the ALLOWED_USERS allow list feature (#117)."""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.config import Settings, get_settings
+
+
+@pytest.fixture
+def _init_db(temp_db_path):
+    """Initialize database with test path."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(storage.init_db())
+        yield
+
+
+@pytest.fixture
+def _seed_result(_init_db, temp_db_path):
+    """Create a completed result with a failure for testing write endpoints."""
+    result_data = {
+        "status": "completed",
+        "summary": "1 failure",
+        "failures": [
+            {
+                "test_name": "test_foo",
+                "error": "AssertionError",
+                "analysis": {"classification": "CODE ISSUE", "details": "test"},
+            }
+        ],
+    }
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(
+            storage.save_result("job-1", "http://jenkins/1", "completed", result_data)
+        )
+
+
+def _make_client(temp_db_path, allowed_users: str = "", admin_key: str = ""):
+    """Create a test client with allow list configured."""
+    env = {
+        "SECURE_COOKIES": "false",
+    }
+    if allowed_users:
+        env["ALLOWED_USERS"] = allowed_users
+    if admin_key:
+        env["ADMIN_KEY"] = admin_key
+        env["JJI_ENCRYPTION_KEY"] = "test-key-for-hmac"  # pragma: allowlist secret
+    with patch.dict(os.environ, env):
+        get_settings.cache_clear()
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as c:
+                yield c
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def client_open(_init_db, temp_db_path):
+    """Client with no allow list (open access)."""
+    yield from _make_client(temp_db_path)
+
+
+@pytest.fixture
+def client_restricted(_seed_result, temp_db_path):
+    """Client with allow list set to 'alice,bob'."""
+    yield from _make_client(
+        temp_db_path,
+        allowed_users="alice,bob",
+        admin_key="test-admin-key-16chars",  # pragma: allowlist secret
+    )
+
+
+class TestAllowListConfig:
+    """Test ALLOWED_USERS parsing in Settings."""
+
+    def test_empty_allowed_users(self):
+        with patch.dict(os.environ, {}, clear=False):
+            get_settings.cache_clear()
+            s = Settings()
+            assert s.allowed_users_set == frozenset()
+        get_settings.cache_clear()
+
+    def test_single_user(self):
+        with patch.dict(os.environ, {"ALLOWED_USERS": "alice"}, clear=False):
+            get_settings.cache_clear()
+            s = Settings()
+            assert s.allowed_users_set == frozenset({"alice"})
+        get_settings.cache_clear()
+
+    def test_multiple_users(self):
+        with patch.dict(
+            os.environ, {"ALLOWED_USERS": "alice, Bob, Charlie"}, clear=False
+        ):
+            get_settings.cache_clear()
+            s = Settings()
+            # Case-insensitive (lowercased)
+            assert s.allowed_users_set == frozenset({"alice", "bob", "charlie"})
+        get_settings.cache_clear()
+
+    def test_whitespace_only(self):
+        with patch.dict(os.environ, {"ALLOWED_USERS": "  ,  , "}, clear=False):
+            get_settings.cache_clear()
+            s = Settings()
+            assert s.allowed_users_set == frozenset()
+        get_settings.cache_clear()
+
+
+class TestOpenAccess:
+    """When ALLOWED_USERS is empty, all users can write."""
+
+    def test_comment_allowed_without_allow_list(self, client_open):
+        """Any user can add a comment when allow list is empty."""
+        # Create a result first
+        result_data = {
+            "status": "completed",
+            "summary": "",
+            "failures": [
+                {
+                    "test_name": "test_foo",
+                    "error": "err",
+                    "analysis": {"classification": "CODE ISSUE"},
+                }
+            ],
+        }
+        asyncio.run(
+            storage.save_result("job-open", "http://j/1", "completed", result_data)
+        )
+        resp = client_open.post(
+            "/results/job-open/comments",
+            json={"test_name": "test_foo", "comment": "looks good"},
+            cookies={"jji_username": "anyone"},
+        )
+        assert resp.status_code == 201
+
+
+class TestRestrictedAccess:
+    """When ALLOWED_USERS is set, only listed users can write."""
+
+    def test_allowed_user_can_comment(self, client_restricted):
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "fix coming"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 201
+
+    def test_allowed_user_case_insensitive(self, client_restricted):
+        """Allow list matching is case-insensitive."""
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "fix coming"},
+            cookies={"jji_username": "Alice"},
+        )
+        assert resp.status_code == 201
+
+    def test_blocked_user_gets_403(self, client_restricted):
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "not allowed"},
+            cookies={"jji_username": "charlie"},
+        )
+        assert resp.status_code == 403
+        assert "allow list" in resp.json()["detail"].lower()
+
+    def test_no_username_gets_403(self, client_restricted):
+        """Requests without a username are blocked."""
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "anon"},
+        )
+        assert resp.status_code == 403
+
+    def test_admin_bypasses_allow_list(self, client_restricted):
+        """Admin users always bypass the allow list."""
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "admin override"},
+            headers={
+                "Authorization": "Bearer test-admin-key-16chars"  # pragma: allowlist secret
+            },
+        )
+        assert resp.status_code == 201
+
+    def test_reviewed_blocked(self, client_restricted):
+        resp = client_restricted.put(
+            "/results/job-1/reviewed",
+            json={"test_name": "test_foo", "reviewed": True},
+            cookies={"jji_username": "charlie"},
+        )
+        assert resp.status_code == 403
+
+    def test_reviewed_allowed(self, client_restricted):
+        resp = client_restricted.put(
+            "/results/job-1/reviewed",
+            json={"test_name": "test_foo", "reviewed": True},
+            cookies={"jji_username": "bob"},
+        )
+        assert resp.status_code == 200
+
+    def test_override_classification_blocked(self, client_restricted):
+        resp = client_restricted.put(
+            "/results/job-1/override-classification",
+            json={"test_name": "test_foo", "classification": "PRODUCT BUG"},
+            cookies={"jji_username": "charlie"},
+        )
+        assert resp.status_code == 403
+
+    def test_override_classification_allowed(self, client_restricted):
+        resp = client_restricted.put(
+            "/results/job-1/override-classification",
+            json={"test_name": "test_foo", "classification": "PRODUCT BUG"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 200
+
+    def test_classify_blocked(self, client_restricted):
+        resp = client_restricted.post(
+            "/history/classify",
+            json={
+                "test_name": "test_foo",
+                "classification": "FLAKY",
+                "job_id": "job-1",
+            },
+            cookies={"jji_username": "charlie"},
+        )
+        assert resp.status_code == 403
+
+    def test_classify_allowed(self, client_restricted):
+        resp = client_restricted.post(
+            "/history/classify",
+            json={
+                "test_name": "test_foo",
+                "classification": "FLAKY",
+                "job_id": "job-1",
+            },
+            cookies={"jji_username": "bob"},
+        )
+        assert resp.status_code == 201
+
+    def test_read_endpoints_not_affected(self, client_restricted):
+        """GET endpoints are not restricted by allow list."""
+        resp = client_restricted.get(
+            "/results/job-1",
+            cookies={"jji_username": "charlie"},
+            headers={"Accept": "application/json"},
+        )
+        # Should be 200 (found), NOT 403
+        assert resp.status_code == 200
+
+    def test_get_comments_not_affected(self, client_restricted):
+        """GET comments endpoint is not restricted."""
+        resp = client_restricted.get(
+            "/results/job-1/comments",
+            cookies={"jji_username": "charlie"},
+        )
+        assert resp.status_code == 200

--- a/tests/test_allow_list.py
+++ b/tests/test_allow_list.py
@@ -42,14 +42,17 @@ def _seed_result(_init_db, temp_db_path):
 def _make_client(temp_db_path, allowed_users: str = "", admin_key: str = ""):
     """Create a test client with allow list configured."""
     env = {
-        "SECURE_COOKIES": "false",
+        k: v
+        for k, v in os.environ.items()
+        if k not in {"ALLOWED_USERS", "ADMIN_KEY", "JJI_ENCRYPTION_KEY"}
     }
+    env["SECURE_COOKIES"] = "false"
     if allowed_users:
         env["ALLOWED_USERS"] = allowed_users
     if admin_key:
         env["ADMIN_KEY"] = admin_key
         env["JJI_ENCRYPTION_KEY"] = "test-key-for-hmac"  # pragma: allowlist secret
-    with patch.dict(os.environ, env):
+    with patch.dict(os.environ, env, clear=True):
         get_settings.cache_clear()
         with patch.object(storage, "DB_PATH", temp_db_path):
             from jenkins_job_insight.main import app
@@ -79,7 +82,7 @@ class TestAllowListConfig:
     """Test ALLOWED_USERS parsing in Settings."""
 
     def test_empty_allowed_users(self):
-        with patch.dict(os.environ, {}, clear=False):
+        with patch.dict(os.environ, {"ALLOWED_USERS": ""}, clear=False):
             get_settings.cache_clear()
             s = Settings()
             assert s.allowed_users_set == frozenset()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -567,6 +567,21 @@ class TestErrorHandling:
         assert "admin access" in result.output.lower()
         assert "--api-key" in result.output
 
+    def test_403_allow_list_hints_about_allow_list(self, mock_client):
+        """_handle_error should hint about allow list when detail mentions it."""
+        mock_client.add_comment.side_effect = JJIError(
+            status_code=403,
+            detail="User not allowed. Contact an administrator to be added to the allow list.",
+        )
+        result = runner.invoke(
+            app,
+            ["comments", "add", "job-1", "--test", "test_foo", "-m", "my comment"],
+        )
+        assert result.exit_code == 1
+        assert "allow list" in result.output.lower()
+        # Should NOT hint about --api-key for allow list errors
+        assert "--api-key" not in result.output
+
 
 class TestNullFieldHandling:
     def test_history_test_with_null_failure_rate(self, mock_client):


### PR DESCRIPTION
## Summary

Adds an `ALLOWED_USERS` environment variable that lets operators restrict which users can create or modify data via write endpoints. When set, only listed users (and admins) can submit execution results, post comments, update classifications, etc.

Closes #117

## Problem / Motivation

Previously, any user could submit data to the server. Operators needed a way to restrict write access to a known set of users without requiring full authentication infrastructure.

## Changes

- Added `ALLOWED_USERS` env var to `Settings` (comma-separated, case-insensitive matching)
- Added `_check_allow_list(request)` helper enforced on all 14 write endpoints
- Returns 403 Forbidden for non-allowed users with clear error message
- Admin users always bypass the allow list
- Empty/unset = open access (fully backward compatible)
- CLI distinguishes allow list 403 from admin-only 403 with appropriate error messages
- 18 new tests covering all scenarios
- Documentation updated (`.env.example`, config reference)

## Deliverables

- [x] Code changes
- [x] Tests (18 new tests)
- [x] Documentation updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional ALLOWED_USERS environment setting to control which usernames may create or modify data; empty value leaves access open and admin users bypass.

* **Documentation**
  * Updated configuration docs and examples to include ALLOWED_USERS and usage notes.

* **Improvements**
  * CLI now shows a specific allow-list hint for relevant authorization errors.

* **Tests**
  * Added integration tests covering allow-list parsing and endpoint behavior (including admin bypass and cookie requirements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->