### PR TITLE
feat: Filter jobs by metadata (fixes #134)

### DIFF
--- a/frontend/src/components/shared/MetadataBadges.tsx
+++ b/frontend/src/components/shared/MetadataBadges.tsx
@@ -15,7 +15,7 @@ export function MetadataBadges({ metadata }: { metadata: JobMetadata | null | un
   if (!hasBadges) return null
 
   return (
-    <span className="inline-flex flex-wrap items-center gap-1">
+    <div className="inline-flex flex-wrap items-center gap-1">
       {team && (
         <Badge variant="outline" className="text-[10px] px-1.5 py-0 font-normal border-accent-blue/30 text-accent-blue">
           {team}
@@ -36,6 +36,6 @@ export function MetadataBadges({ metadata }: { metadata: JobMetadata | null | un
           {label}
         </Badge>
       ))}
-    </span>
+    </div>
   )
 }

--- a/frontend/src/components/shared/MetadataBadges.tsx
+++ b/frontend/src/components/shared/MetadataBadges.tsx
@@ -1,0 +1,41 @@
+import type { JobMetadata } from '@/types'
+import { Badge } from '@/components/ui/badge'
+
+const TIER_COLORS: Record<string, string> = {
+  critical: 'bg-signal-red/15 text-signal-red border-signal-red/30',
+  standard: 'bg-signal-blue/15 text-signal-blue border-signal-blue/30',
+  low: 'bg-text-tertiary/15 text-text-tertiary border-text-tertiary/30',
+}
+
+export function MetadataBadges({ metadata }: { metadata: JobMetadata | null | undefined }) {
+  if (!metadata) return null
+
+  const { team, tier, version, labels } = metadata
+  const hasBadges = team || tier || version || labels.length > 0
+  if (!hasBadges) return null
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {team && (
+        <Badge variant="outline" className="text-[10px] px-1.5 py-0 font-normal border-accent-blue/30 text-accent-blue">
+          {team}
+        </Badge>
+      )}
+      {tier && (
+        <Badge variant="outline" className={`text-[10px] px-1.5 py-0 font-normal ${TIER_COLORS[tier] ?? 'border-border-muted text-text-secondary'}`}>
+          {tier}
+        </Badge>
+      )}
+      {version && (
+        <Badge variant="outline" className="text-[10px] px-1.5 py-0 font-normal border-border-muted text-text-secondary">
+          {version}
+        </Badge>
+      )}
+      {labels.map((label) => (
+        <Badge key={label} variant="outline" className="text-[10px] px-1.5 py-0 font-normal border-signal-green/30 text-signal-green">
+          {label}
+        </Badge>
+      ))}
+    </span>
+  )
+}

--- a/frontend/src/components/shared/MetadataFilterBar.tsx
+++ b/frontend/src/components/shared/MetadataFilterBar.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import type { JobMetadata } from '@/types'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { X } from 'lucide-react'
+
+const ALL_VALUE = '__ALL__'
+
+interface MetadataFilterBarProps {
+  team: string
+  tier: string
+  version: string
+  labels: string[]
+  onTeamChange: (value: string) => void
+  onTierChange: (value: string) => void
+  onVersionChange: (value: string) => void
+  onLabelsChange: (value: string[]) => void
+}
+
+export function MetadataFilterBar({
+  team,
+  tier,
+  version,
+  labels,
+  onTeamChange,
+  onTierChange,
+  onVersionChange,
+  onLabelsChange,
+}: MetadataFilterBarProps) {
+  const [options, setOptions] = useState<{
+    teams: string[]
+    tiers: string[]
+    versions: string[]
+    allLabels: string[]
+  }>({ teams: [], tiers: [], versions: [], allLabels: [] })
+
+  useEffect(() => {
+    let cancelled = false
+    api.get<JobMetadata[]>('/api/jobs/metadata').then((data) => {
+      if (cancelled) return
+      const teams = new Set<string>()
+      const tiers = new Set<string>()
+      const versions = new Set<string>()
+      const allLabels = new Set<string>()
+      for (const m of data) {
+        if (m.team) teams.add(m.team)
+        if (m.tier) tiers.add(m.tier)
+        if (m.version) versions.add(m.version)
+        for (const l of m.labels) allLabels.add(l)
+      }
+      setOptions({
+        teams: [...teams].sort(),
+        tiers: [...tiers].sort(),
+        versions: [...versions].sort(),
+        allLabels: [...allLabels].sort(),
+      })
+    }).catch(() => { /* swallow - filter options are best-effort */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const hasFilters = team || tier || version || labels.length > 0
+
+  const clearAll = useCallback(() => {
+    onTeamChange('')
+    onTierChange('')
+    onVersionChange('')
+    onLabelsChange([])
+  }, [onTeamChange, onTierChange, onVersionChange, onLabelsChange])
+
+  const toggleLabel = useCallback((label: string) => {
+    if (labels.includes(label)) {
+      onLabelsChange(labels.filter((l) => l !== label))
+    } else {
+      onLabelsChange([...labels, label])
+    }
+  }, [labels, onLabelsChange])
+
+  // Don't render if no metadata options exist
+  if (options.teams.length === 0 && options.tiers.length === 0 && options.versions.length === 0 && options.allLabels.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {options.teams.length > 0 && (
+        <Select value={team || ALL_VALUE} onValueChange={(v) => onTeamChange(v === ALL_VALUE ? '' : v)}>
+          <SelectTrigger aria-label="Filter by team" className="w-32">
+            <SelectValue placeholder="Team" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_VALUE}>All teams</SelectItem>
+            {options.teams.map((t) => (
+              <SelectItem key={t} value={t}>{t}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {options.tiers.length > 0 && (
+        <Select value={tier || ALL_VALUE} onValueChange={(v) => onTierChange(v === ALL_VALUE ? '' : v)}>
+          <SelectTrigger aria-label="Filter by tier" className="w-32">
+            <SelectValue placeholder="Tier" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_VALUE}>All tiers</SelectItem>
+            {options.tiers.map((t) => (
+              <SelectItem key={t} value={t}>{t}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {options.versions.length > 0 && (
+        <Select value={version || ALL_VALUE} onValueChange={(v) => onVersionChange(v === ALL_VALUE ? '' : v)}>
+          <SelectTrigger aria-label="Filter by version" className="w-32">
+            <SelectValue placeholder="Version" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_VALUE}>All versions</SelectItem>
+            {options.versions.map((v) => (
+              <SelectItem key={v} value={v}>{v}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {options.allLabels.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1">
+          {options.allLabels.map((label) => (
+            <Badge
+              key={label}
+              variant={labels.includes(label) ? 'default' : 'outline'}
+              className={`cursor-pointer text-xs px-2 py-0.5 transition-colors ${
+                labels.includes(label)
+                  ? 'bg-signal-green/20 text-signal-green border-signal-green/40 hover:bg-signal-green/30'
+                  : 'border-border-muted text-text-tertiary hover:bg-surface-hover hover:text-text-secondary'
+              }`}
+              onClick={() => toggleLabel(label)}
+            >
+              {label}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {hasFilters && (
+        <Button variant="ghost" size="sm" onClick={clearAll} className="h-7 px-2 text-xs text-text-tertiary hover:text-text-secondary">
+          <X className="h-3 w-3 mr-1" />
+          Clear filters
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/MetadataFilterBar.tsx
+++ b/frontend/src/components/shared/MetadataFilterBar.tsx
@@ -8,7 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { X } from 'lucide-react'
 
@@ -88,57 +87,36 @@ export function MetadataFilterBar({
     return null
   }
 
+  const selectFilters = [
+    { key: 'team', value: team, options: options.teams, allLabel: 'All teams', aria: 'Filter by team', onChange: onTeamChange },
+    { key: 'tier', value: tier, options: options.tiers, allLabel: 'All tiers', aria: 'Filter by tier', onChange: onTierChange },
+    { key: 'version', value: version, options: options.versions, allLabel: 'All versions', aria: 'Filter by version', onChange: onVersionChange },
+  ]
+
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {options.teams.length > 0 && (
-        <Select value={team || ALL_VALUE} onValueChange={(v) => onTeamChange(v === ALL_VALUE ? '' : v)}>
-          <SelectTrigger aria-label="Filter by team" className="w-32">
-            <SelectValue placeholder="Team" />
+      {selectFilters.filter((f) => f.options.length > 0).map((f) => (
+        <Select key={f.key} value={f.value || ALL_VALUE} onValueChange={(v) => f.onChange(v === ALL_VALUE ? '' : v)}>
+          <SelectTrigger aria-label={f.aria} className="w-32">
+            <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL_VALUE}>All teams</SelectItem>
-            {options.teams.map((t) => (
-              <SelectItem key={t} value={t}>{t}</SelectItem>
+            <SelectItem value={ALL_VALUE}>{f.allLabel}</SelectItem>
+            {f.options.map((option) => (
+              <SelectItem key={option} value={option}>{option}</SelectItem>
             ))}
           </SelectContent>
         </Select>
-      )}
-
-      {options.tiers.length > 0 && (
-        <Select value={tier || ALL_VALUE} onValueChange={(v) => onTierChange(v === ALL_VALUE ? '' : v)}>
-          <SelectTrigger aria-label="Filter by tier" className="w-32">
-            <SelectValue placeholder="Tier" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_VALUE}>All tiers</SelectItem>
-            {options.tiers.map((t) => (
-              <SelectItem key={t} value={t}>{t}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
-
-      {options.versions.length > 0 && (
-        <Select value={version || ALL_VALUE} onValueChange={(v) => onVersionChange(v === ALL_VALUE ? '' : v)}>
-          <SelectTrigger aria-label="Filter by version" className="w-32">
-            <SelectValue placeholder="Version" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_VALUE}>All versions</SelectItem>
-            {options.versions.map((v) => (
-              <SelectItem key={v} value={v}>{v}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
+      ))}
 
       {options.allLabels.length > 0 && (
         <div className="flex flex-wrap items-center gap-1">
           {options.allLabels.map((label) => (
-            <Badge
+            <button
+              type="button"
               key={label}
-              variant={labels.includes(label) ? 'default' : 'outline'}
-              className={`cursor-pointer text-xs px-2 py-0.5 transition-colors ${
+              aria-pressed={labels.includes(label)}
+              className={`cursor-pointer text-xs px-2 py-0.5 rounded-md border transition-colors ${
                 labels.includes(label)
                   ? 'bg-signal-green/20 text-signal-green border-signal-green/40 hover:bg-signal-green/30'
                   : 'border-border-muted text-text-tertiary hover:bg-surface-hover hover:text-text-secondary'
@@ -146,7 +124,7 @@ export function MetadataFilterBar({
               onClick={() => toggleLabel(label)}
             >
               {label}
-            </Badge>
+            </button>
           ))}
         </div>
       )}

--- a/frontend/src/components/shared/MetadataFilterBar.tsx
+++ b/frontend/src/components/shared/MetadataFilterBar.tsx
@@ -51,7 +51,7 @@ export function MetadataFilterBar({
       const allLabels = new Set<string>()
       for (const m of data) {
         if (m.team) teams.add(m.team)
-        if (m.tier) tiers.add(m.tier)
+        if (m.tier != null) tiers.add(String(m.tier))
         if (m.version) versions.add(m.version)
         for (const l of m.labels) allLabels.add(l)
       }
@@ -83,7 +83,13 @@ export function MetadataFilterBar({
   }, [labels, onLabelsChange])
 
   // Don't render if no metadata options exist
-  if (options.teams.length === 0 && options.tiers.length === 0 && options.versions.length === 0 && options.allLabels.length === 0) {
+  const noMetadataOptions =
+    options.teams.length === 0 &&
+    options.tiers.length === 0 &&
+    options.versions.length === 0 &&
+    options.allLabels.length === 0
+
+  if (!hasFilters && noMetadataOptions) {
     return null
   }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from '@/lib/api'
 import { GITHUB_REPO_URL } from '@/lib/constants'
-import type { DashboardJob } from '@/types'
+import type { DashboardJob, DashboardJobWithMetadata } from '@/types'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -37,6 +37,8 @@ import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
 import { useTableSort } from '@/lib/useTableSort'
 import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
+import { MetadataFilterBar } from '@/components/shared/MetadataFilterBar'
+import { MetadataBadges } from '@/components/shared/MetadataBadges'
 
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
@@ -105,7 +107,7 @@ function getJobDisplayName(job: DashboardJob | null | undefined): string {
 export function DashboardPage() {
   const navigate = useNavigate()
   const { isAdmin } = useAuth()
-  const [jobs, setJobs] = useState<DashboardJob[]>([])
+  const [jobs, setJobs] = useState<DashboardJobWithMetadata[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState(STATUS_FILTER_ALL)
@@ -115,6 +117,29 @@ export function DashboardPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const dateFrom = searchParams.get('date_from') ?? ''
   const dateTo = searchParams.get('date_to') ?? ''
+
+  // Metadata filter state — persisted in URL query params
+  const metaTeam = searchParams.get('team') ?? ''
+  const metaTier = searchParams.get('tier') ?? ''
+  const metaVersion = searchParams.get('version') ?? ''
+  const metaLabels = searchParams.getAll('label')
+  const setMetaParam = useCallback((key: string, value: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      if (value) next.set(key, value)
+      else next.delete(key)
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
+  const setMetaLabels = useCallback((labels: string[]) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.delete('label')
+      for (const l of labels) next.append('label', l)
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
+  const hasMetadataFilters = !!(metaTeam || metaTier || metaVersion || metaLabels.length > 0)
   const setDateFrom = useCallback((value: string) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
@@ -165,7 +190,15 @@ export function DashboardPage() {
     inFlightRef.current = true
     const thisSeq = ++fetchSeqRef.current
     try {
-      const data = await api.get<DashboardJob[]>('/api/dashboard')
+      let url = '/api/dashboard/filtered'
+      const params = new URLSearchParams()
+      if (metaTeam) params.set('team', metaTeam)
+      if (metaTier) params.set('tier', metaTier)
+      if (metaVersion) params.set('version', metaVersion)
+      for (const l of metaLabels) params.append('label', l)
+      const qs = params.toString()
+      if (qs) url += `?${qs}`
+      const data = await api.get<DashboardJobWithMetadata[]>(url)
       if (thisSeq === fetchSeqRef.current) {
         setError(null)
         setJobs(data)
@@ -180,14 +213,14 @@ export function DashboardPage() {
         setLoading(false)
       }
     }
-  }, [])
+  }, [metaTeam, metaTier, metaVersion, metaLabels])
 
   useEffect(() => {
     fetchJobs()
     const interval = setInterval(fetchJobs, 10_000)
     return () => clearInterval(interval)
   }, [fetchJobs])
-  useEffect(() => { setPage(1) }, [search, statusFilter, perPage, dateFrom, dateTo])
+  useEffect(() => { setPage(1) }, [search, statusFilter, perPage, dateFrom, dateTo, metaTeam, metaTier, metaVersion, metaLabels])
 
   const filtered = useMemo(() => {
     const fromBound = dateFrom ? utcStartOfDateInput(dateFrom) : null
@@ -398,6 +431,18 @@ export function DashboardPage() {
           </div>
         </div>
 
+        {/* Metadata filters */}
+        <MetadataFilterBar
+          team={metaTeam}
+          tier={metaTier}
+          version={metaVersion}
+          labels={metaLabels}
+          onTeamChange={(v) => setMetaParam('team', v)}
+          onTierChange={(v) => setMetaParam('tier', v)}
+          onVersionChange={(v) => setMetaParam('version', v)}
+          onLabelsChange={setMetaLabels}
+        />
+
         {/* Bulk result message */}
         {bulkResultMessage && (
           <div role="alert" className="flex items-center justify-between rounded-lg border border-signal-red/30 bg-signal-red/10 px-4 py-3 text-sm text-signal-red">
@@ -430,7 +475,7 @@ export function DashboardPage() {
         ) : pageJobs.length === 0 && (!error || jobs.length > 0) ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-border-muted bg-surface-card py-16 text-center animate-fade-in">
             <p className="text-text-secondary">
-              {search || statusFilter !== STATUS_FILTER_ALL || dateFrom || dateTo
+              {search || statusFilter !== STATUS_FILTER_ALL || dateFrom || dateTo || hasMetadataFilters
                 ? 'No jobs match your filters.'
                 : 'No analysis runs yet.'}
             </p>
@@ -506,6 +551,7 @@ export function DashboardPage() {
                         {job.build_number !== undefined && (
                           <span className="ml-2 font-mono text-xs text-text-tertiary">#{job.build_number}</span>
                         )}
+                        <MetadataBadges metadata={job.metadata} />
                       </div>
                       {failureHint && (
                         <Tooltip>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -122,7 +122,7 @@ export function DashboardPage() {
   const metaTeam = searchParams.get('team') ?? ''
   const metaTier = searchParams.get('tier') ?? ''
   const metaVersion = searchParams.get('version') ?? ''
-  const metaLabels = searchParams.getAll('label')
+  const metaLabels = useMemo(() => searchParams.getAll('label'), [searchParams])
   const setMetaParam = useCallback((key: string, value: string) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
@@ -183,11 +183,8 @@ export function DashboardPage() {
   }, [isAdmin, selectedIds])
 
   const fetchSeqRef = useRef(0)
-  const inFlightRef = useRef(false)
 
   const fetchJobs = useCallback(async () => {
-    if (inFlightRef.current) return
-    inFlightRef.current = true
     const thisSeq = ++fetchSeqRef.current
     try {
       let url = '/api/dashboard/filtered'
@@ -208,7 +205,6 @@ export function DashboardPage() {
         setError(err instanceof Error ? err.message : 'Failed to load dashboard')
       }
     } finally {
-      inFlightRef.current = false
       if (thisSeq === fetchSeqRef.current) {
         setLoading(false)
       }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -309,3 +309,17 @@ export interface CommentEnrichment {
   key: string
   status: string
 }
+
+// -- Job Metadata ---------------------------------------------------
+
+export interface JobMetadata {
+  job_name: string
+  team: string | null
+  tier: string | null
+  version: string | null
+  labels: string[]
+}
+
+export interface DashboardJobWithMetadata extends DashboardJob {
+  metadata?: JobMetadata | null
+}

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -693,3 +693,55 @@ class JJIClient:
         return self._request(
             "PUT", f"/results/{job_id}/override-classification", json=payload
         )
+
+    # -- Job Metadata ---------------------------------------------------------
+
+    def list_jobs_metadata(
+        self,
+        team: str = "",
+        tier: str = "",
+        version: str = "",
+        labels: list[str] | None = None,
+    ) -> list[dict]:
+        """List job metadata with optional filters. GET /api/jobs/metadata"""
+        params: dict = {
+            "team": team,
+            "tier": tier,
+            "version": version,
+        }
+        if labels:
+            params["label"] = labels
+        return self._request("GET", "/api/jobs/metadata", params=params)
+
+    def get_job_metadata(self, job_name: str) -> dict:
+        """Get metadata for a job. GET /api/jobs/{job_name}/metadata"""
+        return self._request("GET", f"/api/jobs/{job_name}/metadata")
+
+    def set_job_metadata(
+        self,
+        job_name: str,
+        *,
+        team: str = "",
+        tier: str = "",
+        version: str = "",
+        labels: list[str] | None = None,
+    ) -> dict:
+        """Set metadata for a job. PUT /api/jobs/{job_name}/metadata"""
+        body: dict = {}
+        if team:
+            body["team"] = team
+        if tier:
+            body["tier"] = tier
+        if version:
+            body["version"] = version
+        if labels is not None:
+            body["labels"] = labels
+        return self._request("PUT", f"/api/jobs/{job_name}/metadata", json=body)
+
+    def delete_job_metadata(self, job_name: str) -> dict:
+        """Delete metadata for a job. DELETE /api/jobs/{job_name}/metadata"""
+        return self._request("DELETE", f"/api/jobs/{job_name}/metadata")
+
+    def bulk_set_metadata(self, items: list[dict]) -> dict:
+        """Bulk import job metadata. PUT /api/jobs/metadata/bulk"""
+        return self._request("PUT", "/api/jobs/metadata/bulk", json={"items": items})

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1844,6 +1844,10 @@ def admin_users_change_role(
 # -- Metadata -----------------------------------------------------------------
 
 
+_METADATA_COLUMNS = ["job_name", "team", "tier", "version", "labels"]
+_METADATA_COLUMN_LABELS = {"job_name": "JOB NAME"}
+
+
 @metadata_app.command("list")
 def metadata_list(
     team: str = typer.Option("", "--team", help="Filter by team."),
@@ -1860,8 +1864,8 @@ def metadata_list(
         lambda c: c.list_jobs_metadata(
             team=team, tier=tier, version=version, labels=label or None
         ),
-        columns=["job_name", "team", "tier", "version", "labels"],
-        labels={"job_name": "JOB NAME"},
+        columns=_METADATA_COLUMNS,
+        labels=_METADATA_COLUMN_LABELS,
     )
 
 
@@ -1874,7 +1878,7 @@ def metadata_get(
     _run_client_command(
         json_output,
         lambda c: c.get_job_metadata(job_name),
-        columns=["job_name", "team", "tier", "version", "labels"],
+        columns=_METADATA_COLUMNS,
     )
 
 
@@ -1945,6 +1949,9 @@ def metadata_import(
                 "Error: PyYAML is required for YAML files. Install with: pip install pyyaml",
                 err=True,
             )
+            raise typer.Exit(code=1) from None
+        except yaml.YAMLError as exc:
+            typer.echo(f"Error: invalid YAML: {exc}", err=True)
             raise typer.Exit(code=1) from None
     else:
         try:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1943,7 +1943,7 @@ def metadata_import(
     content = path.read_text(encoding="utf-8")
     items: list[dict] = []
 
-    if path.suffix in (".yaml", ".yml"):
+    if path.suffix.lower() in (".yaml", ".yml"):
         try:
             import yaml
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1846,6 +1846,12 @@ def admin_users_change_role(
 
 _METADATA_COLUMNS = ["job_name", "team", "tier", "version", "labels"]
 _METADATA_COLUMN_LABELS = {"job_name": "JOB NAME"}
+_METADATA_FILTER_LABEL_OPTION = typer.Option(
+    [], "--label", "-l", help="Filter by label (can repeat)."
+)
+_METADATA_SET_LABEL_OPTION = typer.Option(
+    [], "--label", "-l", help="Label (can repeat)."
+)
 
 
 @metadata_app.command("list")
@@ -1853,9 +1859,7 @@ def metadata_list(
     team: str = typer.Option("", "--team", help="Filter by team."),
     tier: str = typer.Option("", "--tier", help="Filter by tier."),
     version: str = typer.Option("", "--version", help="Filter by version."),
-    label: list[str] = typer.Option(
-        [], "--label", "-l", help="Filter by label (can repeat)."
-    ),
+    label: list[str] = _METADATA_FILTER_LABEL_OPTION,
     json_output: bool = _JSON_OPTION,
 ):
     """List job metadata with optional filters."""
@@ -1888,7 +1892,7 @@ def metadata_set(
     team: str = typer.Option("", "--team", help="Team owning this job."),
     tier: str = typer.Option("", "--tier", help="Service tier."),
     version: str = typer.Option("", "--version", help="Version label."),
-    label: list[str] = typer.Option([], "--label", "-l", help="Label (can repeat)."),
+    label: list[str] = _METADATA_SET_LABEL_OPTION,
     json_output: bool = _JSON_OPTION,
 ):
     """Set or update metadata for a job."""

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1846,12 +1846,6 @@ def admin_users_change_role(
 
 _METADATA_COLUMNS = ["job_name", "team", "tier", "version", "labels"]
 _METADATA_COLUMN_LABELS = {"job_name": "JOB NAME"}
-_METADATA_FILTER_LABEL_OPTION = typer.Option(
-    [], "--label", "-l", help="Filter by label (can repeat)."
-)
-_METADATA_SET_LABEL_OPTION = typer.Option(
-    [], "--label", "-l", help="Label (can repeat)."
-)
 
 
 @metadata_app.command("list")
@@ -1859,7 +1853,9 @@ def metadata_list(
     team: str = typer.Option("", "--team", help="Filter by team."),
     tier: str = typer.Option("", "--tier", help="Filter by tier."),
     version: str = typer.Option("", "--version", help="Filter by version."),
-    label: list[str] = _METADATA_FILTER_LABEL_OPTION,
+    label: list[str] = typer.Option(  # noqa: B008
+        [], "--label", "-l", help="Filter by label (can repeat)."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """List job metadata with optional filters."""
@@ -1892,7 +1888,9 @@ def metadata_set(
     team: str = typer.Option("", "--team", help="Team owning this job."),
     tier: str = typer.Option("", "--tier", help="Service tier."),
     version: str = typer.Option("", "--version", help="Version label."),
-    label: list[str] = _METADATA_SET_LABEL_OPTION,
+    label: list[str] = typer.Option(  # noqa: B008
+        [], "--label", "-l", help="Label (can repeat)."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Set or update metadata for a job."""

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -35,10 +35,13 @@ auth_app = typer.Typer(help="Authentication commands.", no_args_is_help=True)
 admin_app = typer.Typer(help="Admin management commands.", no_args_is_help=True)
 admin_users_app = typer.Typer(help="Manage admin users.", no_args_is_help=True)
 
+metadata_app = typer.Typer(help="Manage job metadata.", no_args_is_help=True)
+
 app.add_typer(results_app, name="results")
 app.add_typer(history_app, name="history")
 app.add_typer(comments_app, name="comments")
 app.add_typer(classifications_app, name="classifications")
+app.add_typer(metadata_app, name="metadata")
 app.add_typer(config_app, name="config")
 app.add_typer(auth_app, name="auth")
 app.add_typer(admin_app, name="admin")
@@ -1836,6 +1839,134 @@ def admin_users_change_role(
             typer.echo(
                 "\u26a0\ufe0f  Save this API key now \u2014 it cannot be retrieved later."
             )
+
+
+# -- Metadata -----------------------------------------------------------------
+
+
+@metadata_app.command("list")
+def metadata_list(
+    team: str = typer.Option("", "--team", help="Filter by team."),
+    tier: str = typer.Option("", "--tier", help="Filter by tier."),
+    version: str = typer.Option("", "--version", help="Filter by version."),
+    label: list[str] = typer.Option(
+        [], "--label", "-l", help="Filter by label (can repeat)."
+    ),
+    json_output: bool = _JSON_OPTION,
+):
+    """List job metadata with optional filters."""
+    _run_client_command(
+        json_output,
+        lambda c: c.list_jobs_metadata(
+            team=team, tier=tier, version=version, labels=label or None
+        ),
+        columns=["job_name", "team", "tier", "version", "labels"],
+        labels={"job_name": "JOB NAME"},
+    )
+
+
+@metadata_app.command("get")
+def metadata_get(
+    job_name: str = typer.Argument(help="Job name."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Show metadata for a specific job."""
+    _run_client_command(
+        json_output,
+        lambda c: c.get_job_metadata(job_name),
+        columns=["job_name", "team", "tier", "version", "labels"],
+    )
+
+
+@metadata_app.command("set")
+def metadata_set(
+    job_name: str = typer.Argument(help="Job name."),
+    team: str = typer.Option("", "--team", help="Team owning this job."),
+    tier: str = typer.Option("", "--tier", help="Service tier."),
+    version: str = typer.Option("", "--version", help="Version label."),
+    label: list[str] = typer.Option([], "--label", "-l", help="Label (can repeat)."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Set or update metadata for a job."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.set_job_metadata(
+            job_name, team=team, tier=tier, version=version, labels=label or None
+        ),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Metadata set for {data.get('job_name', job_name)}")
+
+
+@metadata_app.command("delete")
+def metadata_delete(
+    job_name: str = typer.Argument(help="Job name."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Delete metadata for a job."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.delete_job_metadata(job_name),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        typer.echo(f"Metadata deleted for {data.get('job_name', job_name)}")
+
+
+@metadata_app.command("import")
+def metadata_import(
+    file_path: str = typer.Argument(help="Path to JSON or YAML file."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Bulk import metadata from a JSON or YAML file.
+
+    File format: a list of objects with job_name, team, tier, version, labels.
+    """
+    import json as json_mod
+    from pathlib import Path
+
+    _set_json(json_output)
+    path = Path(file_path)
+    if not path.exists():
+        typer.echo(f"Error: file not found: {file_path}", err=True)
+        raise typer.Exit(code=1)
+
+    content = path.read_text(encoding="utf-8")
+    items: list[dict] = []
+
+    if path.suffix in (".yaml", ".yml"):
+        try:
+            import yaml
+
+            items = yaml.safe_load(content)
+        except ImportError:
+            typer.echo(
+                "Error: PyYAML is required for YAML files. Install with: pip install pyyaml",
+                err=True,
+            )
+            raise typer.Exit(code=1) from None
+    else:
+        try:
+            items = json_mod.loads(content)
+        except json_mod.JSONDecodeError as exc:
+            typer.echo(f"Error: invalid JSON: {exc}", err=True)
+            raise typer.Exit(code=1) from None
+
+    if not isinstance(items, list):
+        typer.echo("Error: file must contain a JSON/YAML array of objects.", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        client = _get_client()
+        data = client.bulk_set_metadata(items)
+    except JJIError as err:
+        _handle_error(err)
+
+    if _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
+    else:
+        typer.echo(f"Imported {data.get('updated', 0)} metadata entries.")
 
 
 # -- Config -------------------------------------------------------------------

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -69,11 +69,13 @@ from jenkins_job_insight.models import (
     AnalyzeRequest,
     BaseAnalysisRequest,
     BulkDeleteRequest,
+    BulkJobMetadataRequest,
     ChildJobAnalysis,
     ClassifyTestRequest,
     CreateIssueRequest,
     FailureAnalysis,
     FailureAnalysisResult,
+    JobMetadataInput,
     OverrideClassificationRequest,
     PreviewIssueRequest,
     ReportPortalPushResult,
@@ -4071,6 +4073,117 @@ async def rotate_key_endpoint(request: Request, username: str) -> JSONResponse:
         content={"username": username, "new_api_key": new_key},
         headers={"Cache-Control": "no-store"},
     )
+
+
+# -- Job Metadata Endpoints ---------------------------------------------------
+
+
+@app.get("/api/jobs/metadata")
+async def list_jobs_metadata(
+    team: str = Query(default=""),
+    tier: str = Query(default=""),
+    version: str = Query(default=""),
+    label: list[str] = Query(default=[]),
+) -> list[dict]:
+    """List all job metadata, optionally filtered by team, tier, version, or labels."""
+    logger.debug(
+        f"GET /api/jobs/metadata: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
+    )
+    return await storage.list_jobs_with_metadata(
+        team=team, tier=tier, version=version, labels=label or None
+    )
+
+
+@app.get("/api/jobs/{job_name:path}/metadata")
+async def get_job_metadata_endpoint(job_name: str) -> dict:
+    """Get metadata for a specific job."""
+    logger.debug(f"GET /api/jobs/{job_name}/metadata")
+    result = await storage.get_job_metadata(job_name)
+    if not result:
+        raise HTTPException(status_code=404, detail=f"No metadata for job '{job_name}'")
+    return result
+
+
+@app.put("/api/jobs/{job_name:path}/metadata")
+async def set_job_metadata_endpoint(
+    job_name: str,
+    body: JobMetadataInput,
+) -> dict:
+    """Set or update metadata for a job."""
+    logger.debug(f"PUT /api/jobs/{job_name}/metadata")
+    return await storage.set_job_metadata(
+        job_name,
+        team=body.team,
+        tier=body.tier,
+        version=body.version,
+        labels=body.labels,
+    )
+
+
+@app.delete("/api/jobs/{job_name:path}/metadata")
+async def delete_job_metadata_endpoint(job_name: str) -> dict:
+    """Delete metadata for a job."""
+    logger.debug(f"DELETE /api/jobs/{job_name}/metadata")
+    deleted = await storage.delete_job_metadata(job_name)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"No metadata for job '{job_name}'")
+    return {"status": "deleted", "job_name": job_name}
+
+
+@app.put("/api/jobs/metadata/bulk")
+async def bulk_set_job_metadata(
+    body: BulkJobMetadataRequest,
+) -> dict:
+    """Bulk import job metadata."""
+    logger.debug(f"PUT /api/jobs/metadata/bulk: {len(body.items)} items")
+    items = [item.model_dump() for item in body.items]
+    return await storage.bulk_set_metadata(items)
+
+
+@app.get("/api/dashboard/filtered")
+async def api_dashboard_filtered(
+    team: str = Query(default=""),
+    tier: str = Query(default=""),
+    version: str = Query(default=""),
+    label: list[str] = Query(default=[]),
+) -> list[dict]:
+    """Return dashboard job list filtered by metadata.
+
+    Joins dashboard results with job_metadata. When no filters are
+    provided, returns all jobs (same as /api/dashboard but with
+    metadata attached).
+    """
+    logger.debug(
+        f"GET /api/dashboard/filtered: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
+    )
+    jobs = await list_results_for_dashboard()
+
+    # If no filters, attach metadata and return all
+    has_filters = bool(team or tier or version or label)
+
+    # Build a lookup of job metadata
+    all_metadata = await storage.list_jobs_with_metadata(
+        team=team if has_filters else "",
+        tier=tier if has_filters else "",
+        version=version if has_filters else "",
+        labels=label if has_filters and label else None,
+    )
+    metadata_by_name = {m["job_name"]: m for m in all_metadata}
+
+    if has_filters:
+        # Only include jobs whose job_name matches filtered metadata
+        filtered_names = set(metadata_by_name.keys())
+        jobs = [j for j in jobs if j.get("job_name", "") in filtered_names]
+
+    # Attach metadata to each job
+    for job in jobs:
+        jn = job.get("job_name", "")
+        if jn in metadata_by_name:
+            job["metadata"] = metadata_by_name[jn]
+        else:
+            job["metadata"] = None
+
+    return jobs
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4088,11 +4088,10 @@ async def _metadata_filters(
     return {"team": team, "tier": tier, "version": version, "label": label or []}
 
 
-@app.get("/api/jobs/metadata")
-async def list_jobs_metadata(
-    filters: Annotated[dict, Depends(_metadata_filters)],
-) -> list[dict]:
-    """List all job metadata, optionally filtered by team, tier, version, or labels."""
+def _unpack_metadata_filters(
+    filters: dict, endpoint: str
+) -> tuple[str, str, str, list[str]]:
+    """Unpack metadata filter dict and log at DEBUG level."""
     team, tier, version, label = (
         filters["team"],
         filters["tier"],
@@ -4100,7 +4099,23 @@ async def list_jobs_metadata(
         filters["label"],
     )
     logger.debug(
-        f"GET /api/jobs/metadata: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
+        "%s: team=%r, tier=%r, version=%r, label=%r",
+        endpoint,
+        team,
+        tier,
+        version,
+        label,
+    )
+    return team, tier, version, label
+
+
+@app.get("/api/jobs/metadata")
+async def list_jobs_metadata(
+    filters: Annotated[dict, Depends(_metadata_filters)],
+) -> list[dict]:
+    """List all job metadata, optionally filtered by team, tier, version, or labels."""
+    team, tier, version, label = _unpack_metadata_filters(
+        filters, "GET /api/jobs/metadata"
     )
     return await storage.list_jobs_with_metadata(
         team=team, tier=tier, version=version, labels=label or None
@@ -4159,8 +4174,11 @@ async def bulk_set_job_metadata(
     """Bulk import job metadata."""
     _require_admin(request)
     logger.debug(f"PUT /api/jobs/metadata/bulk: {len(body.items)} items")
-    items = [item.model_dump() for item in body.items]
-    return await storage.bulk_set_metadata(items)
+    try:
+        items = [item.model_dump() for item in body.items]
+        return await storage.bulk_set_metadata(items)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
 
 
 @app.get("/api/dashboard/filtered")
@@ -4173,14 +4191,8 @@ async def api_dashboard_filtered(
     provided, returns all jobs (same as /api/dashboard but with
     metadata attached).
     """
-    team, tier, version, label = (
-        filters["team"],
-        filters["tier"],
-        filters["version"],
-        filters["label"],
-    )
-    logger.debug(
-        f"GET /api/dashboard/filtered: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
+    team, tier, version, label = _unpack_metadata_filters(
+        filters, "GET /api/dashboard/filtered"
     )
     jobs = await list_results_for_dashboard()
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4078,14 +4078,27 @@ async def rotate_key_endpoint(request: Request, username: str) -> JSONResponse:
 # -- Job Metadata Endpoints ---------------------------------------------------
 
 
-@app.get("/api/jobs/metadata")
-async def list_jobs_metadata(
+async def _metadata_filters(
     team: str = Query(default=""),
     tier: str = Query(default=""),
     version: str = Query(default=""),
     label: list[str] = Query(default=[]),
+) -> dict:
+    """Shared dependency for metadata filter query parameters."""
+    return {"team": team, "tier": tier, "version": version, "label": label}
+
+
+@app.get("/api/jobs/metadata")
+async def list_jobs_metadata(
+    filters: dict = Depends(_metadata_filters),
 ) -> list[dict]:
     """List all job metadata, optionally filtered by team, tier, version, or labels."""
+    team, tier, version, label = (
+        filters["team"],
+        filters["tier"],
+        filters["version"],
+        filters["label"],
+    )
     logger.debug(
         f"GET /api/jobs/metadata: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
     )
@@ -4106,10 +4119,12 @@ async def get_job_metadata_endpoint(job_name: str) -> dict:
 
 @app.put("/api/jobs/{job_name:path}/metadata")
 async def set_job_metadata_endpoint(
+    request: Request,
     job_name: str,
     body: JobMetadataInput,
 ) -> dict:
     """Set or update metadata for a job."""
+    _require_admin(request)
     logger.debug(f"PUT /api/jobs/{job_name}/metadata")
     return await storage.set_job_metadata(
         job_name,
@@ -4121,8 +4136,9 @@ async def set_job_metadata_endpoint(
 
 
 @app.delete("/api/jobs/{job_name:path}/metadata")
-async def delete_job_metadata_endpoint(job_name: str) -> dict:
+async def delete_job_metadata_endpoint(request: Request, job_name: str) -> dict:
     """Delete metadata for a job."""
+    _require_admin(request)
     logger.debug(f"DELETE /api/jobs/{job_name}/metadata")
     deleted = await storage.delete_job_metadata(job_name)
     if not deleted:
@@ -4132,9 +4148,11 @@ async def delete_job_metadata_endpoint(job_name: str) -> dict:
 
 @app.put("/api/jobs/metadata/bulk")
 async def bulk_set_job_metadata(
+    request: Request,
     body: BulkJobMetadataRequest,
 ) -> dict:
     """Bulk import job metadata."""
+    _require_admin(request)
     logger.debug(f"PUT /api/jobs/metadata/bulk: {len(body.items)} items")
     items = [item.model_dump() for item in body.items]
     return await storage.bulk_set_metadata(items)
@@ -4142,10 +4160,7 @@ async def bulk_set_job_metadata(
 
 @app.get("/api/dashboard/filtered")
 async def api_dashboard_filtered(
-    team: str = Query(default=""),
-    tier: str = Query(default=""),
-    version: str = Query(default=""),
-    label: list[str] = Query(default=[]),
+    filters: dict = Depends(_metadata_filters),
 ) -> list[dict]:
     """Return dashboard job list filtered by metadata.
 
@@ -4153,6 +4168,12 @@ async def api_dashboard_filtered(
     provided, returns all jobs (same as /api/dashboard but with
     metadata attached).
     """
+    team, tier, version, label = (
+        filters["team"],
+        filters["tier"],
+        filters["version"],
+        filters["label"],
+    )
     logger.debug(
         f"GET /api/dashboard/filtered: team={team!r}, tier={tier!r}, version={version!r}, label={label!r}"
     )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4171,7 +4171,12 @@ async def bulk_set_job_metadata(
     request: Request,
     body: BulkJobMetadataRequest,
 ) -> dict:
-    """Bulk import job metadata."""
+    """Bulk import job metadata.
+
+    Unlike PUT /api/jobs/{job_name}/metadata which preserves omitted fields,
+    bulk import performs a full replace — omitted optional fields are set to
+    their defaults (None/empty list).
+    """
     _require_admin(request)
     logger.debug(f"PUT /api/jobs/metadata/bulk: {len(body.items)} items")
     try:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -10,7 +10,7 @@ import uuid
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Coroutine, Literal
+from typing import Annotated, Any, Coroutine, Literal
 from xml.etree.ElementTree import ParseError
 
 import httpx
@@ -4079,18 +4079,18 @@ async def rotate_key_endpoint(request: Request, username: str) -> JSONResponse:
 
 
 async def _metadata_filters(
-    team: str = Query(default=""),
-    tier: str = Query(default=""),
-    version: str = Query(default=""),
-    label: list[str] = Query(default=[]),
+    team: Annotated[str, Query()] = "",
+    tier: Annotated[str, Query()] = "",
+    version: Annotated[str, Query()] = "",
+    label: Annotated[list[str] | None, Query()] = None,
 ) -> dict:
     """Shared dependency for metadata filter query parameters."""
-    return {"team": team, "tier": tier, "version": version, "label": label}
+    return {"team": team, "tier": tier, "version": version, "label": label or []}
 
 
 @app.get("/api/jobs/metadata")
 async def list_jobs_metadata(
-    filters: dict = Depends(_metadata_filters),
+    filters: Annotated[dict, Depends(_metadata_filters)],
 ) -> list[dict]:
     """List all job metadata, optionally filtered by team, tier, version, or labels."""
     team, tier, version, label = (
@@ -4126,12 +4126,17 @@ async def set_job_metadata_endpoint(
     """Set or update metadata for a job."""
     _require_admin(request)
     logger.debug(f"PUT /api/jobs/{job_name}/metadata")
+    current = await storage.get_job_metadata(job_name) or {}
     return await storage.set_job_metadata(
         job_name,
-        team=body.team,
-        tier=body.tier,
-        version=body.version,
-        labels=body.labels,
+        team=body.team if "team" in body.model_fields_set else current.get("team"),
+        tier=body.tier if "tier" in body.model_fields_set else current.get("tier"),
+        version=body.version
+        if "version" in body.model_fields_set
+        else current.get("version"),
+        labels=body.labels
+        if "labels" in body.model_fields_set
+        else current.get("labels", []),
     )
 
 
@@ -4160,7 +4165,7 @@ async def bulk_set_job_metadata(
 
 @app.get("/api/dashboard/filtered")
 async def api_dashboard_filtered(
-    filters: dict = Depends(_metadata_filters),
+    filters: Annotated[dict, Depends(_metadata_filters)],
 ) -> list[dict]:
     """Return dashboard job list filtered by metadata.
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -695,3 +695,51 @@ class BulkDeleteRequest(BaseModel):
         max_length=500,
         description="Job IDs to delete (1-500 per request).",
     )
+
+
+class JobMetadata(BaseModel):
+    """Metadata for a Jenkins job used for filtering and organization."""
+
+    job_name: str = Field(description="Jenkins job name (primary key)")
+    team: str | None = Field(default=None, description="Team owning this job")
+    tier: str | None = Field(
+        default=None, description="Service tier (e.g. critical, standard, low)"
+    )
+    version: str | None = Field(default=None, description="Version or release label")
+    labels: list[str] = Field(
+        default_factory=list, description="Arbitrary labels for categorization"
+    )
+
+
+class JobMetadataInput(BaseModel):
+    """Input model for setting job metadata (no job_name — taken from URL path)."""
+
+    team: str | None = Field(default=None, description="Team owning this job")
+    tier: str | None = Field(
+        default=None, description="Service tier (e.g. critical, standard, low)"
+    )
+    version: str | None = Field(default=None, description="Version or release label")
+    labels: list[str] = Field(
+        default_factory=list, description="Arbitrary labels for categorization"
+    )
+
+
+class BulkJobMetadataEntry(BaseModel):
+    """A single entry in a bulk metadata import."""
+
+    job_name: str = Field(description="Jenkins job name")
+    team: str | None = Field(default=None)
+    tier: str | None = Field(default=None)
+    version: str | None = Field(default=None)
+    labels: list[str] = Field(default_factory=list)
+
+
+class BulkJobMetadataRequest(BaseModel):
+    """Request body for bulk-importing job metadata."""
+
+    items: list[BulkJobMetadataEntry] = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Metadata entries to import (1-1000 per request).",
+    )

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -697,41 +697,31 @@ class BulkDeleteRequest(BaseModel):
     )
 
 
-class JobMetadata(BaseModel):
+class _JobMetadataFields(BaseModel):
+    """Shared metadata fields for job metadata request/response models."""
+
+    team: str | None = Field(default=None, description="Team owning this job")
+    tier: str | None = Field(
+        default=None, description="Service tier (e.g. critical, standard, low)"
+    )
+    version: str | None = Field(default=None, description="Version or release label")
+    labels: list[str] = Field(
+        default_factory=list, description="Arbitrary labels for categorization"
+    )
+
+
+class JobMetadata(_JobMetadataFields):
     """Metadata for a Jenkins job used for filtering and organization."""
 
     job_name: str = Field(description="Jenkins job name (primary key)")
-    team: str | None = Field(default=None, description="Team owning this job")
-    tier: str | None = Field(
-        default=None, description="Service tier (e.g. critical, standard, low)"
-    )
-    version: str | None = Field(default=None, description="Version or release label")
-    labels: list[str] = Field(
-        default_factory=list, description="Arbitrary labels for categorization"
-    )
 
 
-class JobMetadataInput(BaseModel):
+class JobMetadataInput(_JobMetadataFields):
     """Input model for setting job metadata (no job_name — taken from URL path)."""
 
-    team: str | None = Field(default=None, description="Team owning this job")
-    tier: str | None = Field(
-        default=None, description="Service tier (e.g. critical, standard, low)"
-    )
-    version: str | None = Field(default=None, description="Version or release label")
-    labels: list[str] = Field(
-        default_factory=list, description="Arbitrary labels for categorization"
-    )
 
-
-class BulkJobMetadataEntry(BaseModel):
+class BulkJobMetadataEntry(JobMetadata):
     """A single entry in a bulk metadata import."""
-
-    job_name: str = Field(description="Jenkins job name")
-    team: str | None = Field(default=None)
-    tier: str | None = Field(default=None)
-    version: str | None = Field(default=None)
-    labels: list[str] = Field(default_factory=list)
 
 
 class BulkJobMetadataRequest(BaseModel):

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2746,6 +2746,22 @@ def _job_metadata_row_to_dict(row) -> dict:
     return d
 
 
+async def _upsert_job_metadata_row(db: aiosqlite.Connection, item: dict) -> None:
+    """Upsert a single job metadata row."""
+    labels_json = json.dumps(item.get("labels") or [])
+    await db.execute(
+        "INSERT OR REPLACE INTO job_metadata (job_name, team, tier, version, labels) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            item["job_name"],
+            item.get("team"),
+            item.get("tier"),
+            item.get("version"),
+            labels_json,
+        ),
+    )
+
+
 async def set_job_metadata(
     job_name: str,
     *,
@@ -2768,12 +2784,16 @@ async def set_job_metadata(
     Returns:
         The stored metadata dict.
     """
-    labels_json = json.dumps(labels or [])
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "INSERT OR REPLACE INTO job_metadata (job_name, team, tier, version, labels) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (job_name, team, tier, version, labels_json),
+        await _upsert_job_metadata_row(
+            db,
+            {
+                "job_name": job_name,
+                "team": team,
+                "tier": tier,
+                "version": version,
+                "labels": labels or [],
+            },
         )
         await db.commit()
     return {
@@ -2838,7 +2858,7 @@ async def list_jobs_with_metadata(
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
-            f"SELECT job_name, team, tier, version, labels FROM job_metadata WHERE {where} ORDER BY job_name",
+            f"SELECT job_name, team, tier, version, labels FROM job_metadata WHERE {where} ORDER BY job_name",  # noqa: S608
             params,
         )
         rows = await cursor.fetchall()
@@ -2865,17 +2885,6 @@ async def bulk_set_metadata(items: list[dict]) -> dict:
     """
     async with aiosqlite.connect(DB_PATH) as db:
         for item in items:
-            labels_json = json.dumps(item.get("labels", []))
-            await db.execute(
-                "INSERT OR REPLACE INTO job_metadata (job_name, team, tier, version, labels) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (
-                    item["job_name"],
-                    item.get("team"),
-                    item.get("tier"),
-                    item.get("version"),
-                    labels_json,
-                ),
-            )
+            await _upsert_job_metadata_row(db, item)
         await db.commit()
     return {"updated": len(items)}

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -367,6 +367,23 @@ async def init_db() -> None:
             "CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions (expires_at)"
         )
 
+        # Job metadata table for filtering and organization
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS job_metadata (
+                job_name TEXT PRIMARY KEY,
+                team TEXT,
+                tier TEXT,
+                version TEXT,
+                labels TEXT NOT NULL DEFAULT '[]'
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jm_team ON job_metadata (team)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jm_tier ON job_metadata (tier)"
+        )
+
         await db.commit()
 
     # Backfill failure_history from existing results (runs once when table is empty).
@@ -2692,3 +2709,173 @@ async def get_user_tokens(username: str) -> dict[str, str]:
             "jira_email": decrypt_value(row[1] or ""),
             "jira_token": decrypt_value(row[2] or ""),
         }
+
+
+# --- Job Metadata ---
+
+
+async def get_job_metadata(job_name: str) -> dict | None:
+    """Get metadata for a specific job.
+
+    Args:
+        job_name: The Jenkins job name.
+
+    Returns:
+        Metadata dict if found, None otherwise.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT job_name, team, tier, version, labels FROM job_metadata WHERE job_name = ?",
+            (job_name,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        return _job_metadata_row_to_dict(row)
+
+
+def _job_metadata_row_to_dict(row) -> dict:
+    """Convert a job_metadata row to a dict, parsing the labels JSON."""
+    d = dict(row)
+    labels_raw = d.get("labels", "[]")
+    try:
+        d["labels"] = json.loads(labels_raw) if labels_raw else []
+    except (json.JSONDecodeError, TypeError):
+        d["labels"] = []
+    return d
+
+
+async def set_job_metadata(
+    job_name: str,
+    *,
+    team: str | None = None,
+    tier: str | None = None,
+    version: str | None = None,
+    labels: list[str] | None = None,
+) -> dict:
+    """Set or update metadata for a job.
+
+    Uses INSERT OR REPLACE to upsert.
+
+    Args:
+        job_name: The Jenkins job name.
+        team: Team owning this job.
+        tier: Service tier.
+        version: Version or release label.
+        labels: Arbitrary labels.
+
+    Returns:
+        The stored metadata dict.
+    """
+    labels_json = json.dumps(labels or [])
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO job_metadata (job_name, team, tier, version, labels) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (job_name, team, tier, version, labels_json),
+        )
+        await db.commit()
+    return {
+        "job_name": job_name,
+        "team": team,
+        "tier": tier,
+        "version": version,
+        "labels": labels or [],
+    }
+
+
+async def delete_job_metadata(job_name: str) -> bool:
+    """Delete metadata for a job.
+
+    Returns:
+        True if deleted, False if not found.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM job_metadata WHERE job_name = ?",
+            (job_name,),
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def list_jobs_with_metadata(
+    *,
+    team: str = "",
+    tier: str = "",
+    version: str = "",
+    labels: list[str] | None = None,
+) -> list[dict]:
+    """List all job metadata entries, optionally filtered.
+
+    Filters combine with AND logic. Multiple labels require all to match.
+
+    Args:
+        team: Filter by team (exact match).
+        tier: Filter by tier (exact match).
+        version: Filter by version (exact match).
+        labels: Filter by labels (all must be present).
+
+    Returns:
+        List of metadata dicts.
+    """
+    conditions: list[str] = []
+    params: list[str] = []
+
+    if team:
+        conditions.append("team = ?")
+        params.append(team)
+    if tier:
+        conditions.append("tier = ?")
+        params.append(tier)
+    if version:
+        conditions.append("version = ?")
+        params.append(version)
+
+    where = " AND ".join(conditions) if conditions else "1=1"
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            f"SELECT job_name, team, tier, version, labels FROM job_metadata WHERE {where} ORDER BY job_name",
+            params,
+        )
+        rows = await cursor.fetchall()
+
+    result = [_job_metadata_row_to_dict(row) for row in rows]
+
+    # Filter by labels in Python (JSON array matching)
+    if labels:
+        result = [
+            r for r in result if all(lbl in r.get("labels", []) for lbl in labels)
+        ]
+
+    return result
+
+
+async def bulk_set_metadata(items: list[dict]) -> dict:
+    """Bulk upsert job metadata.
+
+    Args:
+        items: List of dicts with job_name, team, tier, version, labels.
+
+    Returns:
+        Dict with 'updated' count.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        for item in items:
+            labels_json = json.dumps(item.get("labels", []))
+            await db.execute(
+                "INSERT OR REPLACE INTO job_metadata (job_name, team, tier, version, labels) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    item["job_name"],
+                    item.get("team"),
+                    item.get("tier"),
+                    item.get("version"),
+                    labels_json,
+                ),
+            )
+        await db.commit()
+    return {"updated": len(items)}

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2740,7 +2740,8 @@ def _job_metadata_row_to_dict(row) -> dict:
     d = dict(row)
     labels_raw = d.get("labels", "[]")
     try:
-        d["labels"] = json.loads(labels_raw) if labels_raw else []
+        parsed = json.loads(labels_raw) if labels_raw else []
+        d["labels"] = parsed if isinstance(parsed, list) else []
     except (json.JSONDecodeError, TypeError):
         d["labels"] = []
     return d
@@ -2883,6 +2884,11 @@ async def bulk_set_metadata(items: list[dict]) -> dict:
     Returns:
         Dict with 'updated' count.
     """
+    for idx, item in enumerate(items):
+        if not item.get("job_name"):
+            raise ValueError(
+                f"bulk_set_metadata: item at index {idx} is missing 'job_name'"
+            )
     async with aiosqlite.connect(DB_PATH) as db:
         for item in items:
             await _upsert_job_metadata_row(db, item)

--- a/tests/test_allow_list.py
+++ b/tests/test_allow_list.py
@@ -47,6 +47,7 @@ def _make_client(temp_db_path, allowed_users: str = "", admin_key: str = ""):
         if k not in {"ALLOWED_USERS", "ADMIN_KEY", "JJI_ENCRYPTION_KEY"}
     }
     env["SECURE_COOKIES"] = "false"
+    env["DB_PATH"] = str(temp_db_path)
     if allowed_users:
         env["ALLOWED_USERS"] = allowed_users
     if admin_key:

--- a/tests/test_debug_request_logging.py
+++ b/tests/test_debug_request_logging.py
@@ -170,7 +170,7 @@ class TestMaskSensitiveFields:
 
 
 @pytest.fixture
-def _mock_settings():
+def _mock_settings(temp_db_path):
     """Provide minimal env for Settings, matching test_main.py pattern."""
     env = {
         "JENKINS_URL": "https://jenkins.example.com",
@@ -178,6 +178,7 @@ def _mock_settings():
         "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
         "AI_PROVIDER": "claude",
         "AI_MODEL": "test-model",
+        "DB_PATH": str(temp_db_path),
     }
     with patch.dict(os.environ, env, clear=True):
         from jenkins_job_insight.config import get_settings

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -1,5 +1,6 @@
 """Tests for job metadata storage, API endpoints, and CLI commands."""
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -174,3 +175,151 @@ class TestJobMetadataStorage:
             fetched = await storage.get_job_metadata("my-job")
             assert fetched is not None
             assert fetched["labels"] == []
+
+
+# --- API endpoint tests ---
+
+
+@pytest.fixture
+def mock_settings():
+    env = {
+        "JENKINS_URL": "https://jenkins.example.com",
+        "JENKINS_USER": "testuser",
+        "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
+        "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
+    }
+    with patch.dict(os.environ, env, clear=True):
+        from jenkins_job_insight.config import get_settings
+
+        get_settings.cache_clear()
+        try:
+            yield
+        finally:
+            get_settings.cache_clear()
+
+
+@pytest.fixture
+def api_client(mock_settings, temp_db_path: Path):
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        from starlette.testclient import TestClient
+        from jenkins_job_insight.main import app
+
+        with TestClient(app) as client:
+            yield client
+
+
+class TestJobMetadataAPI:
+    """Tests for job metadata API endpoints."""
+
+    def test_set_and_get_metadata(self, api_client) -> None:
+        resp = api_client.put(
+            "/api/jobs/my-job/metadata",
+            json={"team": "platform", "tier": "critical", "labels": ["smoke"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["job_name"] == "my-job"
+        assert data["team"] == "platform"
+
+        resp = api_client.get("/api/jobs/my-job/metadata")
+        assert resp.status_code == 200
+        assert resp.json()["team"] == "platform"
+
+    def test_get_metadata_not_found(self, api_client) -> None:
+        resp = api_client.get("/api/jobs/nonexistent/metadata")
+        assert resp.status_code == 404
+
+    def test_delete_metadata(self, api_client) -> None:
+        api_client.put("/api/jobs/my-job/metadata", json={"team": "alpha"})
+        resp = api_client.delete("/api/jobs/my-job/metadata")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        resp = api_client.get("/api/jobs/my-job/metadata")
+        assert resp.status_code == 404
+
+    def test_delete_metadata_not_found(self, api_client) -> None:
+        resp = api_client.delete("/api/jobs/nonexistent/metadata")
+        assert resp.status_code == 404
+
+    def test_list_metadata(self, api_client) -> None:
+        api_client.put("/api/jobs/job-a/metadata", json={"team": "alpha"})
+        api_client.put("/api/jobs/job-b/metadata", json={"team": "beta"})
+
+        resp = api_client.get("/api/jobs/metadata")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+    def test_list_metadata_filter_by_team(self, api_client) -> None:
+        api_client.put("/api/jobs/job-a/metadata", json={"team": "alpha"})
+        api_client.put("/api/jobs/job-b/metadata", json={"team": "beta"})
+
+        resp = api_client.get("/api/jobs/metadata", params={"team": "alpha"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["team"] == "alpha"
+
+    def test_list_metadata_filter_by_label(self, api_client) -> None:
+        api_client.put(
+            "/api/jobs/job-a/metadata",
+            json={"labels": ["nightly", "smoke"]},
+        )
+        api_client.put(
+            "/api/jobs/job-b/metadata",
+            json={"labels": ["nightly"]},
+        )
+
+        resp = api_client.get(
+            "/api/jobs/metadata", params={"label": ["nightly", "smoke"]}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["job_name"] == "job-a"
+
+    def test_bulk_import(self, api_client) -> None:
+        resp = api_client.put(
+            "/api/jobs/metadata/bulk",
+            json={
+                "items": [
+                    {"job_name": "job-a", "team": "alpha"},
+                    {"job_name": "job-b", "team": "beta", "labels": ["ci"]},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == 2
+
+        resp = api_client.get("/api/jobs/job-b/metadata")
+        assert resp.status_code == 200
+        assert resp.json()["labels"] == ["ci"]
+
+    def test_dashboard_filtered_no_filters(self, api_client) -> None:
+        resp = api_client.get("/api/dashboard/filtered")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_dashboard_filtered_with_team(self, api_client) -> None:
+        # Set metadata for a job
+        api_client.put("/api/jobs/my-job/metadata", json={"team": "alpha"})
+
+        resp = api_client.get("/api/dashboard/filtered", params={"team": "alpha"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # Even if no analysis results, the response should be a list
+        assert isinstance(data, list)
+
+    def test_folder_style_job_name(self, api_client) -> None:
+        """Test that folder-style job names (with /) work correctly."""
+        resp = api_client.put(
+            "/api/jobs/folder/subfolder/my-job/metadata",
+            json={"team": "platform"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["job_name"] == "folder/subfolder/my-job"
+
+        resp = api_client.get("/api/jobs/folder/subfolder/my-job/metadata")
+        assert resp.status_code == 200
+        assert resp.json()["team"] == "platform"

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -519,18 +519,20 @@ class TestJobMetadataCLIClient:
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def reset_cli_state():
+    """Reset CLI state before each test to prevent cross-test pollution."""
+    _state.clear()
+    _state["server_url"] = CLI_TEST_BASE_URL
+    _state["username"] = "testuser"
+    _state["no_verify_ssl"] = False
+    _state["api_key"] = ""
+    yield
+    _state.clear()
+
+
 class TestMetadataCLICommands:
     """Tests for metadata CLI commands."""
-
-    @pytest.fixture(autouse=True)
-    def reset_cli_state(self):
-        _state.clear()
-        _state["server_url"] = CLI_TEST_BASE_URL
-        _state["username"] = "testuser"
-        _state["no_verify_ssl"] = False
-        _state["api_key"] = ""
-        yield
-        _state.clear()
 
     @patch("jenkins_job_insight.cli.main._get_client")
     def test_metadata_list(self, mock_get_client) -> None:

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -1,12 +1,18 @@
 """Tests for job metadata storage, API endpoints, and CLI commands."""
 
+import json as json_mod
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+from typer.testing import CliRunner
 
 from jenkins_job_insight import storage
+from jenkins_job_insight.cli.main import _state
+from jenkins_job_insight.cli.main import app as cli_app
+from tests.conftest import CLI_TEST_BASE_URL, make_test_client
 
 
 @pytest.fixture
@@ -323,3 +329,212 @@ class TestJobMetadataAPI:
         resp = api_client.get("/api/jobs/folder/subfolder/my-job/metadata")
         assert resp.status_code == 200
         assert resp.json()["team"] == "platform"
+
+
+# --- CLI client tests ---
+
+
+def _metadata_handler(request: httpx.Request) -> httpx.Response:
+    """Mock handler for metadata CLI client tests."""
+    path = request.url.path
+    method = request.method
+
+    if method == "GET" and path == "/api/jobs/metadata":
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "job_name": "job-a",
+                    "team": "alpha",
+                    "tier": None,
+                    "version": None,
+                    "labels": [],
+                }
+            ],
+        )
+    if method == "GET" and path == "/api/jobs/my-job/metadata":
+        return httpx.Response(
+            200,
+            json={
+                "job_name": "my-job",
+                "team": "platform",
+                "tier": "critical",
+                "version": None,
+                "labels": ["smoke"],
+            },
+        )
+    if method == "PUT" and path == "/api/jobs/my-job/metadata":
+        import json
+
+        body = json.loads(request.content)
+        body["job_name"] = "my-job"
+        return httpx.Response(200, json=body)
+    if method == "DELETE" and path == "/api/jobs/my-job/metadata":
+        return httpx.Response(200, json={"status": "deleted", "job_name": "my-job"})
+    if method == "PUT" and path == "/api/jobs/metadata/bulk":
+        import json
+
+        body = json.loads(request.content)
+        return httpx.Response(200, json={"updated": len(body.get("items", []))})
+    return httpx.Response(404, json={"detail": "Not found"})
+
+
+class TestJobMetadataCLIClient:
+    """Tests for job metadata CLI client methods."""
+
+    def test_list_jobs_metadata(self) -> None:
+        client = make_test_client(_metadata_handler)
+        data = client.list_jobs_metadata()
+        assert len(data) == 1
+        assert data[0]["team"] == "alpha"
+
+    def test_get_job_metadata(self) -> None:
+        client = make_test_client(_metadata_handler)
+        data = client.get_job_metadata("my-job")
+        assert data["team"] == "platform"
+        assert data["labels"] == ["smoke"]
+
+    def test_set_job_metadata(self) -> None:
+        client = make_test_client(_metadata_handler)
+        data = client.set_job_metadata("my-job", team="platform", labels=["ci"])
+        assert data["job_name"] == "my-job"
+
+    def test_delete_job_metadata(self) -> None:
+        client = make_test_client(_metadata_handler)
+        data = client.delete_job_metadata("my-job")
+        assert data["status"] == "deleted"
+
+    def test_bulk_set_metadata(self) -> None:
+        client = make_test_client(_metadata_handler)
+        data = client.bulk_set_metadata(
+            [
+                {"job_name": "job-a", "team": "alpha"},
+                {"job_name": "job-b", "team": "beta"},
+            ]
+        )
+        assert data["updated"] == 2
+
+
+# --- CLI command tests ---
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_state():
+    _state.clear()
+    _state["server_url"] = CLI_TEST_BASE_URL
+    _state["username"] = "testuser"
+    _state["no_verify_ssl"] = False
+    _state["api_key"] = ""
+    yield
+    _state.clear()
+
+
+class TestMetadataCLICommands:
+    """Tests for metadata CLI commands."""
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_list(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.list_jobs_metadata.return_value = [
+            {
+                "job_name": "job-a",
+                "team": "alpha",
+                "tier": None,
+                "version": None,
+                "labels": [],
+            }
+        ]
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(cli_app, ["metadata", "list"])
+        assert result.exit_code == 0
+        assert "job-a" in result.output
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_get(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.get_job_metadata.return_value = {
+            "job_name": "my-job",
+            "team": "platform",
+            "tier": "critical",
+            "version": None,
+            "labels": [],
+        }
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(cli_app, ["metadata", "get", "my-job"])
+        assert result.exit_code == 0
+        assert "platform" in result.output
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_set(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.set_job_metadata.return_value = {
+            "job_name": "my-job",
+            "team": "alpha",
+        }
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(
+            cli_app, ["metadata", "set", "my-job", "--team", "alpha"]
+        )
+        assert result.exit_code == 0
+        assert "Metadata set" in result.output
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_delete(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.delete_job_metadata.return_value = {
+            "status": "deleted",
+            "job_name": "my-job",
+        }
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(cli_app, ["metadata", "delete", "my-job"])
+        assert result.exit_code == 0
+        assert "Metadata deleted" in result.output
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_import_json(self, mock_get_client, tmp_path) -> None:
+        import json as json_mod
+
+        mock_client = MagicMock()
+        mock_client.bulk_set_metadata.return_value = {"updated": 2}
+        mock_get_client.return_value = mock_client
+
+        f = tmp_path / "metadata.json"
+        f.write_text(
+            json_mod.dumps(
+                [
+                    {"job_name": "job-a", "team": "alpha"},
+                    {"job_name": "job-b", "team": "beta"},
+                ]
+            )
+        )
+
+        result = runner.invoke(cli_app, ["metadata", "import", str(f)])
+        assert result.exit_code == 0
+        assert "Imported 2" in result.output
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_list_with_filters(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.list_jobs_metadata.return_value = []
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(
+            cli_app,
+            ["metadata", "list", "--team", "alpha", "--tier", "critical"],
+        )
+        assert result.exit_code == 0
+        mock_client.list_jobs_metadata.assert_called_once_with(
+            team="alpha", tier="critical", version="", labels=None
+        )
+
+    @patch("jenkins_job_insight.cli.main._get_client")
+    def test_metadata_list_json(self, mock_get_client) -> None:
+        mock_client = MagicMock()
+        mock_client.list_jobs_metadata.return_value = [{"job_name": "j"}]
+        mock_get_client.return_value = mock_client
+        result = runner.invoke(cli_app, ["metadata", "list", "--json"])
+        assert result.exit_code == 0
+        # JSON output should be parseable
+        parsed = json_mod.loads(result.output)
+        assert isinstance(parsed, list)

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -1,0 +1,176 @@
+"""Tests for job metadata storage, API endpoints, and CLI commands."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jenkins_job_insight import storage
+
+
+@pytest.fixture
+async def setup_test_db(temp_db_path: Path):
+    """Set up a test database with the path patched."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        await storage.init_db()
+        yield temp_db_path
+
+
+# --- Storage tests ---
+
+
+class TestJobMetadataStorage:
+    """Tests for job_metadata CRUD in storage.py."""
+
+    async def test_set_and_get_metadata(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            result = await storage.set_job_metadata(
+                "my-job",
+                team="platform",
+                tier="critical",
+                version="v1.0",
+                labels=["nightly", "smoke"],
+            )
+            assert result["job_name"] == "my-job"
+            assert result["team"] == "platform"
+            assert result["labels"] == ["nightly", "smoke"]
+
+            fetched = await storage.get_job_metadata("my-job")
+            assert fetched is not None
+            assert fetched["team"] == "platform"
+            assert fetched["tier"] == "critical"
+            assert fetched["labels"] == ["nightly", "smoke"]
+
+    async def test_get_metadata_not_found(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            result = await storage.get_job_metadata("nonexistent")
+            assert result is None
+
+    async def test_update_metadata(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("my-job", team="alpha")
+            await storage.set_job_metadata("my-job", team="beta", tier="low")
+            fetched = await storage.get_job_metadata("my-job")
+            assert fetched is not None
+            assert fetched["team"] == "beta"
+            assert fetched["tier"] == "low"
+
+    async def test_delete_metadata(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("my-job", team="platform")
+            deleted = await storage.delete_job_metadata("my-job")
+            assert deleted is True
+            assert await storage.get_job_metadata("my-job") is None
+
+    async def test_delete_metadata_not_found(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            deleted = await storage.delete_job_metadata("nonexistent")
+            assert deleted is False
+
+    async def test_list_all_metadata(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("job-a", team="alpha")
+            await storage.set_job_metadata("job-b", team="beta")
+            await storage.set_job_metadata("job-c", team="alpha")
+
+            all_items = await storage.list_jobs_with_metadata()
+            assert len(all_items) == 3
+
+    async def test_list_filter_by_team(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("job-a", team="alpha")
+            await storage.set_job_metadata("job-b", team="beta")
+            await storage.set_job_metadata("job-c", team="alpha")
+
+            filtered = await storage.list_jobs_with_metadata(team="alpha")
+            assert len(filtered) == 2
+            assert all(j["team"] == "alpha" for j in filtered)
+
+    async def test_list_filter_by_tier(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("job-a", tier="critical")
+            await storage.set_job_metadata("job-b", tier="low")
+
+            filtered = await storage.list_jobs_with_metadata(tier="critical")
+            assert len(filtered) == 1
+            assert filtered[0]["job_name"] == "job-a"
+
+    async def test_list_filter_by_version(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("job-a", version="v1.0")
+            await storage.set_job_metadata("job-b", version="v2.0")
+
+            filtered = await storage.list_jobs_with_metadata(version="v1.0")
+            assert len(filtered) == 1
+            assert filtered[0]["job_name"] == "job-a"
+
+    async def test_list_filter_by_labels(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("job-a", labels=["nightly", "smoke"])
+            await storage.set_job_metadata("job-b", labels=["nightly"])
+            await storage.set_job_metadata("job-c", labels=["regression"])
+
+            # Filter by single label
+            filtered = await storage.list_jobs_with_metadata(labels=["nightly"])
+            assert len(filtered) == 2
+
+            # Filter by multiple labels (AND logic)
+            filtered = await storage.list_jobs_with_metadata(
+                labels=["nightly", "smoke"]
+            )
+            assert len(filtered) == 1
+            assert filtered[0]["job_name"] == "job-a"
+
+    async def test_list_filter_combined(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata(
+                "job-a", team="alpha", tier="critical", labels=["nightly"]
+            )
+            await storage.set_job_metadata(
+                "job-b", team="alpha", tier="low", labels=["nightly"]
+            )
+            await storage.set_job_metadata(
+                "job-c", team="beta", tier="critical", labels=["nightly"]
+            )
+
+            filtered = await storage.list_jobs_with_metadata(
+                team="alpha", tier="critical"
+            )
+            assert len(filtered) == 1
+            assert filtered[0]["job_name"] == "job-a"
+
+    async def test_bulk_set_metadata(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            items = [
+                {"job_name": "job-a", "team": "alpha", "labels": ["smoke"]},
+                {"job_name": "job-b", "team": "beta", "tier": "critical"},
+            ]
+            result = await storage.bulk_set_metadata(items)
+            assert result["updated"] == 2
+
+            a = await storage.get_job_metadata("job-a")
+            assert a is not None
+            assert a["team"] == "alpha"
+            assert a["labels"] == ["smoke"]
+
+            b = await storage.get_job_metadata("job-b")
+            assert b is not None
+            assert b["team"] == "beta"
+            assert b["tier"] == "critical"
+
+    async def test_metadata_with_none_fields(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("my-job", team="alpha")
+            fetched = await storage.get_job_metadata("my-job")
+            assert fetched is not None
+            assert fetched["team"] == "alpha"
+            assert fetched["tier"] is None
+            assert fetched["version"] is None
+            assert fetched["labels"] == []
+
+    async def test_metadata_empty_labels(self, setup_test_db: Path) -> None:
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.set_job_metadata("my-job", labels=[])
+            fetched = await storage.get_job_metadata("my-job")
+            assert fetched is not None
+            assert fetched["labels"] == []

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -186,6 +186,9 @@ class TestJobMetadataStorage:
 # --- API endpoint tests ---
 
 
+_ADMIN_KEY = "test-admin-key-16chars"  # pragma: allowlist secret
+
+
 @pytest.fixture
 def mock_settings():
     env = {
@@ -193,6 +196,7 @@ def mock_settings():
         "JENKINS_USER": "testuser",
         "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
         "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
+        "ADMIN_KEY": _ADMIN_KEY,
     }
     with patch.dict(os.environ, env, clear=True):
         from jenkins_job_insight.config import get_settings
@@ -211,6 +215,24 @@ def api_client(mock_settings, temp_db_path: Path):
         from jenkins_job_insight.main import app
 
         with TestClient(app) as client:
+            # Inject admin auth header for mutation endpoints
+            _original_put = client.put
+            _original_delete = client.delete
+
+            def _put_with_auth(*args, **kwargs):
+                kwargs.setdefault("headers", {})["Authorization"] = (
+                    f"Bearer {_ADMIN_KEY}"
+                )
+                return _original_put(*args, **kwargs)
+
+            def _delete_with_auth(*args, **kwargs):
+                kwargs.setdefault("headers", {})["Authorization"] = (
+                    f"Bearer {_ADMIN_KEY}"
+                )
+                return _original_delete(*args, **kwargs)
+
+            client.put = _put_with_auth
+            client.delete = _delete_with_auth
             yield client
 
 

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -329,15 +329,53 @@ class TestJobMetadataAPI:
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
 
-    def test_dashboard_filtered_with_team(self, api_client) -> None:
-        # Set metadata for a job
-        api_client.put("/api/jobs/my-job/metadata", json={"team": "alpha"})
+    def test_dashboard_filtered_by_metadata(self, api_client, temp_db_path) -> None:
+        """Verify dashboard filter returns only jobs matching metadata."""
+        import asyncio
 
+        async def _seed():
+            with patch.object(storage, "DB_PATH", temp_db_path):
+                await storage.save_result(
+                    "id-alpha",
+                    "https://jenkins.example.com/job/alpha-job/1",
+                    "completed",
+                    {"job_name": "alpha-job", "build_number": 1, "failures": []},
+                )
+                await storage.save_result(
+                    "id-beta",
+                    "https://jenkins.example.com/job/beta-job/2",
+                    "completed",
+                    {"job_name": "beta-job", "build_number": 2, "failures": []},
+                )
+
+        asyncio.run(_seed())
+
+        # Attach metadata only to alpha-job
+        api_client.put("/api/jobs/alpha-job/metadata", json={"team": "alpha"})
+        api_client.put("/api/jobs/beta-job/metadata", json={"team": "beta"})
+
+        # Filter by team=alpha → only alpha-job returned
         resp = api_client.get("/api/dashboard/filtered", params={"team": "alpha"})
         assert resp.status_code == 200
         data = resp.json()
-        # Even if no analysis results, the response should be a list
-        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["job_name"] == "alpha-job"
+        assert data[0]["metadata"]["team"] == "alpha"
+
+    def test_partial_update_preserves_omitted_fields(self, api_client) -> None:
+        """PUT with a subset of fields should not clear the others."""
+        api_client.put(
+            "/api/jobs/my-job/metadata",
+            json={"team": "alpha", "tier": "critical", "labels": ["nightly"]},
+        )
+        # Update only team — tier and labels should be preserved
+        api_client.put("/api/jobs/my-job/metadata", json={"team": "beta"})
+        resp = api_client.get("/api/jobs/my-job/metadata")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["team"] == "beta"
+        assert data["tier"] == "critical"
+        assert data["labels"] == ["nightly"]
 
     def test_folder_style_job_name(self, api_client) -> None:
         """Test that folder-style job names (with /) work correctly."""
@@ -351,6 +389,44 @@ class TestJobMetadataAPI:
         resp = api_client.get("/api/jobs/folder/subfolder/my-job/metadata")
         assert resp.status_code == 200
         assert resp.json()["team"] == "platform"
+
+
+# --- Non-admin access tests ---
+
+
+@pytest.fixture
+def noauth_client(mock_settings, temp_db_path: Path):
+    """Test client with NO admin credentials."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        from starlette.testclient import TestClient
+        from jenkins_job_insight.main import app
+
+        with TestClient(app) as client:
+            yield client
+
+
+class TestJobMetadataNoAdmin:
+    """Mutation endpoints must return 403 without admin auth."""
+
+    def test_put_metadata_forbidden(self, noauth_client) -> None:
+        resp = noauth_client.put("/api/jobs/my-job/metadata", json={"team": "alpha"})
+        assert resp.status_code == 403
+
+    def test_delete_metadata_forbidden(self, noauth_client) -> None:
+        resp = noauth_client.delete("/api/jobs/my-job/metadata")
+        assert resp.status_code == 403
+
+    def test_bulk_put_metadata_forbidden(self, noauth_client) -> None:
+        resp = noauth_client.put(
+            "/api/jobs/metadata/bulk",
+            json={"items": [{"job_name": "j", "team": "t"}]},
+        )
+        assert resp.status_code == 403
+
+    def test_get_metadata_allowed(self, noauth_client) -> None:
+        """Read endpoints should work without admin auth."""
+        resp = noauth_client.get("/api/jobs/metadata")
+        assert resp.status_code == 200
 
 
 # --- CLI client tests ---

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -10,7 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from jenkins_job_insight import storage
-from jenkins_job_insight.cli.main import _state
+from jenkins_job_insight.cli.config import ServerConfig
 from jenkins_job_insight.cli.main import app as cli_app
 from tests.conftest import CLI_TEST_BASE_URL, make_test_client
 
@@ -519,25 +519,30 @@ class TestJobMetadataCLIClient:
 runner = CliRunner()
 
 
-@pytest.fixture(autouse=True)
-def reset_cli_state():
-    """Reset CLI state before each test to prevent cross-test pollution."""
-    _state.clear()
-    _state["server_url"] = CLI_TEST_BASE_URL
-    _state["username"] = "testuser"
-    _state["no_verify_ssl"] = False
-    _state["api_key"] = ""
-    yield
-    _state.clear()
-
-
 class TestMetadataCLICommands:
     """Tests for metadata CLI commands."""
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_list(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.list_jobs_metadata.return_value = [
+    @pytest.fixture(autouse=True)
+    def mock_client(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"JJI_SERVER": CLI_TEST_BASE_URL},
+                clear=True,
+            ),
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=ServerConfig(url=CLI_TEST_BASE_URL),
+            ),
+            patch("jenkins_job_insight.cli.main._get_client") as mock_get,
+        ):
+            client = MagicMock()
+            mock_get.return_value = client
+            self._mock_client = client
+            yield client
+
+    def test_metadata_list(self) -> None:
+        self._mock_client.list_jobs_metadata.return_value = [
             {
                 "job_name": "job-a",
                 "team": "alpha",
@@ -546,99 +551,44 @@ class TestMetadataCLICommands:
                 "labels": [],
             }
         ]
-        mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "list"])
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         assert "job-a" in result.output
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_get(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.get_job_metadata.return_value = {
+    def test_metadata_get(self) -> None:
+        self._mock_client.get_job_metadata.return_value = {
             "job_name": "my-job",
             "team": "platform",
             "tier": "critical",
             "version": None,
             "labels": [],
         }
-        mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "get", "my-job"])
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         assert "platform" in result.output
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_set(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.set_job_metadata.return_value = {
+    def test_metadata_set(self) -> None:
+        self._mock_client.set_job_metadata.return_value = {
             "job_name": "my-job",
             "team": "alpha",
         }
-        mock_get_client.return_value = mock_client
         result = runner.invoke(
             cli_app, ["metadata", "set", "my-job", "--team", "alpha"]
         )
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         assert "Metadata set" in result.output
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_delete(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.delete_job_metadata.return_value = {
+    def test_metadata_delete(self) -> None:
+        self._mock_client.delete_job_metadata.return_value = {
             "status": "deleted",
             "job_name": "my-job",
         }
-        mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "delete", "my-job"])
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         assert "Metadata deleted" in result.output
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_import_json(self, mock_get_client, tmp_path) -> None:
-        import json as json_mod
-
-        mock_client = MagicMock()
-        mock_client.bulk_set_metadata.return_value = {"updated": 2}
-        mock_get_client.return_value = mock_client
+    def test_metadata_import_json(self, tmp_path) -> None:
+        self._mock_client.bulk_set_metadata.return_value = {"updated": 2}
 
         f = tmp_path / "metadata.json"
         f.write_text(
@@ -651,59 +601,23 @@ class TestMetadataCLICommands:
         )
 
         result = runner.invoke(cli_app, ["metadata", "import", str(f)])
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         assert "Imported 2" in result.output
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_list_with_filters(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.list_jobs_metadata.return_value = []
-        mock_get_client.return_value = mock_client
+    def test_metadata_list_with_filters(self) -> None:
+        self._mock_client.list_jobs_metadata.return_value = []
         result = runner.invoke(
             cli_app,
             ["metadata", "list", "--team", "alpha", "--tier", "critical"],
         )
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
-        mock_client.list_jobs_metadata.assert_called_once_with(
+        self._mock_client.list_jobs_metadata.assert_called_once_with(
             team="alpha", tier="critical", version="", labels=None
         )
 
-    @patch("jenkins_job_insight.cli.main._get_client")
-    def test_metadata_list_json(self, mock_get_client) -> None:
-        mock_client = MagicMock()
-        mock_client.list_jobs_metadata.return_value = [{"job_name": "j"}]
-        mock_get_client.return_value = mock_client
+    def test_metadata_list_json(self) -> None:
+        self._mock_client.list_jobs_metadata.return_value = [{"job_name": "j"}]
         result = runner.invoke(cli_app, ["metadata", "list", "--json"])
-        if result.exit_code != 0:
-            print(f"CLI output: {result.output}")
-            if result.exception:
-                import traceback
-
-                traceback.print_exception(
-                    type(result.exception),
-                    result.exception,
-                    result.exception.__traceback__,
-                )
         assert result.exit_code == 0
         # JSON output should be parseable
         parsed = json_mod.loads(result.output)

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -548,6 +548,16 @@ class TestMetadataCLICommands:
         ]
         mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "list"])
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         assert "job-a" in result.output
 
@@ -563,6 +573,16 @@ class TestMetadataCLICommands:
         }
         mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "get", "my-job"])
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         assert "platform" in result.output
 
@@ -577,6 +597,16 @@ class TestMetadataCLICommands:
         result = runner.invoke(
             cli_app, ["metadata", "set", "my-job", "--team", "alpha"]
         )
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         assert "Metadata set" in result.output
 
@@ -589,6 +619,16 @@ class TestMetadataCLICommands:
         }
         mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "delete", "my-job"])
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         assert "Metadata deleted" in result.output
 
@@ -611,6 +651,16 @@ class TestMetadataCLICommands:
         )
 
         result = runner.invoke(cli_app, ["metadata", "import", str(f)])
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         assert "Imported 2" in result.output
 
@@ -623,6 +673,16 @@ class TestMetadataCLICommands:
             cli_app,
             ["metadata", "list", "--team", "alpha", "--tier", "critical"],
         )
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         mock_client.list_jobs_metadata.assert_called_once_with(
             team="alpha", tier="critical", version="", labels=None
@@ -634,6 +694,16 @@ class TestMetadataCLICommands:
         mock_client.list_jobs_metadata.return_value = [{"job_name": "j"}]
         mock_get_client.return_value = mock_client
         result = runner.invoke(cli_app, ["metadata", "list", "--json"])
+        if result.exit_code != 0:
+            print(f"CLI output: {result.output}")
+            if result.exception:
+                import traceback
+
+                traceback.print_exception(
+                    type(result.exception),
+                    result.exception,
+                    result.exception.__traceback__,
+                )
         assert result.exit_code == 0
         # JSON output should be parseable
         parsed = json_mod.loads(result.output)

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -518,19 +518,18 @@ class TestJobMetadataCLIClient:
 runner = CliRunner()
 
 
-@pytest.fixture(autouse=True)
-def reset_cli_state():
-    _state.clear()
-    _state["server_url"] = CLI_TEST_BASE_URL
-    _state["username"] = "testuser"
-    _state["no_verify_ssl"] = False
-    _state["api_key"] = ""
-    yield
-    _state.clear()
-
-
 class TestMetadataCLICommands:
     """Tests for metadata CLI commands."""
+
+    @pytest.fixture(autouse=True)
+    def reset_cli_state(self):
+        _state.clear()
+        _state["server_url"] = CLI_TEST_BASE_URL
+        _state["username"] = "testuser"
+        _state["no_verify_ssl"] = False
+        _state["api_key"] = ""
+        yield
+        _state.clear()
 
     @patch("jenkins_job_insight.cli.main._get_client")
     def test_metadata_list(self, mock_get_client) -> None:

--- a/tests/test_job_metadata.py
+++ b/tests/test_job_metadata.py
@@ -190,13 +190,14 @@ _ADMIN_KEY = "test-admin-key-16chars"  # pragma: allowlist secret
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(temp_db_path):
     env = {
         "JENKINS_URL": "https://jenkins.example.com",
         "JENKINS_USER": "testuser",
         "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
         "GEMINI_API_KEY": "test-key",  # pragma: allowlist secret
         "ADMIN_KEY": _ADMIN_KEY,
+        "DB_PATH": str(temp_db_path),
     }
     with patch.dict(os.environ, env, clear=True):
         from jenkins_job_insight.config import get_settings


### PR DESCRIPTION
## Summary

Full-stack feature adding job metadata support across all layers, enabling users to filter jobs by team, tier, version, and labels.

Fixes #134

## Changes

- **Database**: `job_metadata` table with team, tier, version, labels fields + indexes
- **Models**: `JobMetadata`, `JobMetadataInput`, `BulkJobMetadataEntry`, `BulkJobMetadataRequest`
- **API endpoints**: CRUD (`GET/PUT/DELETE /api/jobs/{name}/metadata`), list (`GET /api/jobs/metadata`), bulk import (`PUT /api/jobs/metadata/bulk`), filtered dashboard (`GET /api/dashboard/filtered`)
- **CLI**: `jji metadata list/get/set/delete/import` commands with `--team/--tier/--version/--label` filter flags
- **Frontend**: `MetadataFilterBar` (dynamic dropdowns + label chips), `MetadataBadges` (color-coded badges), filters persist in URL query params
- Labels stored as JSON array, filters combine with AND logic
- All metadata fields optional — backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job metadata management (team, tier, version, labels) with per-job CRUD, bulk import, and metadata-aware dashboard filtering
  * UI: metadata filter bar with dropdowns/label toggles, inline metadata badges per job, and filter state persisted in the URL; empty state now reflects metadata filters
  * CLI: metadata subcommands for list/get/set/delete/import (JSON/YAML)

* **Tests**
  * End-to-end tests covering storage, API, CLI, dashboard filtering, and bulk import behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->