### PR TITLE
feat: Allow force analysis on successful builds (fixes #148)

### DIFF
--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -106,7 +106,7 @@ function initFormState(p: AnalysisResult['request_params']) {
     jiraProjectKey: (p?.jira_project_key as string) || '',
     getArtifacts: p?.get_job_artifacts != null ? (p.get_job_artifacts as boolean) : undefined,
     maxArtifactsSize: p?.jenkins_artifacts_max_size_mb != null ? (p.jenkins_artifacts_max_size_mb as number) : undefined,
-    force: p?.force != null ? (p.force as boolean) : false,
+    force: p?.force ?? false,
   }
 }
 
@@ -173,7 +173,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
       const body: Record<string, unknown> = {
         ai_provider: aiProvider,
         ai_model: aiModel,
-        ...(force && { force: true }),
+        force,
         ...(aiCliTimeout !== undefined && { ai_cli_timeout: aiCliTimeout }),
         ...(enableJira !== undefined && { enable_jira: enableJira }),
         ...(jiraUrl && { jira_url: jiraUrl }),

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -106,6 +106,7 @@ function initFormState(p: AnalysisResult['request_params']) {
     jiraProjectKey: (p?.jira_project_key as string) || '',
     getArtifacts: p?.get_job_artifacts != null ? (p.get_job_artifacts as boolean) : undefined,
     maxArtifactsSize: p?.jenkins_artifacts_max_size_mb != null ? (p.jenkins_artifacts_max_size_mb as number) : undefined,
+    force: p?.force != null ? (p.force as boolean) : false,
   }
 }
 
@@ -136,6 +137,8 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
   const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(init.getArtifacts)
   const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(init.maxArtifactsSize)
 
+  const [force, setForce] = useState(init.force)
+
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
 
@@ -158,6 +161,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
     setJiraProjectKey(s.jiraProjectKey)
     setGetArtifacts(s.getArtifacts)
     setMaxArtifactsSize(s.maxArtifactsSize)
+    setForce(s.force)
     setSubmitting(false)
     setError('')
   }, [open, result.request_params])
@@ -169,6 +173,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
       const body: Record<string, unknown> = {
         ai_provider: aiProvider,
         ai_model: aiModel,
+        ...(force && { force: true }),
         ...(aiCliTimeout !== undefined && { ai_cli_timeout: aiCliTimeout }),
         ...(enableJira !== undefined && { enable_jira: enableJira }),
         ...(jiraUrl && { jira_url: jiraUrl }),
@@ -198,6 +203,7 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
   }, [
     aiProvider,
     aiModel,
+    force,
     aiCliTimeout,
     rawPrompt,
     enablePeers,
@@ -473,6 +479,19 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
                 </p>
               </>
             )}
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Force Analysis */}
+          <Section title="Advanced" dotColor="bg-text-tertiary">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Force analysis on successful builds</span>
+              <Toggle checked={force} onChange={setForce} label="Force analysis on successful builds" />
+            </div>
+            <p className="text-[11px] text-text-tertiary">
+              When enabled, analysis runs even if Jenkins reports the build as SUCCESS.
+            </p>
           </Section>
 
           <hr className="border-border-muted" />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -139,6 +139,7 @@ export interface AnalysisResult {
     tests_repo_url?: string
     tests_repo_ref?: string
     additional_repos?: Array<{ name: string; url: string; ref?: string }>
+    force?: boolean
     [key: string]: unknown
   }
 }

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1487,9 +1487,10 @@ async def analyze_job(
     except Exception as e:
         handle_jenkins_exception(e, job_name, build_number)
 
-    # Check if build passed - return early if yes
+    # Check if build passed - return early if yes (unless force is set)
     build_result = build_info.get("result")
-    if build_result == "SUCCESS":
+    force = getattr(request, "force", False) or settings.force_analysis
+    if build_result == "SUCCESS" and not force:
         return AnalysisResult(
             job_id=job_id,
             job_name=request.job_name,
@@ -1500,6 +1501,10 @@ async def analyze_job(
             ai_provider=ai_provider,
             ai_model=ai_model,
             failures=[],
+        )
+    if build_result == "SUCCESS" and force:
+        logger.info(
+            f"Build {job_name} #{build_number} passed but force=True, continuing analysis"
         )
 
     # Download build artifacts for context

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -57,6 +57,8 @@ class ServerConfig:
     wait_for_completion: bool | None = None
     poll_interval_minutes: int = 0  # 0 means use server default
     max_wait_minutes: int = 0  # 0 means use server default
+    # Force analysis on successful builds
+    force: bool | None = None
     # Admin authentication
     api_key: str = ""  # Admin API key for authentication
 
@@ -243,6 +245,8 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         wait_for_completion=data.get("wait_for_completion"),
         poll_interval_minutes=data.get("poll_interval_minutes", 0),
         max_wait_minutes=data.get("max_wait_minutes", 0),
+        # Force analysis on successful builds
+        force=data.get("force"),
         # Admin authentication
         api_key=data.get("api_key", ""),
     )

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -643,6 +643,11 @@ def analyze(
     max_wait: int = typer.Option(
         None, "--max-wait", help="Maximum minutes to wait for completion."
     ),
+    force: bool | None = typer.Option(
+        None,
+        "--force/--no-force",
+        help="Force analysis even if the build succeeded.",
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Submit a Jenkins job for analysis."""
@@ -726,6 +731,8 @@ def analyze(
             extras["jira_ssl_verify"] = cfg.jira_ssl_verify
         if cfg.wait_for_completion is not None:
             extras["wait_for_completion"] = cfg.wait_for_completion
+        if cfg.force is not None:
+            extras["force"] = cfg.force
 
     # CLI flags override config (highest priority).
     if provider:
@@ -772,6 +779,7 @@ def analyze(
         "jira_ssl_verify": jira_ssl_verify,
         "get_job_artifacts": get_job_artifacts,
         "wait_for_completion": wait_for_completion,
+        "force": force,
     }
     for key, value in _bool_fields.items():
         if value is not None:

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -173,6 +173,9 @@ class Settings(BaseSettings):
     # Artifact download toggle
     get_job_artifacts: bool = True
 
+    # Force analysis on successful builds
+    force_analysis: bool = False
+
     # Jenkins job monitoring (wait for completion before analysis)
     wait_for_completion: bool = True
     poll_interval_minutes: int = Field(default=2, gt=0)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -305,6 +305,7 @@ def _reconstruct_from_params(
         additional_repos=(
             params["additional_repos"] if "additional_repos" in params else None
         ),
+        force=params.get("force", False),
     )
     # Build Settings from env defaults, then layer stored overrides
     base_settings = get_settings()
@@ -327,10 +328,15 @@ def _reconstruct_from_params(
         "jenkins_artifacts_max_size_mb",
         "get_job_artifacts",
         "peer_analysis_max_rounds",
+        "force_analysis",
     ]
     for field in settings_fields:
         if field in params:
             overrides[field] = params[field]
+
+    # Map stored 'force' flag to Settings.force_analysis
+    if "force" in params:
+        overrides["force_analysis"] = params["force"]
 
     # Tests repo URL
     recomposed = _recompose_repo_spec(
@@ -796,6 +802,11 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
             if field in body.model_fields_set:
                 overrides[field] = getattr(body, field)
 
+        # force has a non-None default (False); only override when
+        # explicitly sent so that omitted requests inherit from env/settings.
+        if "force" in body.model_fields_set:
+            overrides["force_analysis"] = body.force
+
     if overrides:
         merged_data = settings.model_dump(mode="python") | overrides
         return Settings.model_validate(merged_data)
@@ -1228,6 +1239,7 @@ def _build_request_params(
             "get_job_artifacts": merged.get_job_artifacts,
             "raw_prompt": body.raw_prompt or "",
             "peer_analysis_max_rounds": merged.peer_analysis_max_rounds,
+            "force": body.force,
             "wait_started_at": _time.time(),
         }
     )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -305,7 +305,7 @@ def _reconstruct_from_params(
         additional_repos=(
             params["additional_repos"] if "additional_repos" in params else None
         ),
-        force=params.get("force", False),
+        **({"force": params["force"]} if "force" in params else {}),
     )
     # Build Settings from env defaults, then layer stored overrides
     base_settings = get_settings()
@@ -1239,7 +1239,7 @@ def _build_request_params(
             "get_job_artifacts": merged.get_job_artifacts,
             "raw_prompt": body.raw_prompt or "",
             "peer_analysis_max_rounds": merged.peer_analysis_max_rounds,
-            "force": body.force,
+            "force": merged.force_analysis,
             "wait_started_at": _time.time(),
         }
     )

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -173,6 +173,10 @@ class AnalyzeRequest(BaseAnalysisRequest):
         description="Jenkins job name (can include folders like 'folder/job-name')"
     )
     build_number: int = Field(description="Build number to analyze")
+    force: bool = Field(
+        default=False,
+        description="Force analysis even if the build succeeded (bypass SUCCESS early-return)",
+    )
     wait_for_completion: bool = Field(
         default=True,
         description="Wait for Jenkins job to complete before analyzing",

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1076,6 +1076,176 @@ class TestAnalyzeJobProgressPhases:
         mock_update.assert_not_called()
 
 
+class TestForceAnalysisSuccessfulBuild:
+    """Tests for force-analyzing builds that passed (SUCCESS)."""
+
+    @pytest.mark.asyncio
+    async def test_success_build_returns_early_without_force(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When build is SUCCESS and force is False, returns early with no-failures summary."""
+        from jenkins_job_insight.analyzer import analyze_job
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="my-job",
+            build_number=123,
+            force=False,
+        )
+        settings = Settings()
+        settings_data = settings.model_dump(mode="python")
+        settings_data["jenkins_url"] = "https://jenkins.example.com"
+        settings_data["jenkins_user"] = "user"
+        settings_data["jenkins_password"] = _FAKE_JENKINS_PASSWORD
+        merged = Settings.model_validate(settings_data)
+
+        mock_client = MagicMock()
+        mock_client.get_build_info_safe.return_value = {
+            "result": "SUCCESS",
+            "building": False,
+        }
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.JenkinsClient",
+            lambda **kwargs: mock_client,
+        )
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            fake_to_thread,
+        )
+
+        result = await analyze_job(
+            body,
+            merged,
+            ai_provider="claude",
+            ai_model="test-model",
+            job_id=None,
+        )
+
+        assert result.status == "completed"
+        assert "Build passed successfully" in result.summary
+        assert result.failures == []
+
+    @pytest.mark.asyncio
+    async def test_success_build_continues_with_force_on_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When build is SUCCESS and request.force is True, analysis continues past the early return."""
+        from jenkins_job_insight.analyzer import analyze_job
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="my-job",
+            build_number=123,
+            force=True,
+        )
+        settings = Settings()
+        settings_data = settings.model_dump(mode="python")
+        settings_data["jenkins_url"] = "https://jenkins.example.com"
+        settings_data["jenkins_user"] = "user"
+        settings_data["jenkins_password"] = _FAKE_JENKINS_PASSWORD
+        merged = Settings.model_validate(settings_data)
+
+        mock_client = MagicMock()
+        mock_client.get_build_info_safe.return_value = {
+            "result": "SUCCESS",
+            "building": False,
+            "artifacts": [],
+        }
+        mock_client.get_build_console.return_value = "Build finished successfully"
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.JenkinsClient",
+            lambda **kwargs: mock_client,
+        )
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            fake_to_thread,
+        )
+
+        # With force=True, it should NOT return the early "Build passed" result.
+        # It will proceed into the analysis flow and may fail at AI CLI sanity
+        # check (which is expected in test env without actual AI CLI).
+        # The key assertion: get_build_console was called, proving it went past
+        # the SUCCESS early-return guard.
+        try:
+            await analyze_job(
+                body,
+                merged,
+                ai_provider="claude",
+                ai_model="test-model",
+                job_id=None,
+            )
+        except Exception:
+            pass  # AI CLI sanity check failure is expected
+
+        mock_client.get_build_console.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_success_build_continues_with_force_on_settings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When build is SUCCESS and settings.force_analysis is True, analysis continues."""
+        from jenkins_job_insight.analyzer import analyze_job
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="my-job",
+            build_number=123,
+            force=False,  # request-level force is off
+        )
+        settings = Settings()
+        settings_data = settings.model_dump(mode="python")
+        settings_data["jenkins_url"] = "https://jenkins.example.com"
+        settings_data["jenkins_user"] = "user"
+        settings_data["jenkins_password"] = _FAKE_JENKINS_PASSWORD
+        settings_data["force_analysis"] = True  # env-level force is on
+        merged = Settings.model_validate(settings_data)
+
+        mock_client = MagicMock()
+        mock_client.get_build_info_safe.return_value = {
+            "result": "SUCCESS",
+            "building": False,
+            "artifacts": [],
+        }
+        mock_client.get_build_console.return_value = "Build finished successfully"
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.JenkinsClient",
+            lambda **kwargs: mock_client,
+        )
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.asyncio.to_thread",
+            fake_to_thread,
+        )
+
+        try:
+            await analyze_job(
+                body,
+                merged,
+                ai_provider="claude",
+                ai_model="test-model",
+                job_id=None,
+            )
+        except Exception:
+            pass  # AI CLI sanity check failure is expected
+
+        # Verify it went past the SUCCESS early-return guard
+        mock_client.get_build_console.assert_called_once()
+
+
 class TestResolveAdditionalRepos:
     """Tests for resolve_additional_repos."""
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1207,7 +1207,7 @@ class TestForceAnalysisSuccessfulBuild:
         body = AnalyzeRequest(
             job_name="my-job",
             build_number=123,
-            force=False,  # request-level force is off
+            # force intentionally omitted — settings.force_analysis should drive behavior
         )
         settings = Settings()
         settings_data = settings.model_dump(mode="python")

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1157,6 +1157,7 @@ class TestForceAnalysisSuccessfulBuild:
             "artifacts": [],
         }
         mock_client.get_build_console.return_value = "Build finished successfully"
+        mock_client.get_test_report.return_value = None
 
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.JenkinsClient",
@@ -1170,22 +1171,28 @@ class TestForceAnalysisSuccessfulBuild:
             "jenkins_job_insight.analyzer.asyncio.to_thread",
             fake_to_thread,
         )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.check_ai_cli_available",
+            AsyncMock(return_value=(True, "")),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
+            AsyncMock(
+                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+            ),
+        )
 
         # With force=True, it should NOT return the early "Build passed" result.
-        # It will proceed into the analysis flow and may fail at AI CLI sanity
-        # check (which is expected in test env without actual AI CLI).
+        # It will proceed into the analysis flow.
         # The key assertion: get_build_console was called, proving it went past
         # the SUCCESS early-return guard.
-        try:
-            await analyze_job(
-                body,
-                merged,
-                ai_provider="claude",
-                ai_model="test-model",
-                job_id=None,
-            )
-        except Exception:
-            pass  # AI CLI sanity check failure is expected
+        await analyze_job(
+            body,
+            merged,
+            ai_provider="claude",
+            ai_model="test-model",
+            job_id=None,
+        )
 
         mock_client.get_build_console.assert_called_once()
 
@@ -1217,6 +1224,7 @@ class TestForceAnalysisSuccessfulBuild:
             "artifacts": [],
         }
         mock_client.get_build_console.return_value = "Build finished successfully"
+        mock_client.get_test_report.return_value = None
 
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.JenkinsClient",
@@ -1230,17 +1238,24 @@ class TestForceAnalysisSuccessfulBuild:
             "jenkins_job_insight.analyzer.asyncio.to_thread",
             fake_to_thread,
         )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer.check_ai_cli_available",
+            AsyncMock(return_value=(True, "")),
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
+            AsyncMock(
+                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+            ),
+        )
 
-        try:
-            await analyze_job(
-                body,
-                merged,
-                ai_provider="claude",
-                ai_model="test-model",
-                job_id=None,
-            )
-        except Exception:
-            pass  # AI CLI sanity check failure is expected
+        await analyze_job(
+            body,
+            merged,
+            ai_provider="claude",
+            ai_model="test-model",
+            job_id=None,
+        )
 
         # Verify it went past the SUCCESS early-return guard
         mock_client.get_build_console.assert_called_once()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -49,6 +49,7 @@ github_token = "ghp_dev123"
 wait_for_completion = true
 poll_interval_minutes = 2
 max_wait_minutes = 45
+force = true
 
 [servers.prod]
 url = "https://jji.example.com"
@@ -255,6 +256,7 @@ class TestGetServerConfig:
         assert cfg.wait_for_completion is True
         assert cfg.poll_interval_minutes == 2
         assert cfg.max_wait_minutes == 45
+        assert cfg.force is True
 
     def test_defaults_for_missing_analyze_fields(self, config_file: Path):
         """Servers without analyze fields get dataclass defaults."""
@@ -273,6 +275,7 @@ class TestGetServerConfig:
         assert cfg.wait_for_completion is None
         assert cfg.poll_interval_minutes == 0
         assert cfg.max_wait_minutes == 0
+        assert cfg.force is None
 
 
 # -- list_servers --------------------------------------------------------------

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2206,6 +2206,95 @@ class TestAnalyzeWaitFlags:
         assert "wait_for_completion" not in kwargs
 
 
+class TestAnalyzeForceFlag:
+    """Tests for --force/--no-force CLI flag."""
+
+    def test_force_flag(self, mock_client):
+        """--force should send force=True."""
+        mock_client.analyze.return_value = {"status": "queued", "job_id": "j1"}
+        result = runner.invoke(
+            app,
+            ["analyze", "--job-name", "my-job", "--build-number", "1", "--force"],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.analyze.call_args[1]
+        assert kwargs["force"] is True
+
+    def test_no_force_flag(self, mock_client):
+        """--no-force should send force=False."""
+        mock_client.analyze.return_value = {"status": "queued", "job_id": "j1"}
+        result = runner.invoke(
+            app,
+            ["analyze", "--job-name", "my-job", "--build-number", "1", "--no-force"],
+        )
+        assert result.exit_code == 0
+        kwargs = mock_client.analyze.call_args[1]
+        assert kwargs["force"] is False
+
+    def test_force_omitted_not_in_extras(self, mock_client):
+        """When --force/--no-force is not given, force is not sent."""
+        mock_client.analyze.return_value = {"status": "queued", "job_id": "j1"}
+        with patch.dict(os.environ, _env_without_analyze_bindings(), clear=True):
+            result = runner.invoke(
+                app,
+                ["analyze", "--job-name", "my-job", "--build-number", "1"],
+            )
+        assert result.exit_code == 0
+        kwargs = mock_client.analyze.call_args[1]
+        assert "force" not in kwargs
+
+    def test_force_from_config(self, mock_client):
+        """Config force=true is used as default when CLI flag is absent."""
+        cfg = ServerConfig(url=_TEST_SERVER, force=True)
+        with (
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=cfg,
+            ),
+            patch("jenkins_job_insight.cli.main._get_client") as mock_fn,
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            client = MagicMock()
+            client.analyze.return_value = {"status": "queued", "job_id": "j1"}
+            mock_fn.return_value = client
+            result = runner.invoke(
+                app,
+                ["analyze", "--job-name", "my-job", "--build-number", "1"],
+            )
+            assert result.exit_code == 0
+            kwargs = client.analyze.call_args[1]
+            assert kwargs["force"] is True
+
+    def test_cli_force_overrides_config(self, mock_client):
+        """CLI --no-force overrides config force=true."""
+        cfg = ServerConfig(url=_TEST_SERVER, force=True)
+        with (
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=cfg,
+            ),
+            patch("jenkins_job_insight.cli.main._get_client") as mock_fn,
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            client = MagicMock()
+            client.analyze.return_value = {"status": "queued", "job_id": "j1"}
+            mock_fn.return_value = client
+            result = runner.invoke(
+                app,
+                [
+                    "analyze",
+                    "--job-name",
+                    "my-job",
+                    "--build-number",
+                    "1",
+                    "--no-force",
+                ],
+            )
+            assert result.exit_code == 0
+            kwargs = client.analyze.call_args[1]
+            assert kwargs["force"] is False
+
+
 class TestValidateTokenCommand:
     def test_validate_token_valid(self, mock_client):
         mock_client.validate_token.return_value = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -505,3 +505,27 @@ class TestPeerSettingsFields:
         with patch.dict(os.environ, env, clear=True):
             settings = Settings(_env_file=None)
             assert settings.peer_analysis_max_rounds == 5
+
+
+class TestForceAnalysisSettings:
+    """Tests for force_analysis setting."""
+
+    def test_force_analysis_default_false(self) -> None:
+        """force_analysis defaults to False."""
+        with patch.dict(os.environ, _build_env(), clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.force_analysis is False
+
+    def test_force_analysis_from_env(self) -> None:
+        """force_analysis is loaded from FORCE_ANALYSIS env var."""
+        env = _build_env(FORCE_ANALYSIS="true")
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.force_analysis is True
+
+    def test_force_analysis_env_false(self) -> None:
+        """FORCE_ANALYSIS=false sets force_analysis to False."""
+        env = _build_env(FORCE_ANALYSIS="false")
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.force_analysis is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4236,3 +4236,66 @@ class TestJiraSecurityLevelsEndpoint:
             assert data[0]["name"] == "Internal"
         finally:
             app.dependency_overrides.pop(get_settings, None)
+
+
+class TestMergeSettingsForce:
+    """Tests for force -> force_analysis mapping in _merge_settings."""
+
+    def test_force_true_in_request_sets_force_analysis(self) -> None:
+        """When request.force=True is explicitly set, merged settings have force_analysis=True."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+            force=True,
+        )
+        settings = Settings()
+        merged = _merge_settings(body, settings)
+        assert merged.force_analysis is True
+
+    def test_force_false_in_request_sets_force_analysis_false(self) -> None:
+        """When request.force=False is explicitly set, merged settings have force_analysis=False."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+            force=False,
+        )
+        # Start with settings that have force_analysis=True
+        settings_data = Settings().model_dump(mode="python")
+        settings_data["force_analysis"] = True
+        settings = Settings.model_validate(settings_data)
+        merged = _merge_settings(body, settings)
+        assert merged.force_analysis is False
+
+    def test_force_omitted_preserves_settings_default(self) -> None:
+        """When force is omitted from request, settings.force_analysis is preserved."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+        )
+        settings_data = Settings().model_dump(mode="python")
+        settings_data["force_analysis"] = True
+        settings = Settings.model_validate(settings_data)
+        merged = _merge_settings(body, settings)
+        assert merged.force_analysis is True
+
+    def test_force_omitted_default_false(self) -> None:
+        """When force is omitted and settings default, force_analysis is False."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+        )
+        settings = Settings()
+        merged = _merge_settings(body, settings)
+        assert merged.force_analysis is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1010,3 +1010,32 @@ class TestBaseAnalysisRequestPeerFields:
             job_name="j", build_number=1, peer_analysis_max_rounds=10
         )
         assert req10.peer_analysis_max_rounds == 10
+
+
+class TestAnalyzeRequestForce:
+    """Tests for the force field on AnalyzeRequest."""
+
+    def test_force_defaults_to_false(self) -> None:
+        """force defaults to False for backward compatibility."""
+        req = AnalyzeRequest(job_name="j", build_number=1)
+        assert req.force is False
+
+    def test_force_true(self) -> None:
+        """force can be set to True."""
+        req = AnalyzeRequest(job_name="j", build_number=1, force=True)
+        assert req.force is True
+
+    def test_force_false_explicit(self) -> None:
+        """force can be explicitly set to False."""
+        req = AnalyzeRequest(job_name="j", build_number=1, force=False)
+        assert req.force is False
+
+    def test_force_in_model_fields_set_when_provided(self) -> None:
+        """force appears in model_fields_set when explicitly provided."""
+        req = AnalyzeRequest(job_name="j", build_number=1, force=True)
+        assert "force" in req.model_fields_set
+
+    def test_force_not_in_model_fields_set_when_omitted(self) -> None:
+        """force does not appear in model_fields_set when omitted."""
+        req = AnalyzeRequest(job_name="j", build_number=1)
+        assert "force" not in req.model_fields_set


### PR DESCRIPTION
## Summary

Allow users to force analysis on successful Jenkins builds, bypassing the early "SUCCESS" return. Closes #148.

## Changes

- **Configuration Parity**: Full config parity following project conventions:
  - `FORCE_ANALYSIS` environment variable (server-level default)
  - `force: bool` API payload field (per-request override)
  - `--force / --no-force` CLI option (command-line flag)
  - `force = true` config file setting (`~/.config/jji/config.toml`)
- Added `force: bool = False` to `AnalyzeRequest` model
- Added `force_analysis: bool = False` to `Settings`
- Updated `_merge_settings()` to map `body.force → settings.force_analysis`
- Updated `analyze_job()` SUCCESS check: bypasses early return when `force=True`
- **Frontend**: Added "Force analysis on successful builds" toggle in ReAnalyzeDialog Advanced section
- **20 new tests** across models, config, main, analyzer, and CLI

## Linked Issue

Fixes #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI: "Advanced" toggle to force re-analysis when re-running analysis
  * CLI: new --force / --no-force option to control forcing analysis
  * Configuration: new setting to enable force-analysis by default (can be set per server)

* **Tests**
  * Added comprehensive tests covering force-analysis behavior across UI, CLI, config, and analysis flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->