### PR TITLE
feat(notifications): Web Push notifications for @mentions in comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     hooks:
       - id: eslint
         files: \.js$
-        exclude: (eslint\.config\.js|^docs/)
+        exclude: (eslint\.config\.js|^docs/|^frontend/)
         args: [--fix]
         additional_dependencies:
           - eslint@9.38.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,9 @@ Exceptions (server-level only, no payload equivalent):
 - `LOG_LEVEL` — server log verbosity
 - `PUBLIC_BASE_URL` — trusted server-only origin for building absolute links; never derive from request headers to prevent host-header injection
 - `SECURE_COOKIES` — server-only deployment toggle for HTTPS cookie flags (default: True, set False for local HTTP dev)
+- `VAPID_CLAIM_EMAIL` — server-only contact email for VAPID claims (Web Push notifications)
+- `VAPID_PRIVATE_KEY` — server-only VAPID private key for Web Push notifications; never expose via request payloads, CLI flags, or shared config files
+- `VAPID_PUBLIC_KEY` — server-only VAPID public key for Web Push notifications; auto-generated with `VAPID_PRIVATE_KEY` if not set
 - Security-sensitive credentials for preview/create-issue endpoints (`GITHUB_TOKEN`, `TESTS_REPO_URL`, Jira credentials, `REPORTPORTAL_URL`, `REPORTPORTAL_API_TOKEN`, `REPORTPORTAL_PROJECT`) — these use deployment config, not per-request overrides
 
 ### Sensitive Data Handling
@@ -202,6 +205,6 @@ Sensitive data (passwords, API tokens, credentials) must be:
 2. **Stripped from responses** — use `strip_sensitive_from_response()` before returning to API consumers
 3. **Never logged** — do not log passwords, tokens, or credentials at any log level
 
-Sensitive fields: `jenkins_password`, `jenkins_user`, `jira_api_token`, `jira_pat`, `jira_email`, `github_token`, `reportportal_api_token`
+Sensitive fields: `jenkins_password`, `jenkins_user`, `jira_api_token`, `jira_pat`, `jira_email`, `github_token`, `reportportal_api_token`, `vapid_private_key`
 
 Encryption uses Fernet (AES-128-CBC + HMAC-SHA256). Set `JJI_ENCRYPTION_KEY` env var for production; falls back to an auto-generated file-based key under `$XDG_DATA_HOME/jji/.encryption_key` (default: `~/.local/share/jji/.encryption_key`) for development.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Run `jji --help` for all commands.
 
 See the [API reference](https://myk-org.github.io/jenkins-job-insight/) for all endpoints.
 
+## Web Push Notifications
+
+Users can receive browser push notifications when @mentioned in comments. The server uses [VAPID](https://datatracker.ietf.org/doc/html/rfc8292) for Web Push authentication.
+
+| Variable | Description |
+|----------|-------------|
+| `VAPID_PUBLIC_KEY` | VAPID public key (auto-generated with private key if not set) |
+| `VAPID_PRIVATE_KEY` | VAPID private key |
+| `VAPID_CLAIM_EMAIL` | Contact email included in VAPID claims |
+
+Subscribe/unsubscribe is browser-only (managed via the web UI). To list users available for @mentions:
+
+```bash
+jji mentionable-users
+```
+
 ## Development
 
 ```bash

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,5 +1,9 @@
 const SW_VERSION = '1.0.0';
 
+self.addEventListener('activate', () => {
+  console.log('Service worker activated, version:', SW_VERSION);
+});
+
 self.addEventListener('push', (event) => {
   let data = {};
   try {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,7 +1,12 @@
 const SW_VERSION = '1.0.0';
 
 self.addEventListener('push', (event) => {
-  const data = event.data ? event.data.json() : {};
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = {};
+  }
   const title = data.title || 'JJI Notification';
   const options = {
     body: data.body || '',
@@ -14,5 +19,14 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const url = event.notification.data?.url || '/';
-  event.waitUntil(clients.openWindow(url));
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(url) && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      return clients.openWindow(url);
+    })
+  );
 });

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,18 @@
+const SW_VERSION = '1.0.0';
+
+self.addEventListener('push', (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'JJI Notification';
+  const options = {
+    body: data.body || '',
+    icon: '/favicon.svg',
+    data: { url: data.url || '/' },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/';
+  event.waitUntil(clients.openWindow(url));
+});

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -21,8 +21,9 @@ self.addEventListener('notificationclick', (event) => {
   const url = event.notification.data?.url || '/';
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      const targetUrl = new URL(url, self.location.origin).href;
       for (const client of windowClients) {
-        if (client.url.includes(url) && 'focus' in client) {
+        if (client.url === targetUrl && 'focus' in client) {
           return client.focus();
         }
       }

--- a/frontend/src/components/shared/LinkedText.tsx
+++ b/frontend/src/components/shared/LinkedText.tsx
@@ -6,9 +6,11 @@ interface LinkedTextProps {
   repoUrls: RepoUrl[]
   /** Custom renderer for link segments. */
   renderLink?: (seg: LinkSegment, index: number) => ReactNode
+  /** Custom renderer for plain-text segments (e.g. @mention highlighting). */
+  renderText?: (text: string, index: number) => ReactNode
 }
 
-export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
+export function LinkedText({ text, repoUrls, renderLink, renderText }: LinkedTextProps) {
   const segments = useMemo<LinkSegment[]>(() => autoLinkAnalysis(text, repoUrls), [text, repoUrls])
 
   return (
@@ -21,7 +23,7 @@ export function LinkedText({ text, repoUrls, renderLink }: LinkedTextProps) {
             </a>
           )
         ) : (
-          <span key={i}>{seg.text}</span>
+          renderText ? <Fragment key={i}>{renderText(seg.text, i)}</Fragment> : <span key={i}>{seg.text}</span>
         )
       )}
     </>

--- a/frontend/src/components/shared/NotificationPrompt.tsx
+++ b/frontend/src/components/shared/NotificationPrompt.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { subscribeToPush, getVapidPublicKey, hasActivePushSubscription, getPushSubscriptionState } from '@/lib/notifications'
+import { Bell } from 'lucide-react'
+
+const ASKED_KEY = 'jji_notifications_asked'
+const SHOW_DELAY_MS = 1500
+
+function wasAlreadyAsked(): boolean {
+  try {
+    return localStorage.getItem(ASKED_KEY) === 'true'
+  } catch {
+    return true // If storage unavailable, don't prompt
+  }
+}
+
+function markAsked(): void {
+  try {
+    localStorage.setItem(ASKED_KEY, 'true')
+  } catch {
+    // Storage unavailable — silently ignore
+  }
+}
+
+export function NotificationPrompt() {
+  const [open, setOpen] = useState(false)
+  const [enabling, setEnabling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const alreadyAsked = wasAlreadyAsked()
+    if (alreadyAsked) return
+
+    let cancelled = false
+
+    async function check() {
+      const state = await getPushSubscriptionState()
+      if (cancelled || state === 'unsupported') return
+
+      // Check for actual push subscription, not just permission
+      if (await hasActivePushSubscription()) {
+        markAsked()
+        return
+      }
+
+      const vapidKey = await getVapidPublicKey()
+      if (cancelled || !vapidKey) return
+
+      // All conditions met — show after delay
+      setTimeout(() => {
+        if (!cancelled) setOpen(true)
+      }, SHOW_DELAY_MS)
+    }
+
+    check()
+    return () => { cancelled = true }
+  }, [])
+
+  const handleEnable = useCallback(async () => {
+    setEnabling(true)
+    const result = await subscribeToPush()
+    setEnabling(false)
+    if (result.ok) {
+      markAsked()
+      setOpen(false)
+    } else {
+      setError(result.error || 'Failed to enable notifications')
+    }
+  }, [])
+
+  const handleDismiss = useCallback(() => {
+    markAsked()
+    setOpen(false)
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-accent-blue" />
+            Enable Notifications?
+          </DialogTitle>
+          <DialogDescription>
+            Get notified when someone mentions you in a comment.
+          </DialogDescription>
+          {error && (
+            <p className="text-sm text-destructive mt-2">{error}</p>
+          )}
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleDismiss} disabled={enabling}>
+            Not now
+          </Button>
+          <Button onClick={handleEnable} disabled={enabling}>
+            {enabling ? 'Enabling…' : 'Enable'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -119,6 +119,8 @@ function NotificationToggle() {
         }
       }
       await refreshState()
+    } catch (err) {
+      setToggleError(err instanceof Error ? err.message : 'Unexpected error')
     } finally {
       setToggling(false)
     }
@@ -225,14 +227,24 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
       }
     }
     loadTokens()
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- initialUsername and cookie setters are stable refs
   }, [])
 
   async function refreshTokensFromServer() {
     try {
       const freshTokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-      if (freshTokens.github_token && !githubToken.trim()) setGithubTokenValue(freshTokens.github_token)
-      if (freshTokens.jira_email && !jiraEmail.trim()) setJiraEmailValue(freshTokens.jira_email)
-      if (freshTokens.jira_token && !jiraToken.trim()) setJiraTokenValue(freshTokens.jira_token)
+      if (freshTokens.github_token && !githubToken.trim()) {
+        setGithubTokenValue(freshTokens.github_token)
+        setGithubToken(freshTokens.github_token)
+      }
+      if (freshTokens.jira_email && !jiraEmail.trim()) {
+        setJiraEmailValue(freshTokens.jira_email)
+        setJiraEmail(freshTokens.jira_email)
+      }
+      if (freshTokens.jira_token && !jiraToken.trim()) {
+        setJiraTokenValue(freshTokens.jira_token)
+        setJiraToken(freshTokens.jira_token)
+      }
     } catch {
       // ignore — tokens may not be available yet
     }

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, type FormEvent, type ReactNode } from 'react'
 import { api, ApiError } from '@/lib/api'
 import {
   setUsername,
@@ -10,10 +10,15 @@ import {
   getJiraToken,
   getJiraEmail,
 } from '@/lib/cookies'
+import {
+  getPushSubscriptionState,
+  subscribeToPush,
+  unsubscribeFromPush,
+} from '@/lib/notifications'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, Bell, BellOff } from 'lucide-react'
 
 interface ProfileFormProps {
   onSaved: () => void | Promise<void>
@@ -71,6 +76,97 @@ async function persistTokensToServer(gh: string, je: string, jt: string) {
   } catch (err) {
     console.error('Failed to sync tokens to server:', err)
   }
+}
+
+type PushState = 'granted' | 'denied' | 'default' | 'unsupported'
+
+function NotificationToggle() {
+  const [pushState, setPushState] = useState<PushState>('default')
+  const [hasSubscription, setHasSubscription] = useState(false)
+  const [toggling, setToggling] = useState(false)
+
+  const refreshState = useCallback(async () => {
+    const state = await getPushSubscriptionState()
+    setPushState(state)
+    if (state === 'granted' && 'serviceWorker' in navigator) {
+      try {
+        const reg = await navigator.serviceWorker.ready
+        const sub = await reg.pushManager.getSubscription()
+        setHasSubscription(sub !== null)
+      } catch {
+        setHasSubscription(false)
+      }
+    } else {
+      setHasSubscription(false)
+    }
+  }, [])
+
+  useEffect(() => { refreshState() }, [refreshState])
+
+  async function handleToggle() {
+    setToggling(true)
+    try {
+      if (hasSubscription) {
+        const ok = await unsubscribeFromPush()
+        if (ok) setHasSubscription(false)
+      } else {
+        const ok = await subscribeToPush()
+        if (ok) setHasSubscription(true)
+      }
+      await refreshState()
+    } finally {
+      setToggling(false)
+    }
+  }
+
+  if (pushState === 'unsupported') {
+    return (
+      <div className="space-y-1.5 pt-2">
+        <div className="flex items-center gap-3 py-1">
+          <div className="h-px flex-1 bg-border-muted" />
+          <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
+          <div className="h-px flex-1 bg-border-muted" />
+        </div>
+        <p className="text-xs text-text-tertiary">Push notifications are not supported in this browser.</p>
+      </div>
+    )
+  }
+
+  if (pushState === 'denied') {
+    return (
+      <div className="space-y-1.5 pt-2">
+        <div className="flex items-center gap-3 py-1">
+          <div className="h-px flex-1 bg-border-muted" />
+          <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
+          <div className="h-px flex-1 bg-border-muted" />
+        </div>
+        <div className="flex items-center gap-2 text-xs text-signal-amber">
+          <BellOff className="h-4 w-4 shrink-0" />
+          <span>Notifications blocked. To re-enable, update this site&apos;s notification permission in your browser settings.</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1.5 pt-2">
+      <div className="flex items-center gap-3 py-1">
+        <div className="h-px flex-1 bg-border-muted" />
+        <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
+        <div className="h-px flex-1 bg-border-muted" />
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-xs text-text-secondary">
+          {hasSubscription ? <Bell className="h-4 w-4 text-signal-green" /> : <BellOff className="h-4 w-4" />}
+          <span>{hasSubscription ? 'Notifications enabled' : 'Notifications disabled'}</span>
+        </div>
+        <Button type="button" variant={hasSubscription ? 'outline' : 'default'} size="sm" disabled={toggling} onClick={handleToggle}>
+          {toggling ? 'Updating...' : hasSubscription ? 'Disable' : 'Enable'}
+        </Button>
+      </div>
+      <p className="text-xs text-text-tertiary">Receive browser notifications when someone mentions you in a comment.</p>
+    </div>
+  )
 }
 
 export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
@@ -303,6 +399,10 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
             {saving ? 'Saving...' : 'Save'}
           </Button>
           </fieldset>
+
+          {/* Push Notifications */}
+          <NotificationToggle />
+
         </form>
       </CardContent>
     </Card>

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -109,6 +109,7 @@ function NotificationToggle() {
       if (hasSubscription) {
         const ok = await unsubscribeFromPush()
         if (ok) setHasSubscription(false)
+        else setToggleError('Failed to disable notifications')
       } else {
         const result = await subscribeToPush()
         if (result.ok) {
@@ -193,7 +194,6 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [githubValidation, setGithubValidation] = useState<TokenValidationResult | null>(null)
   const [jiraValidation, setJiraValidation] = useState<TokenValidationResult | null>(null)
 
-  const [saved, setSaved] = useState(false)
   const [saving, setSaving] = useState(false)
   const [usernameError, setUsernameError] = useState<string | null>(null)
   const [tokensLoaded, setTokensLoaded] = useState(false)
@@ -272,7 +272,6 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         await onAdminLogin(trimmed, apiKey.trim())
         // Admin login succeeded — also save the username cookie
         await commitProfile(trimmed)
-        setSaved(true)
         setSaving(false)
         // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
         await refreshTokensFromServer()
@@ -304,7 +303,6 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     }
 
     await commitProfile(trimmed)
-    setSaved(true)
     setSaving(false)
     // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
     await refreshTokensFromServer()

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -102,6 +102,7 @@ function NotificationToggle() {
       setHasSubscription(await hasActivePushSubscription())
     } catch (err) {
       setToggleError(err instanceof Error ? err.message : 'Unable to read notification state')
+      setPushState((prev) => (prev === 'loading' ? 'default' : prev))
     }
   }, [])
 

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -87,7 +87,7 @@ async function persistTokensToServer(gh: string, je: string, jt: string) {
   }
 }
 
-type PushState = 'granted' | 'denied' | 'default' | 'unsupported'
+type PushState = Awaited<ReturnType<typeof getPushSubscriptionState>>
 
 function NotificationToggle() {
   const [pushState, setPushState] = useState<PushState>('default')
@@ -261,12 +261,10 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
       const gh = githubToken.trim()
       const je = jiraEmail.trim()
       const jt = jiraToken.trim()
-      if (gh || je || jt) {
-        setGithubToken(gh)
-        setJiraEmail(je)
-        setJiraToken(jt)
-        await persistTokensToServer(gh, je, jt)
-      }
+      setGithubToken(gh)
+      setJiraEmail(je)
+      setJiraToken(jt)
+      await persistTokensToServer(gh, je, jt)
     }
 
     // Try admin login if API key is provided

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -87,10 +87,10 @@ async function persistTokensToServer(gh: string, je: string, jt: string) {
   }
 }
 
-type PushState = Awaited<ReturnType<typeof getPushSubscriptionState>>
+type PushState = Awaited<ReturnType<typeof getPushSubscriptionState>> | 'loading'
 
 function NotificationToggle() {
-  const [pushState, setPushState] = useState<PushState>('default')
+  const [pushState, setPushState] = useState<PushState>('loading')
   const [hasSubscription, setHasSubscription] = useState(false)
   const [toggling, setToggling] = useState(false)
   const [toggleError, setToggleError] = useState<string | null>(null)
@@ -132,6 +132,8 @@ function NotificationToggle() {
       setToggling(false)
     }
   }
+
+  if (pushState === 'loading') return null
 
   if (pushState === 'unsupported') {
     return (
@@ -273,9 +275,9 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         await onAdminLogin(trimmed, apiKey.trim())
         // Admin login succeeded — also save the username cookie
         await commitProfile(trimmed)
-        setSaving(false)
         // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
         await refreshTokensFromServer()
+        setSaving(false)
         await onSaved()
         return
       } catch (err) {
@@ -304,9 +306,9 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     }
 
     await commitProfile(trimmed)
-    setSaving(false)
     // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
     await refreshTokensFromServer()
+    setSaving(false)
     await onSaved()
   }
 

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -170,7 +170,8 @@ function NotificationToggle() {
 }
 
 export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
-  const [username, setUsernameValue] = useState(getUsername())
+  const [initialUsername] = useState(getUsername)
+  const [username, setUsernameValue] = useState(initialUsername)
   const [apiKey, setApiKey] = useState('')
   const [showApiKey, setShowApiKey] = useState(false)
   const [apiKeyError, setApiKeyError] = useState<string | null>(null)
@@ -400,8 +401,8 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
           </Button>
           </fieldset>
 
-          {/* Push Notifications */}
-          <NotificationToggle />
+          {/* Push Notifications — only show when user already has a saved profile */}
+          {initialUsername && <NotificationToggle />}
 
         </form>
       </CardContent>

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type FormEvent, type ReactNode } from 'react'
-import { api, ApiError } from '@/lib/api'
+import { api, ApiError, isExpectedTokenSyncError } from '@/lib/api'
 import {
   setUsername,
   setGithubToken,
@@ -81,7 +81,7 @@ async function persistTokensToServer(gh: string, je: string, jt: string) {
   } catch (err) {
     // May fail with 404 on first registration (user not yet in DB)
     // or 401 if cookie not set yet — both are expected, not errors
-    if (!(err instanceof ApiError && (err.status === 404 || err.status === 401))) {
+    if (!isExpectedTokenSyncError(err)) {
       console.error('Failed to sync tokens to server:', err)
     }
   }
@@ -220,7 +220,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         }
       } catch (err) {
         // 401 (no cookie yet) and 404 (user not registered) are expected; log anything else.
-        if (!(err instanceof ApiError && (err.status === 404 || err.status === 401))) {
+        if (!isExpectedTokenSyncError(err)) {
           console.error('Failed to hydrate tokens from server:', err)
         }
       }
@@ -234,7 +234,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
       return
     }
     hydrateTokensFromServer({ gh: githubTokenRef.current, je: jiraEmailRef.current, jt: jiraTokenRef.current }).finally(() => setTokensLoaded(true))
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- initialUsername and cookie setters are stable refs
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- initialUsername (lazy useState) and hydrateTokensFromServer (useCallback) are stable; run once on mount
   }, [])
 
   async function refreshTokensFromServer() {

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/cookies'
 import {
   getPushSubscriptionState,
+  hasActivePushSubscription,
   subscribeToPush,
   unsubscribeFromPush,
 } from '@/lib/notifications'
@@ -96,17 +97,7 @@ function NotificationToggle() {
   const refreshState = useCallback(async () => {
     const state = await getPushSubscriptionState()
     setPushState(state)
-    if (state === 'granted' && 'serviceWorker' in navigator) {
-      try {
-        const reg = await navigator.serviceWorker.ready
-        const sub = await reg.pushManager.getSubscription()
-        setHasSubscription(sub !== null)
-      } catch {
-        setHasSubscription(false)
-      }
-    } else {
-      setHasSubscription(false)
-    }
+    setHasSubscription(await hasActivePushSubscription())
   }, [])
 
   useEffect(() => { refreshState() }, [refreshState])

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -95,12 +95,18 @@ function NotificationToggle() {
   const [toggleError, setToggleError] = useState<string | null>(null)
 
   const refreshState = useCallback(async () => {
-    const state = await getPushSubscriptionState()
-    setPushState(state)
-    setHasSubscription(await hasActivePushSubscription())
+    try {
+      const state = await getPushSubscriptionState()
+      setPushState(state)
+      setHasSubscription(await hasActivePushSubscription())
+    } catch (err) {
+      setToggleError(err instanceof Error ? err.message : 'Unable to read notification state')
+    }
   }, [])
 
-  useEffect(() => { refreshState() }, [refreshState])
+  useEffect(() => {
+    void refreshState()
+  }, [refreshState])
 
   async function handleToggle() {
     setToggling(true)

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -218,8 +218,11 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
           setJiraTokenValue(tokens.jira_token)
           setJiraToken(tokens.jira_token)
         }
-      } catch {
-        // Server tokens not available — keep local values
+      } catch (err) {
+        // 401 (no cookie yet) and 404 (user not registered) are expected; log anything else.
+        if (!(err instanceof ApiError && (err.status === 404 || err.status === 401))) {
+          console.error('Failed to hydrate tokens from server:', err)
+        }
       }
     },
     [],

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -68,6 +68,8 @@ function TokenField({ id, label, value, onChange, show, onToggleShow, validation
 }
 
 async function persistTokensToServer(gh: string, je: string, jt: string) {
+  // Don't overwrite server tokens with empty values
+  if (!gh && !je && !jt) return
   try {
     await api.put('/api/user/tokens', {
       github_token: gh,
@@ -75,7 +77,11 @@ async function persistTokensToServer(gh: string, je: string, jt: string) {
       jira_token: jt,
     })
   } catch (err) {
-    console.error('Failed to sync tokens to server:', err)
+    // May fail with 404 on first registration (user not yet in DB)
+    // or 401 if cookie not set yet — both are expected, not errors
+    if (!(err instanceof ApiError && (err.status === 404 || err.status === 401))) {
+      console.error('Failed to sync tokens to server:', err)
+    }
   }
 }
 
@@ -199,6 +205,47 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [saved, setSaved] = useState(false)
   const [saving, setSaving] = useState(false)
   const [usernameError, setUsernameError] = useState<string | null>(null)
+  const [tokensLoaded, setTokensLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!initialUsername) {
+      setTokensLoaded(true) // no user yet, nothing to load
+      return
+    }
+    async function loadTokens() {
+      try {
+        const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+        if (tokens.github_token) {
+          setGithubTokenValue(tokens.github_token)
+          setGithubToken(tokens.github_token)
+        }
+        if (tokens.jira_email) {
+          setJiraEmailValue(tokens.jira_email)
+          setJiraEmail(tokens.jira_email)
+        }
+        if (tokens.jira_token) {
+          setJiraTokenValue(tokens.jira_token)
+          setJiraToken(tokens.jira_token)
+        }
+      } catch {
+        // Server tokens not available — keep localStorage values
+      } finally {
+        setTokensLoaded(true)
+      }
+    }
+    loadTokens()
+  }, [])
+
+  async function refreshTokensFromServer() {
+    try {
+      const freshTokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+      if (freshTokens.github_token && !githubToken.trim()) setGithubTokenValue(freshTokens.github_token)
+      if (freshTokens.jira_email && !jiraEmail.trim()) setJiraEmailValue(freshTokens.jira_email)
+      if (freshTokens.jira_token && !jiraToken.trim()) setJiraTokenValue(freshTokens.jira_token)
+    } catch {
+      // ignore — tokens may not be available yet
+    }
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -216,10 +263,16 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
 
     async function commitProfile(trimmedUsername: string) {
       setUsername(trimmedUsername)
-      setGithubToken(githubToken.trim())
-      setJiraEmail(jiraEmail.trim())
-      setJiraToken(jiraToken.trim())
-      await persistTokensToServer(githubToken.trim(), jiraEmail.trim(), jiraToken.trim())
+      // Only persist tokens if user actually entered values
+      const gh = githubToken.trim()
+      const je = jiraEmail.trim()
+      const jt = jiraToken.trim()
+      if (gh || je || jt) {
+        setGithubToken(gh)
+        setJiraEmail(je)
+        setJiraToken(jt)
+        await persistTokensToServer(gh, je, jt)
+      }
     }
 
     // Try admin login if API key is provided
@@ -230,6 +283,8 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         await commitProfile(trimmed)
         setSaved(true)
         setSaving(false)
+        // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
+        await refreshTokensFromServer()
         await onSaved()
         return
       } catch (err) {
@@ -260,6 +315,8 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     await commitProfile(trimmed)
     setSaved(true)
     setSaving(false)
+    // Re-fetch tokens from server before navigating away (onSaved unmounts the component)
+    await refreshTokensFromServer()
     await onSaved()
   }
 
@@ -424,13 +481,13 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
             helpContent={<>Jira Cloud: API token from{' '}<a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener noreferrer" className="text-text-link hover:underline">Atlassian account →</a>{' '}· Jira Server/DC: Personal Access Token</>}
           />
 
-          <Button type="submit" className="w-full" disabled={!username.trim() || saving || validatingGithub || validatingJira}>
+          <Button type="submit" className="w-full" disabled={!username.trim() || saving || validatingGithub || validatingJira || !tokensLoaded}>
             {saving ? 'Saving...' : 'Save'}
           </Button>
           </fieldset>
 
           {/* Push Notifications */}
-          <NotificationToggle />
+          {initialUsername && <NotificationToggle />}
 
         </form>
       </CardContent>

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -21,6 +21,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Eye, EyeOff, Bell, BellOff, ShieldCheck } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
+import { SectionDivider } from '@/components/shared/SectionDivider'
 
 interface ProfileFormProps {
   onSaved: () => void | Promise<void>
@@ -135,11 +136,7 @@ function NotificationToggle() {
   if (pushState === 'unsupported') {
     return (
       <div className="space-y-1.5 pt-2">
-        <div className="flex items-center gap-3 py-1">
-          <div className="h-px flex-1 bg-border-muted" />
-          <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
-          <div className="h-px flex-1 bg-border-muted" />
-        </div>
+        <SectionDivider title="Push Notifications" />
         <p className="text-xs text-text-tertiary">Push notifications are not supported in this browser.</p>
       </div>
     )
@@ -148,11 +145,7 @@ function NotificationToggle() {
   if (pushState === 'denied') {
     return (
       <div className="space-y-1.5 pt-2">
-        <div className="flex items-center gap-3 py-1">
-          <div className="h-px flex-1 bg-border-muted" />
-          <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
-          <div className="h-px flex-1 bg-border-muted" />
-        </div>
+        <SectionDivider title="Push Notifications" />
         <div className="flex items-center gap-2 text-xs text-signal-amber">
           <BellOff className="h-4 w-4 shrink-0" />
           <span>Notifications blocked. To re-enable, update this site&apos;s notification permission in your browser settings.</span>
@@ -163,11 +156,7 @@ function NotificationToggle() {
 
   return (
     <div className="space-y-1.5 pt-2">
-      <div className="flex items-center gap-3 py-1">
-        <div className="h-px flex-1 bg-border-muted" />
-        <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">Push Notifications</span>
-        <div className="h-px flex-1 bg-border-muted" />
-      </div>
+      <SectionDivider title="Push Notifications" />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-xs text-text-secondary">
           {hasSubscription ? <Bell className="h-4 w-4 text-signal-green" /> : <BellOff className="h-4 w-4" />}
@@ -213,54 +202,40 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const jiraTokenRef = useRef(jiraToken)
   jiraTokenRef.current = jiraToken
 
+  const hydrateTokensFromServer = useCallback(
+    async (current: { gh: string; je: string; jt: string }) => {
+      try {
+        const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
+        if (tokens.github_token && !current.gh.trim()) {
+          setGithubTokenValue(tokens.github_token)
+          setGithubToken(tokens.github_token)
+        }
+        if (tokens.jira_email && !current.je.trim()) {
+          setJiraEmailValue(tokens.jira_email)
+          setJiraEmail(tokens.jira_email)
+        }
+        if (tokens.jira_token && !current.jt.trim()) {
+          setJiraTokenValue(tokens.jira_token)
+          setJiraToken(tokens.jira_token)
+        }
+      } catch {
+        // Server tokens not available — keep local values
+      }
+    },
+    [],
+  )
+
   useEffect(() => {
     if (!initialUsername) {
       setTokensLoaded(true) // no user yet, nothing to load
       return
     }
-    async function loadTokens() {
-      try {
-        const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-        if (tokens.github_token && !githubTokenRef.current.trim()) {
-          setGithubTokenValue(tokens.github_token)
-          setGithubToken(tokens.github_token)
-        }
-        if (tokens.jira_email && !jiraEmailRef.current.trim()) {
-          setJiraEmailValue(tokens.jira_email)
-          setJiraEmail(tokens.jira_email)
-        }
-        if (tokens.jira_token && !jiraTokenRef.current.trim()) {
-          setJiraTokenValue(tokens.jira_token)
-          setJiraToken(tokens.jira_token)
-        }
-      } catch {
-        // Server tokens not available — keep localStorage values
-      } finally {
-        setTokensLoaded(true)
-      }
-    }
-    loadTokens()
+    hydrateTokensFromServer({ gh: githubTokenRef.current, je: jiraEmailRef.current, jt: jiraTokenRef.current }).finally(() => setTokensLoaded(true))
   // eslint-disable-next-line react-hooks/exhaustive-deps -- initialUsername and cookie setters are stable refs
   }, [])
 
   async function refreshTokensFromServer() {
-    try {
-      const freshTokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-      if (freshTokens.github_token && !githubToken.trim()) {
-        setGithubTokenValue(freshTokens.github_token)
-        setGithubToken(freshTokens.github_token)
-      }
-      if (freshTokens.jira_email && !jiraEmail.trim()) {
-        setJiraEmailValue(freshTokens.jira_email)
-        setJiraEmail(freshTokens.jira_email)
-      }
-      if (freshTokens.jira_token && !jiraToken.trim()) {
-        setJiraTokenValue(freshTokens.jira_token)
-        setJiraToken(freshTokens.jira_token)
-      }
-    } catch {
-      // ignore — tokens may not be available yet
-    }
+    await hydrateTokensFromServer({ gh: githubToken, je: jiraEmail, jt: jiraToken })
   }
 
   async function handleSubmit(e: FormEvent) {
@@ -396,13 +371,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
           {onAdminLogin && (
             <>
               {/* Admin Authentication Divider */}
-              <div className="flex items-center gap-3 py-1">
-                <div className="h-px flex-1 bg-border-muted" />
-                <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
-                  Admin Authentication
-                </span>
-                <div className="h-px flex-1 bg-border-muted" />
-              </div>
+              <SectionDivider title="Admin Authentication" />
               <p className="text-xs text-text-tertiary">
                 Provide your API key for admin access. Leave empty for regular user access.
               </p>
@@ -428,13 +397,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
           )}
 
           {/* Tracker Tokens Divider */}
-          <div className="flex items-center gap-3 py-1">
-            <div className="h-px flex-1 bg-border-muted" />
-            <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">
-              Tracker Tokens
-            </span>
-            <div className="h-px flex-1 bg-border-muted" />
-          </div>
+          <SectionDivider title="Tracker Tokens" />
           <p className="text-xs text-text-tertiary">
             Provide your personal tokens to create issues and bugs directly
             under your name. Without tokens, you can still preview generated

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, type FormEvent, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useRef, type FormEvent, type ReactNode } from 'react'
 import { api, ApiError } from '@/lib/api'
 import {
   setUsername,
@@ -206,6 +206,13 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [usernameError, setUsernameError] = useState<string | null>(null)
   const [tokensLoaded, setTokensLoaded] = useState(false)
 
+  const githubTokenRef = useRef(githubToken)
+  githubTokenRef.current = githubToken
+  const jiraEmailRef = useRef(jiraEmail)
+  jiraEmailRef.current = jiraEmail
+  const jiraTokenRef = useRef(jiraToken)
+  jiraTokenRef.current = jiraToken
+
   useEffect(() => {
     if (!initialUsername) {
       setTokensLoaded(true) // no user yet, nothing to load
@@ -214,15 +221,15 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     async function loadTokens() {
       try {
         const tokens = await api.get<{ github_token: string; jira_email: string; jira_token: string }>('/api/user/tokens')
-        if (tokens.github_token) {
+        if (tokens.github_token && !githubTokenRef.current.trim()) {
           setGithubTokenValue(tokens.github_token)
           setGithubToken(tokens.github_token)
         }
-        if (tokens.jira_email) {
+        if (tokens.jira_email && !jiraEmailRef.current.trim()) {
           setJiraEmailValue(tokens.jira_email)
           setJiraEmail(tokens.jira_email)
         }
-        if (tokens.jira_token) {
+        if (tokens.jira_token && !jiraTokenRef.current.trim()) {
           setJiraTokenValue(tokens.jira_token)
           setJiraToken(tokens.jira_token)
         }

--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -18,7 +18,8 @@ import {
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Eye, EyeOff, Bell, BellOff } from 'lucide-react'
+import { Eye, EyeOff, Bell, BellOff, ShieldCheck } from 'lucide-react'
+import { useAuth } from '@/lib/auth'
 
 interface ProfileFormProps {
   onSaved: () => void | Promise<void>
@@ -84,6 +85,7 @@ function NotificationToggle() {
   const [pushState, setPushState] = useState<PushState>('default')
   const [hasSubscription, setHasSubscription] = useState(false)
   const [toggling, setToggling] = useState(false)
+  const [toggleError, setToggleError] = useState<string | null>(null)
 
   const refreshState = useCallback(async () => {
     const state = await getPushSubscriptionState()
@@ -105,13 +107,18 @@ function NotificationToggle() {
 
   async function handleToggle() {
     setToggling(true)
+    setToggleError(null)
     try {
       if (hasSubscription) {
         const ok = await unsubscribeFromPush()
         if (ok) setHasSubscription(false)
       } else {
-        const ok = await subscribeToPush()
-        if (ok) setHasSubscription(true)
+        const result = await subscribeToPush()
+        if (result.ok) {
+          setHasSubscription(true)
+        } else {
+          setToggleError(result.error || 'Failed to enable notifications')
+        }
       }
       await refreshState()
     } finally {
@@ -164,12 +171,16 @@ function NotificationToggle() {
           {toggling ? 'Updating...' : hasSubscription ? 'Disable' : 'Enable'}
         </Button>
       </div>
+      {toggleError && (
+        <p className="text-xs text-signal-red">{toggleError}</p>
+      )}
       <p className="text-xs text-text-tertiary">Receive browser notifications when someone mentions you in a comment.</p>
     </div>
   )
 }
 
 export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
+  const { isAdmin } = useAuth()
   const [initialUsername] = useState(getUsername)
   const [username, setUsernameValue] = useState(initialUsername)
   const [apiKey, setApiKey] = useState('')
@@ -185,12 +196,20 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
   const [githubValidation, setGithubValidation] = useState<TokenValidationResult | null>(null)
   const [jiraValidation, setJiraValidation] = useState<TokenValidationResult | null>(null)
 
+  const [saved, setSaved] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [usernameError, setUsernameError] = useState<string | null>(null)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     const trimmed = username.trim()
     if (!trimmed) return
+
+    if (trimmed.toLowerCase() === 'admin') {
+      setUsernameError("The username 'admin' is reserved")
+      return
+    }
+    setUsernameError(null)
 
     setSaving(true)
     setApiKeyError(null)
@@ -209,6 +228,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
         await onAdminLogin(trimmed, apiKey.trim())
         // Admin login succeeded — also save the username cookie
         await commitProfile(trimmed)
+        setSaved(true)
         setSaving(false)
         await onSaved()
         return
@@ -238,6 +258,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     }
 
     await commitProfile(trimmed)
+    setSaved(true)
     setSaving(false)
     await onSaved()
   }
@@ -290,12 +311,15 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
             <Input
               id="username"
               value={username}
-              onChange={(e) => setUsernameValue(e.target.value)}
+              onChange={(e) => { setUsernameValue(e.target.value); setUsernameError(null) }}
               placeholder="e.g. jdoe"
               autoFocus
               autoComplete="username"
               className="h-10 font-mono"
             />
+            {usernameError && (
+              <p className="text-xs text-signal-red">{usernameError}</p>
+            )}
           </div>
 
           {onAdminLogin && (
@@ -322,8 +346,12 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
                 onToggleShow={() => setShowApiKey(!showApiKey)}
                 validation={null}
                 error={apiKeyError}
-                placeholder="Enter API key..."
-                helpContent={<>Admin API key provided by your server administrator.</>}
+                placeholder={isAdmin ? 'Authenticated ✓' : 'Enter API key...'}
+                helpContent={
+                  isAdmin && !apiKey.trim()
+                    ? <span className="inline-flex items-center gap-1 text-signal-green"><ShieldCheck className="h-3 w-3" />Authenticated as admin</span>
+                    : <>Admin API key provided by your server administrator.</>
+                }
               />
             </>
           )}
@@ -401,8 +429,8 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
           </Button>
           </fieldset>
 
-          {/* Push Notifications — only show when user already has a saved profile */}
-          {initialUsername && <NotificationToggle />}
+          {/* Push Notifications */}
+          <NotificationToggle />
 
         </form>
       </CardContent>

--- a/frontend/src/components/shared/SectionDivider.tsx
+++ b/frontend/src/components/shared/SectionDivider.tsx
@@ -1,0 +1,9 @@
+export function SectionDivider({ title }: { title: string }) {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <div className="h-px flex-1 bg-border-muted" />
+      <span className="font-display text-[10px] uppercase tracking-widest text-text-tertiary">{title}</span>
+      <div className="h-px flex-1 bg-border-muted" />
+    </div>
+  )
+}

--- a/frontend/src/components/shared/__tests__/NotificationPrompt.test.tsx
+++ b/frontend/src/components/shared/__tests__/NotificationPrompt.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NotificationPrompt } from '../NotificationPrompt'
+
+// Mock the notifications module
+vi.mock('@/lib/notifications', () => ({
+  getPushSubscriptionState: vi.fn(),
+  getVapidPublicKey: vi.fn(),
+  subscribeToPush: vi.fn(),
+  hasActivePushSubscription: vi.fn(),
+}))
+
+import { getPushSubscriptionState, getVapidPublicKey, subscribeToPush, hasActivePushSubscription } from '@/lib/notifications'
+
+const mockGetState = vi.mocked(getPushSubscriptionState)
+const mockGetVapid = vi.mocked(getVapidPublicKey)
+const mockSubscribe = vi.mocked(subscribeToPush)
+const mockHasActiveSub = vi.mocked(hasActivePushSubscription)
+
+const ASKED_KEY = 'jji_notifications_asked'
+
+describe('NotificationPrompt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    localStorage.clear()
+    mockGetState.mockResolvedValue('default')
+    mockGetVapid.mockResolvedValue('fake-vapid-key')
+    mockSubscribe.mockResolvedValue({ ok: true })
+    mockHasActiveSub.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('shows dialog after delay when all conditions are met', async () => {
+    render(<NotificationPrompt />)
+
+    // Not visible immediately
+    expect(screen.queryByText('Enable Notifications?')).toBeNull()
+
+    // Flush async checks + timer
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.getByText('Enable Notifications?')).toBeDefined()
+    expect(screen.getByText('Get notified when someone mentions you in a comment.')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Enable' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeDefined()
+  })
+
+  it('does not show dialog if already asked', async () => {
+    localStorage.setItem(ASKED_KEY, 'true')
+
+    render(<NotificationPrompt />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.queryByText('Enable Notifications?')).toBeNull()
+  })
+
+  it('does not show dialog if push is unsupported', async () => {
+    mockGetState.mockResolvedValue('unsupported')
+
+    render(<NotificationPrompt />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.queryByText('Enable Notifications?')).toBeNull()
+  })
+
+  it('does not show dialog if granted with active subscription', async () => {
+    mockGetState.mockResolvedValue('granted')
+    mockHasActiveSub.mockResolvedValue(true)
+
+    render(<NotificationPrompt />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.queryByText('Enable Notifications?')).toBeNull()
+    // Should mark as asked so it never checks again
+    expect(localStorage.getItem(ASKED_KEY)).toBe('true')
+  })
+
+  it('shows dialog if granted but no active subscription', async () => {
+    mockGetState.mockResolvedValue('granted')
+    mockHasActiveSub.mockResolvedValue(false)
+
+    render(<NotificationPrompt />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.getByText('Enable Notifications?')).toBeDefined()
+  })
+
+  it('does not show dialog if VAPID key unavailable', async () => {
+    mockGetVapid.mockResolvedValue(null)
+
+    render(<NotificationPrompt />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(screen.queryByText('Enable Notifications?')).toBeNull()
+  })
+
+  it('calls subscribeToPush and marks asked when Enable clicked', async () => {
+    vi.useRealTimers()
+    render(<NotificationPrompt />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Enable Notifications?')).toBeDefined()
+    }, { timeout: 3000 })
+
+    const enableBtn = screen.getByRole('button', { name: 'Enable' })
+    await userEvent.click(enableBtn)
+
+    await waitFor(() => {
+      expect(mockSubscribe).toHaveBeenCalledOnce()
+      expect(localStorage.getItem(ASKED_KEY)).toBe('true')
+      expect(screen.queryByText('Enable Notifications?')).toBeNull()
+    })
+  })
+
+  it('marks asked without subscribing when Not now clicked', async () => {
+    vi.useRealTimers()
+    render(<NotificationPrompt />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Enable Notifications?')).toBeDefined()
+    }, { timeout: 3000 })
+
+    const dismissBtn = screen.getByRole('button', { name: 'Not now' })
+    await userEvent.click(dismissBtn)
+
+    await waitFor(() => {
+      expect(mockSubscribe).not.toHaveBeenCalled()
+      expect(localStorage.getItem(ASKED_KEY)).toBe('true')
+      expect(screen.queryByText('Enable Notifications?')).toBeNull()
+    })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -68,4 +68,9 @@ export const api = {
 }
 
 
+/** 404: user not yet in DB; 401: cookie not set yet — both expected during first registration */
+export function isExpectedTokenSyncError(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 404 || err.status === 401)
+}
+
 export { ApiError }

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -29,6 +29,12 @@ export async function subscribeToPush(): Promise<{ ok: boolean; error?: string }
       navigator.serviceWorker.ready,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SW registration timeout')), 10_000)),
     ]);
+    // Clear any stale subscription from a previous VAPID key
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) {
+      await existing.unsubscribe();
+    }
+
     const subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: urlBase64ToUint8Array(vapidKey),
@@ -44,6 +50,12 @@ export async function subscribeToPush(): Promise<{ ok: boolean; error?: string }
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Unknown error';
     console.error('Push subscription failed:', msg);
+    if (msg.includes('push service') || msg.includes('Registration failed')) {
+      return {
+        ok: false,
+        error: 'Push service unavailable. If using Brave, go to Settings → Privacy → enable "Use Google services for push messaging".',
+      };
+    }
     return { ok: false, error: msg };
   }
 }

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -116,7 +116,12 @@ export async function hasActivePushSubscription(): Promise<boolean> {
   if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
   if (Notification.permission !== 'granted') return false;
   try {
-    const reg = await navigator.serviceWorker.ready;
+    const reg = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('SW registration timeout')), 10_000),
+      ),
+    ]);
     const sub = await reg.pushManager.getSubscription();
     return sub !== null;
   } catch {

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -29,23 +29,44 @@ export async function subscribeToPush(): Promise<{ ok: boolean; error?: string }
       navigator.serviceWorker.ready,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SW registration timeout')), 10_000)),
     ]);
-    // Clear any stale subscription from a previous VAPID key
-    const existing = await registration.pushManager.getSubscription();
-    if (existing) {
-      await existing.unsubscribe();
+
+    let subscription: PushSubscription;
+    try {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+    } catch (firstErr) {
+      // Only retry with unsubscribe for VAPID key mismatch errors
+      const isKeyMismatch = firstErr instanceof DOMException &&
+        (firstErr.name === 'InvalidAccessError' || firstErr.name === 'InvalidStateError');
+      if (!isKeyMismatch) throw firstErr;
+
+      // VAPID key changed — clear stale subscription and retry
+      const existing = await registration.pushManager.getSubscription();
+      if (existing) await existing.unsubscribe();
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
     }
 
-    const subscription = await registration.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(vapidKey),
-    });
-
     const sub = subscription.toJSON();
-    await api.post('/api/notifications/subscribe', {
-      endpoint: sub.endpoint,
-      p256dh_key: sub.keys?.p256dh,
-      auth_key: sub.keys?.auth,
-    });
+    try {
+      await api.post('/api/notifications/subscribe', {
+        endpoint: sub.endpoint,
+        p256dh_key: sub.keys?.p256dh,
+        auth_key: sub.keys?.auth,
+      });
+    } catch (postErr) {
+      // Server registration failed — roll back local subscription to stay in sync
+      try {
+        await subscription.unsubscribe();
+      } catch {
+        // Best-effort cleanup
+      }
+      throw postErr;
+    }
     return { ok: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -89,6 +110,18 @@ export async function unsubscribeFromPush(): Promise<boolean> {
 export async function getPushSubscriptionState(): Promise<'granted' | 'denied' | 'default' | 'unsupported'> {
   if (!('serviceWorker' in navigator) || !('PushManager' in window)) return 'unsupported';
   return Notification.permission as 'granted' | 'denied' | 'default';
+}
+
+export async function hasActivePushSubscription(): Promise<boolean> {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
+  if (Notification.permission !== 'granted') return false;
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    return sub !== null;
+  } catch {
+    return false;
+  }
 }
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -19,7 +19,10 @@ export async function subscribeToPush(): Promise<boolean> {
     const permission = await Notification.requestPermission();
     if (permission !== 'granted') return false;
 
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SW registration timeout')), 10_000)),
+    ]);
     const subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: urlBase64ToUint8Array(vapidKey),
@@ -39,7 +42,10 @@ export async function subscribeToPush(): Promise<boolean> {
 
 export async function unsubscribeFromPush(): Promise<boolean> {
   try {
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SW registration timeout')), 10_000)),
+    ]);
     const subscription = await registration.pushManager.getSubscription();
     if (!subscription) return true;
 

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,70 @@
+import { api } from './api';
+
+export async function getVapidPublicKey(): Promise<string | null> {
+  try {
+    const res = await api.get<{ vapid_public_key: string }>('/api/notifications/vapid-public-key');
+    return res.vapid_public_key;
+  } catch {
+    return null;
+  }
+}
+
+export async function subscribeToPush(): Promise<boolean> {
+  try {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
+
+    const vapidKey = await getVapidPublicKey();
+    if (!vapidKey) return false;
+
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return false;
+
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidKey),
+    });
+
+    const sub = subscription.toJSON();
+    await api.post('/api/notifications/subscribe', {
+      endpoint: sub.endpoint,
+      p256dh_key: sub.keys?.p256dh,
+      auth_key: sub.keys?.auth,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function unsubscribeFromPush(): Promise<boolean> {
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    if (!subscription) return true;
+
+    await api.post('/api/notifications/unsubscribe', {
+      endpoint: subscription.endpoint,
+    });
+    await subscription.unsubscribe();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getPushSubscriptionState(): Promise<'granted' | 'denied' | 'default' | 'unsupported'> {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return 'unsupported';
+  return Notification.permission as 'granted' | 'denied' | 'default';
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -9,16 +9,22 @@ export async function getVapidPublicKey(): Promise<string | null> {
   }
 }
 
-export async function subscribeToPush(): Promise<boolean> {
+export async function subscribeToPush(): Promise<{ ok: boolean; error?: string }> {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+    return { ok: false, error: 'Push notifications not supported in this browser' };
+  }
+
+  const vapidKey = await getVapidPublicKey();
+  if (!vapidKey) {
+    return { ok: false, error: 'Push notifications not configured on server' };
+  }
+
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') {
+    return { ok: false, error: 'Notification permission denied' };
+  }
+
   try {
-    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
-
-    const vapidKey = await getVapidPublicKey();
-    if (!vapidKey) return false;
-
-    const permission = await Notification.requestPermission();
-    if (permission !== 'granted') return false;
-
     const registration = await Promise.race([
       navigator.serviceWorker.ready,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SW registration timeout')), 10_000)),
@@ -34,9 +40,11 @@ export async function subscribeToPush(): Promise<boolean> {
       p256dh_key: sub.keys?.p256dh,
       auth_key: sub.keys?.auth,
     });
-    return true;
-  } catch {
-    return false;
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    console.error('Push subscription failed:', msg);
+    return { ok: false, error: msg };
   }
 }
 

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -43,9 +43,16 @@ export async function unsubscribeFromPush(): Promise<boolean> {
     const subscription = await registration.pushManager.getSubscription();
     if (!subscription) return true;
 
-    await api.post('/api/notifications/unsubscribe', {
-      endpoint: subscription.endpoint,
-    });
+    // Try server unsubscribe but don't let failure prevent local cleanup
+    try {
+      await api.post('/api/notifications/unsubscribe', {
+        endpoint: subscription.endpoint,
+      });
+    } catch {
+      // Server record may already be gone — that's fine
+    }
+
+    // Always clear the local subscription
     await subscription.unsubscribe();
     return true;
   } catch {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,3 +8,10 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+
+// Register service worker for push notifications
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js').catch(() => {
+    // Service worker registration failed — push notifications won't work
+  })
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } f
 import { useAuth } from '@/lib/auth'
 import { MetadataFilterBar } from '@/components/shared/MetadataFilterBar'
 import { MetadataBadges } from '@/components/shared/MetadataBadges'
+import { NotificationPrompt } from '@/components/shared/NotificationPrompt'
 
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
@@ -710,6 +711,8 @@ export function DashboardPage() {
           onConfirm={handleBulkDelete}
           loading={bulkDeleting}
         />
+
+        <NotificationPrompt />
       </div>
     </TooltipProvider>
   )

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -163,13 +163,7 @@ export function TokenUsagePage() {
 
   useEffect(() => {
     fetchSummary()
-  }, [fetchSummary])
-
-  // Auto-refresh summary every 30s
-  useEffect(() => {
-    const interval = setInterval(() => {
-      fetchSummary()
-    }, 30000)
+    const interval = setInterval(fetchSummary, 30000)
     return () => clearInterval(interval)
   }, [fetchSummary])
 
@@ -214,13 +208,7 @@ export function TokenUsagePage() {
 
   useEffect(() => {
     fetchBreakdown()
-  }, [fetchBreakdown])
-
-  // Auto-refresh breakdown every 30s
-  useEffect(() => {
-    const interval = setInterval(() => {
-      fetchBreakdown()
-    }, 30000)
+    const interval = setInterval(fetchBreakdown, 30000)
     return () => clearInterval(interval)
   }, [fetchBreakdown])
 

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -68,11 +68,13 @@ const GROUP_BY_OPTIONS = [
 
 type GroupByValue = typeof GROUP_BY_OPTIONS[number]['value']
 
-function SummaryCard({ title, icon, calls, tokens, cost }: {
+function SummaryCard({ title, icon, calls, tokens, inputTokens, outputTokens, cost }: {
   title: string
   icon: React.ReactNode
   calls: number
   tokens: number
+  inputTokens: number
+  outputTokens: number
   cost: number
 }) {
   return (
@@ -90,6 +92,14 @@ function SummaryCard({ title, icon, calls, tokens, cost }: {
           <div className="flex items-center justify-between">
             <span className="text-xs text-text-tertiary">Tokens</span>
             <span className="font-mono text-sm font-medium text-text-primary">{formatCompactNumber(tokens)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-tertiary">Input</span>
+            <span className="font-mono text-xs text-text-secondary">{formatCompactNumber(inputTokens)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-tertiary">Output</span>
+            <span className="font-mono text-xs text-text-secondary">{formatCompactNumber(outputTokens)}</span>
           </div>
           <div className="flex items-center justify-between">
             <span className="text-xs text-text-tertiary">Cost</span>
@@ -140,7 +150,7 @@ export function TokenUsagePage() {
   const latestRequestIdRef = useRef(0)
 
   // Fetch summary cards
-  useEffect(() => {
+  const fetchSummary = useCallback(() => {
     setSummaryLoading(true)
     api.get<TokenUsageDashboard>('/api/admin/token-usage/summary')
       .then((data) => {
@@ -151,9 +161,20 @@ export function TokenUsagePage() {
       .finally(() => setSummaryLoading(false))
   }, [])
 
-  // Fetch breakdown table
   useEffect(() => {
-    let cancelled = false
+    fetchSummary()
+  }, [fetchSummary])
+
+  // Auto-refresh summary every 30s
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchSummary()
+    }, 30000)
+    return () => clearInterval(interval)
+  }, [fetchSummary])
+
+  // Fetch breakdown table
+  const fetchBreakdown = useCallback(() => {
     const requestId = ++latestRequestIdRef.current
     setBreakdownLoading(true)
 
@@ -165,7 +186,7 @@ export function TokenUsagePage() {
 
     api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
       .then((data) => {
-        if (cancelled || requestId !== latestRequestIdRef.current) return
+        if (requestId !== latestRequestIdRef.current) return
         setBreakdown(
           data.breakdown.map((row) => ({
             group: row.group_key,
@@ -181,17 +202,27 @@ export function TokenUsagePage() {
         setBreakdownError(null)
       })
       .catch((err) => {
-        if (cancelled || requestId !== latestRequestIdRef.current) return
+        if (requestId !== latestRequestIdRef.current) return
         setBreakdownError(err instanceof Error ? err.message : 'Failed to load breakdown')
       })
       .finally(() => {
-        if (!cancelled && requestId === latestRequestIdRef.current) {
+        if (requestId === latestRequestIdRef.current) {
           setBreakdownLoading(false)
         }
       })
-
-    return () => { cancelled = true }
   }, [groupBy, dateFrom, dateTo, debouncedProvider])
+
+  useEffect(() => {
+    fetchBreakdown()
+  }, [fetchBreakdown])
+
+  // Auto-refresh breakdown every 30s
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchBreakdown()
+    }, 30000)
+    return () => clearInterval(interval)
+  }, [fetchBreakdown])
 
   const sorted = useMemo(() => {
     const copy = [...breakdown]
@@ -249,6 +280,8 @@ export function TokenUsagePage() {
             icon={<Zap className="h-4 w-4 text-signal-blue" />}
             calls={summary.today.calls}
             tokens={summary.today.tokens}
+            inputTokens={summary.today.input_tokens}
+            outputTokens={summary.today.output_tokens}
             cost={summary.today.cost_usd}
           />
           <SummaryCard
@@ -256,6 +289,8 @@ export function TokenUsagePage() {
             icon={<TrendingUp className="h-4 w-4 text-signal-green" />}
             calls={summary.this_week.calls}
             tokens={summary.this_week.tokens}
+            inputTokens={summary.this_week.input_tokens}
+            outputTokens={summary.this_week.output_tokens}
             cost={summary.this_week.cost_usd}
           />
           <SummaryCard
@@ -263,6 +298,8 @@ export function TokenUsagePage() {
             icon={<Calendar className="h-4 w-4 text-signal-orange" />}
             calls={summary.this_month.calls}
             tokens={summary.this_month.tokens}
+            inputTokens={summary.this_month.input_tokens}
+            outputTokens={summary.this_month.output_tokens}
             cost={summary.this_month.cost_usd}
           />
         </div>

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -1,14 +1,14 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, type ReactNode } from 'react'
 import { api } from '@/lib/api'
 import { formatTimestamp } from '@/lib/utils'
 import { isCommentInScope } from '@/lib/grouping'
 import { getUsername } from '@/lib/cookies'
 import { useReportState, useReportDispatch, useRefreshEnrichments } from './ReportContext'
-import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { LinkedText } from '@/components/shared/LinkedText'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { MentionTextarea } from './MentionTextarea'
 import { Trash2, MessageSquare } from 'lucide-react'
 import type { Comment } from '@/types'
 
@@ -21,6 +21,39 @@ function enrichmentBadgeVariant(status: string): 'success' | 'destructive' | 'de
   if (s === 'merged' || s === 'open') return 'success'
   if (s === 'closed') return 'destructive'
   return 'default'
+}
+
+/* ------------------------------------------------------------------ */
+/*  @mention highlighting in rendered text                             */
+/* ------------------------------------------------------------------ */
+
+const MENTION_RE = /(?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)/g
+
+/** Render a plain-text segment with @mentions highlighted. */
+function renderTextWithMentions(text: string, segIndex: number): ReactNode {
+  const parts: ReactNode[] = []
+  let lastIndex = 0
+  // Clone regex to reset state
+  const re = new RegExp(MENTION_RE.source, MENTION_RE.flags)
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index))
+    }
+    parts.push(
+      <span
+        key={`${segIndex}-m-${match.index}`}
+        className="font-semibold text-signal-blue"
+      >
+        {match[0]}
+      </span>,
+    )
+    lastIndex = match.index + match[0].length
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+  return parts.length > 0 ? <>{parts}</> : text
 }
 
 /* ------------------------------------------------------------------ */
@@ -195,6 +228,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
                     <LinkedText
                       text={c.comment}
                       repoUrls={[]}
+                      renderText={renderTextWithMentions}
                       renderLink={(seg, i) => {
                         const match = badges.find((b) => seg.text === b.key || seg.href === b.key)
                         return (
@@ -233,20 +267,11 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
 
       <div className="space-y-1">
         <div className="flex gap-2">
-          <Textarea
-            aria-label="Add a comment"
+          <MentionTextarea
             value={text}
-            onChange={(e) => setText(e.target.value)}
+            onChange={setText}
+            onSubmit={handleSubmit}
             placeholder="Add a comment..."
-            className="min-h-[36px] resize-none text-sm"
-            rows={1}
-            onKeyDown={(e) => {
-              if (e.nativeEvent.isComposing) return
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault()
-                handleSubmit()
-              }
-            }}
           />
           <Button size="sm" onClick={handleSubmit} disabled={!text.trim() || submitting} className="shrink-0">
             Post

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -76,7 +76,6 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
   const [text, setText] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [succeededTestNames, setSucceededTestNames] = useState<Set<string>>(new Set())
   const draftActiveRef = useRef(false)
   const username = getUsername()
 
@@ -106,11 +105,6 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
     }
   }, [dispatch])
 
-  // Reset retry tracking when scope or draft content changes
-  useEffect(() => {
-    setSucceededTestNames(new Set())
-  }, [jobId, testNames.join(','), scopedChildJobName, scopedChildBuildNumber, text]) // eslint-disable-line react-hooks/exhaustive-deps -- join produces a stable string key
-
   const testComments = comments.filter((c) => isCommentInScope(c, testNames, scopedChildJobName, scopedChildBuildNumber))
 
   async function handleSubmit() {
@@ -118,60 +112,35 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
     const submittedDraft = text
     const submittedText = submittedDraft.trim()
     if (!submittedText) return
-    let pendingTestNames = testNames.filter((t) => !succeededTestNames.has(t))
-    if (pendingTestNames.length === 0) {
-      setSucceededTestNames(new Set())
-      pendingTestNames = testNames
-    }
     setSubmitting(true)
     setSubmitError(null)
     try {
-      const results = await Promise.allSettled(
-        pendingTestNames.map((testName) =>
-          api.post<{ id: number }>(`/results/${jobId}/comments`, {
-            test_name: testName,
-            comment: submittedText,
-            child_job_name: scopedChildJobName,
-            child_build_number: scopedChildBuildNumber,
-          }).then((res) => ({ testName, id: res.id }))
-        )
-      )
-      const errors: string[] = []
-      let successCount = 0
-      results.forEach((result, i) => {
-        if (result.status === 'fulfilled') {
-          successCount++
-          const { testName, id } = result.value
-          setSucceededTestNames((prev) => new Set(prev).add(testName))
-          const fresh: Comment = {
-            id,
-            job_id: jobId,
-            test_name: testName,
-            child_job_name: scopedChildJobName,
-            child_build_number: scopedChildBuildNumber,
-            comment: submittedText,
-            username,
-            created_at: new Date().toISOString(),
-          }
-          dispatch({ type: 'ADD_COMMENT', payload: fresh })
-        } else {
-          const msg = result.reason instanceof Error ? result.reason.message : 'Failed to post comment'
-          errors.push(`${pendingTestNames[i]}: ${msg}`)
-        }
+      // Post comment once using the first test name —
+      // the backend associates it with all tests via error_signature
+      const firstTestName = testNames[0]
+      const res = await api.post<{ id: number }>(`/results/${jobId}/comments`, {
+        test_name: firstTestName,
+        comment: submittedText,
+        child_job_name: scopedChildJobName,
+        child_build_number: scopedChildBuildNumber,
       })
-      // Refresh enrichments once to pick up any tracker links in new comments
-      if (successCount > 0) refreshEnrichments(jobId)
-      if (errors.length > 0) {
-        const total = pendingTestNames.length
-        setSubmitError(`Posted ${successCount}/${total}. Failed: ${errors.join('; ')}`)
+      const fresh: Comment = {
+        id: res.id,
+        job_id: jobId,
+        test_name: firstTestName,
+        child_job_name: scopedChildJobName,
+        child_build_number: scopedChildBuildNumber,
+        comment: submittedText,
+        username,
+        created_at: new Date().toISOString(),
       }
-      // Clear text only if ALL posts succeeded and the user hasn't changed it during submission
-      if (errors.length === 0) {
-        setSucceededTestNames(new Set())
-        setText((current) => (current === submittedDraft ? '' : current))
-      }
+      dispatch({ type: 'ADD_COMMENT', payload: fresh })
+      refreshEnrichments(jobId)
+      // Clear text
+      setText('')
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : 'Failed to post comment')
+      const msg = err instanceof Error ? err.message : 'Failed to post comment'
+      setSubmitError(msg)
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -31,12 +31,11 @@ const MENTION_RE = /(?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)/g
 
 /** Render a plain-text segment with @mentions highlighted. */
 function renderTextWithMentions(text: string, segIndex: number): ReactNode {
+  MENTION_RE.lastIndex = 0
   const parts: ReactNode[] = []
   let lastIndex = 0
-  // Clone regex to reset state
-  const re = new RegExp(MENTION_RE.source, MENTION_RE.flags)
   let match: RegExpExecArray | null
-  while ((match = re.exec(text)) !== null) {
+  while ((match = MENTION_RE.exec(text)) !== null) {
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index))
     }

--- a/frontend/src/pages/report/MentionTextarea.tsx
+++ b/frontend/src/pages/report/MentionTextarea.tsx
@@ -1,0 +1,237 @@
+import { useState, useRef, useEffect, useCallback, type KeyboardEvent, type ChangeEvent } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { api } from '@/lib/api'
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface MentionTextareaProps {
+  value: string
+  onChange: (value: string) => void
+  onSubmit: () => void
+  placeholder?: string
+  disabled?: boolean
+}
+
+interface MentionQuery {
+  /** Start index of the `@` character in the textarea value. */
+  start: number
+  /** The partial username typed so far (after `@`). */
+  query: string
+}
+
+/* ------------------------------------------------------------------ */
+/*  Module-level cache for mentionable users                           */
+/* ------------------------------------------------------------------ */
+
+let cachedUsers: string[] | null = null
+let fetchPromise: Promise<string[]> | null = null
+
+async function fetchMentionableUsers(): Promise<string[]> {
+  if (cachedUsers) return cachedUsers
+  if (fetchPromise) return fetchPromise
+  fetchPromise = api
+    .get<{ users: string[] }>('/api/users/mentionable')
+    .then((res) => {
+      cachedUsers = res.users
+      return cachedUsers
+    })
+    .catch(() => {
+      fetchPromise = null
+      return []
+    })
+  return fetchPromise
+}
+
+/** Exported for testing only — resets the module-level cache. */
+export function _resetMentionCache() {
+  cachedUsers = null
+  fetchPromise = null
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Detect an active @mention query at the current cursor position.
+ * Returns null if the cursor is not inside a `@…` token, or if there's
+ * a space between the `@` and the cursor.
+ */
+function detectMentionQuery(text: string, cursorPos: number): MentionQuery | null {
+  // Walk backwards from cursor to find the `@` trigger
+  const before = text.slice(0, cursorPos)
+  const atIdx = before.lastIndexOf('@')
+  if (atIdx === -1) return null
+  // `@` must be at start of input or preceded by whitespace
+  if (atIdx > 0 && !/\s/.test(before[atIdx - 1])) return null
+  const query = before.slice(atIdx + 1)
+  // No spaces allowed in the partial query
+  if (/\s/.test(query)) return null
+  return { start: atIdx, query }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function MentionTextarea({ value, onChange, onSubmit, placeholder, disabled }: MentionTextareaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [allUsers, setAllUsers] = useState<string[]>(cachedUsers ?? [])
+  const [mentionQuery, setMentionQuery] = useState<MentionQuery | null>(null)
+  const [selectedIdx, setSelectedIdx] = useState(0)
+
+  // Fetch users on mount (cached after first successful call)
+  useEffect(() => {
+    void fetchMentionableUsers().then((users) => {
+      if (users.length > 0) setAllUsers(users)
+    })
+  }, [])
+
+  // Filtered list of matching users
+  const filtered = mentionQuery
+    ? allUsers.filter((u) => u.toLowerCase().startsWith(mentionQuery.query.toLowerCase()))
+    : []
+
+  // Keep selectedIdx in bounds
+  useEffect(() => {
+    setSelectedIdx(0)
+  }, [mentionQuery?.query])
+
+  /** Update the mention query state whenever the cursor moves or text changes. */
+  const syncMentionQuery = useCallback(() => {
+    const el = textareaRef.current
+    if (!el) return
+    const detected = detectMentionQuery(el.value, el.selectionStart)
+    setMentionQuery(detected)
+  }, [])
+
+  /** Insert the selected username at the @-trigger position. */
+  const insertMention = useCallback(
+    (username: string) => {
+      if (!mentionQuery) return
+      const before = value.slice(0, mentionQuery.start)
+      const after = value.slice(mentionQuery.start + 1 + mentionQuery.query.length)
+      const insert = `@${username} `
+      const newValue = before + insert + after
+      onChange(newValue)
+      setMentionQuery(null)
+      // Restore cursor position after React re-render
+      const cursorPos = before.length + insert.length
+      requestAnimationFrame(() => {
+        const el = textareaRef.current
+        if (el) {
+          el.focus()
+          el.setSelectionRange(cursorPos, cursorPos)
+        }
+      })
+    },
+    [mentionQuery, value, onChange],
+  )
+
+  function handleChange(e: ChangeEvent<HTMLTextAreaElement>) {
+    onChange(e.target.value)
+    // Defer query detection to after React has flushed the new value
+    requestAnimationFrame(() => syncMentionQuery())
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.nativeEvent.isComposing) return
+
+    // When dropdown is open, intercept navigation keys
+    if (mentionQuery && filtered.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIdx((i) => (i + 1) % filtered.length)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIdx((i) => (i - 1 + filtered.length) % filtered.length)
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        insertMention(filtered[selectedIdx])
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setMentionQuery(null)
+        return
+      }
+    }
+
+    // Default Enter = submit
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      onSubmit()
+    }
+  }
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!mentionQuery) return
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node) &&
+        textareaRef.current &&
+        !textareaRef.current.contains(e.target as Node)
+      ) {
+        setMentionQuery(null)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [mentionQuery])
+
+  const showDropdown = mentionQuery !== null && filtered.length > 0
+
+  return (
+    <div className="relative flex-1">
+      <Textarea
+        ref={textareaRef}
+        aria-label="Add a comment"
+        value={value}
+        onChange={handleChange}
+        onSelect={syncMentionQuery}
+        placeholder={placeholder}
+        className="min-h-[36px] resize-none text-sm"
+        rows={1}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      {showDropdown && (
+        <div
+          ref={dropdownRef}
+          role="listbox"
+          className="absolute bottom-full left-0 z-50 mb-1 max-h-40 w-56 overflow-y-auto rounded-md border border-border-default bg-surface-elevated shadow-lg"
+        >
+          {filtered.map((user, i) => (
+            <button
+              key={user}
+              type="button"
+              role="option"
+              aria-selected={i === selectedIdx}
+              className={`w-full px-3 py-1.5 text-left text-sm ${
+                i === selectedIdx
+                  ? 'bg-signal-blue/20 text-text-primary'
+                  : 'text-text-secondary hover:bg-surface-hover'
+              }`}
+              onMouseDown={(e) => {
+                // Prevent blur on textarea
+                e.preventDefault()
+                insertMention(user)
+              }}
+            >
+              @{user}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/report/MentionTextarea.tsx
+++ b/frontend/src/pages/report/MentionTextarea.tsx
@@ -32,9 +32,9 @@ async function fetchMentionableUsers(): Promise<string[]> {
   if (cachedUsers) return cachedUsers
   if (fetchPromise) return fetchPromise
   fetchPromise = api
-    .get<{ users: string[] }>('/api/users/mentionable')
+    .get<{ usernames: string[] }>('/api/users/mentionable')
     .then((res) => {
-      cachedUsers = res.users
+      cachedUsers = res.usernames ?? []
       return cachedUsers
     })
     .catch(() => {

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -17,9 +17,11 @@ vi.mock('@/lib/cookies', () => ({
 
 const mockDelete = vi.fn()
 const mockPost = vi.fn()
+const mockGet = vi.fn()
 
 vi.mock('@/lib/api', () => ({
   api: {
+    get: (...args: unknown[]) => mockGet(...args),
     delete: (...args: unknown[]) => mockDelete(...args),
     post: (...args: unknown[]) => mockPost(...args),
   },
@@ -74,10 +76,14 @@ function renderWithComments(comments: Comment[]) {
 /*  Tests                                                              */
 /* ------------------------------------------------------------------ */
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks()
   mockDelete.mockResolvedValue({})
   mockPost.mockResolvedValue({ enrichments: {} })
+  mockGet.mockResolvedValue({ users: [] })
+  // Reset mention cache between tests
+  const { _resetMentionCache } = await import('../MentionTextarea')
+  _resetMentionCache()
 })
 
 describe('CommentsSection – delete confirmation', () => {
@@ -140,5 +146,29 @@ describe('CommentsSection – delete confirmation', () => {
       expect(screen.getByRole('alert')).toBeDefined()
       expect(screen.getByText('Network error')).toBeDefined()
     })
+  })
+})
+
+describe('CommentsSection – @mention highlighting', () => {
+  it('highlights @mentions in rendered comments', () => {
+    renderWithComments([makeComment({ comment: 'Hey @alice check this' })])
+    const mention = screen.getByText('@alice')
+    expect(mention.tagName).toBe('SPAN')
+    expect(mention.className).toContain('text-signal-blue')
+    expect(mention.className).toContain('font-semibold')
+  })
+
+  it('does not highlight @domain in email addresses as a mention', () => {
+    renderWithComments([makeComment({ comment: 'Contact user@domain.com for info' })])
+    const mentionSpans = document.querySelectorAll('.text-signal-blue')
+    mentionSpans.forEach((el) => {
+      expect(el.textContent).not.toBe('@domain')
+    })
+  })
+
+  it('renders plain text without @mention styling', () => {
+    renderWithComments([makeComment({ comment: 'No mentions here' })])
+    expect(screen.getByText('No mentions here')).toBeDefined()
+    expect(screen.queryByText(/@/)).toBeNull()
   })
 })

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -160,7 +160,7 @@ describe('CommentsSection – @mention highlighting', () => {
 
   it('does not highlight @domain in email addresses as a mention', () => {
     renderWithComments([makeComment({ comment: 'Contact user@domain.com for info' })])
-    const mentionSpans = document.querySelectorAll('.text-signal-blue')
+    const mentionSpans = document.querySelectorAll('.text-signal-blue.font-semibold')
     mentionSpans.forEach((el) => {
       expect(el.textContent).not.toBe('@domain')
     })

--- a/frontend/src/pages/report/__tests__/MentionTextarea.test.tsx
+++ b/frontend/src/pages/report/__tests__/MentionTextarea.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MentionTextarea, _resetMentionCache } from '../MentionTextarea'
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mockGet = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}))
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function renderTextarea(overrides: Partial<Parameters<typeof MentionTextarea>[0]> = {}) {
+  const props = {
+    value: '',
+    onChange: vi.fn(),
+    onSubmit: vi.fn(),
+    placeholder: 'Add a comment...',
+    ...overrides,
+  }
+  const result = render(<MentionTextarea {...props} />)
+  return { ...result, ...props }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  _resetMentionCache()
+  mockGet.mockResolvedValue({ users: ['alice', 'bob', 'charlie'] })
+})
+
+describe('MentionTextarea', () => {
+  it('renders a textarea with the given placeholder', () => {
+    renderTextarea()
+    expect(screen.getByPlaceholderText('Add a comment...')).toBeDefined()
+  })
+
+  it('calls onChange when text is typed', () => {
+    const { onChange } = renderTextarea()
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+    expect(onChange).toHaveBeenCalledWith('hello')
+  })
+
+  it('calls onSubmit when Enter is pressed without Shift', () => {
+    const { onSubmit } = renderTextarea({ value: 'some text' })
+    const textarea = screen.getByRole('textbox')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+    expect(onSubmit).toHaveBeenCalled()
+  })
+
+  it('does not call onSubmit when Shift+Enter is pressed', () => {
+    const { onSubmit } = renderTextarea({ value: 'some text' })
+    const textarea = screen.getByRole('textbox')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('fetches mentionable users on mount', async () => {
+    renderTextarea()
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/users/mentionable')
+    })
+  })
+
+  it('caches users and does not re-fetch', async () => {
+    const { unmount } = renderTextarea()
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(1)
+    })
+    unmount()
+    renderTextarea()
+    // Should not call again — cached
+    expect(mockGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows dropdown when @ is typed and users match', async () => {
+    renderTextarea({ value: '@a' })
+    const textarea = screen.getByRole('textbox')
+
+    // Wait for users to be fetched
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    // Simulate cursor at end of value
+    Object.defineProperty(textarea, 'selectionStart', { value: 2, writable: true })
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeDefined()
+      expect(screen.getByText('@alice')).toBeDefined()
+    })
+  })
+
+  it('does not show dropdown when no users match', async () => {
+    renderTextarea({ value: '@zzz' })
+    const textarea = screen.getByRole('textbox')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    Object.defineProperty(textarea, 'selectionStart', { value: 4, writable: true })
+    fireEvent.select(textarea)
+
+    // Should not show listbox
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('closes dropdown on Escape', async () => {
+    renderTextarea({ value: '@a' })
+    const textarea = screen.getByRole('textbox')
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled()
+    })
+
+    Object.defineProperty(textarea, 'selectionStart', { value: 2, writable: true })
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeDefined()
+    })
+
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/frontend/src/pages/report/__tests__/MentionTextarea.test.tsx
+++ b/frontend/src/pages/report/__tests__/MentionTextarea.test.tsx
@@ -37,7 +37,7 @@ function renderTextarea(overrides: Partial<Parameters<typeof MentionTextarea>[0]
 beforeEach(() => {
   vi.clearAllMocks()
   _resetMentionCache()
-  mockGet.mockResolvedValue({ users: ['alice', 'bob', 'charlie'] })
+  mockGet.mockResolvedValue({ usernames: ['alice', 'bob', 'charlie'] })
 })
 
 describe('MentionTextarea', () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -338,10 +338,18 @@ export interface TokenUsageSummary {
   calls: TokenUsageEntry[]
 }
 
+export interface TokenUsagePeriod {
+  calls: number
+  tokens: number
+  input_tokens: number
+  output_tokens: number
+  cost_usd: number
+}
+
 export interface TokenUsageDashboard {
-  today: { calls: number; tokens: number; cost_usd: number }
-  this_week: { calls: number; tokens: number; cost_usd: number }
-  this_month: { calls: number; tokens: number; cost_usd: number }
+  today: TokenUsagePeriod
+  this_week: TokenUsagePeriod
+  this_month: TokenUsagePeriod
   top_models: { model: string; calls: number; cost_usd: number }[]
   top_jobs: { job_id: string; calls: number; cost_usd: number }[]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pydantic-settings",
   "python-jenkins",
   "python-multipart",
+  "pywebpush",
   "python-simple-logger",
   "reportportal-client>=5.7.4",
   "typer>=0.9.0",

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -703,6 +703,12 @@ class JJIClient:
         """Get token usage for a specific job. GET /api/admin/token-usage/{job_id}"""
         return self._request("GET", f"/api/admin/token-usage/{job_id}")
 
+    # -- Users ----------------------------------------------------------------
+
+    def get_mentionable_users(self) -> dict:
+        """Get list of mentionable usernames. GET /api/users/mentionable"""
+        return self._request("GET", "/api/users/mentionable")
+
     # -- AI Configs -----------------------------------------------------------
 
     def get_ai_configs(self) -> list[dict]:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1340,6 +1340,30 @@ def ai_configs(
         )
 
 
+# -- Users ----------------------------------------------------------------
+# NOTE: Push subscribe/unsubscribe are web-only (browser-specific push
+# subscriptions) and intentionally not exposed via CLI.
+
+
+@app.command("mentionable-users")
+def mentionable_users_cmd(
+    json_output: bool = _JSON_OPTION,
+):
+    """List users that can be mentioned in comments."""
+    data = _run_client_command(
+        json_output,
+        lambda c: c.get_mentionable_users(),
+        emit_output=False,
+    )
+    if not _state.get("json", False):
+        usernames = data.get("usernames", [])
+        if usernames:
+            for name in usernames:
+                typer.echo(name)
+        else:
+            typer.echo("No mentionable users found.")
+
+
 # -- Bug Creation -------------------------------------------------------------
 
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1341,8 +1341,10 @@ def ai_configs(
 
 
 # -- Users ----------------------------------------------------------------
-# NOTE: Push subscribe/unsubscribe are web-only (browser-specific push
-# subscriptions) and intentionally not exposed via CLI.
+# Note: /api/notifications/subscribe, /api/notifications/unsubscribe, and
+# /api/notifications/vapid-public-key are intentionally browser-only (Web Push
+# subscriptions require a browser service worker). No CLI equivalent needed.
+# See AGENTS.md CLI Parity exceptions.
 
 
 @app.command("mentionable-users")

--- a/src/jenkins_job_insight/comment_enrichment.py
+++ b/src/jenkins_job_insight/comment_enrichment.py
@@ -14,6 +14,8 @@ _GITHUB_ISSUE_PATTERN = re.compile(r"https?://github\.com/([^/]+)/([^/]+)/issues
 
 _JIRA_KEY_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
 
+_MENTION_PATTERN = re.compile(r"(?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)")
+
 
 def _detect_github_links(text: str, pattern: re.Pattern, label: str) -> list[dict]:
     """Detect GitHub links matching a pattern.
@@ -54,6 +56,29 @@ def detect_jira_keys(text: str) -> list[str]:
     keys = _JIRA_KEY_PATTERN.findall(text)
     logger.debug(f"detect_jira_keys: found={len(keys)}")
     return keys
+
+
+def detect_mentions(text: str) -> list[str]:
+    """Detect @username mentions in text.
+
+    Returns a deduplicated list of mentioned usernames (without the @ prefix).
+    Email addresses (e.g. user@domain.com) are excluded.
+
+    Args:
+        text: The comment text to scan.
+
+    Returns:
+        List of unique usernames in order of first occurrence.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in _MENTION_PATTERN.finditer(text):
+        username = match.group(1)
+        if username not in seen:
+            seen.add(username)
+            result.append(username)
+    logger.debug(f"detect_mentions: found={len(result)}")
+    return result
 
 
 async def fetch_github_pr_status(

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -355,16 +355,29 @@ class Settings(BaseSettings):
     @property
     def web_push_enabled(self) -> bool:
         """Check if Web Push is enabled (env vars or auto-generated keys)."""
-        if (
-            self.vapid_public_key.strip()
-            and self.vapid_private_key.strip()
-            and self.vapid_claim_email.strip()
-        ):
+        if hasattr(self, "_vapid_config_cache"):
+            return bool(self._vapid_config_cache)
+
+        pub = self.vapid_public_key.strip()
+        priv = self.vapid_private_key.strip()
+        email = self.vapid_claim_email.strip()
+
+        # Detect partial env config
+        if bool(pub) != bool(priv):
+            logger.warning(
+                "Partial VAPID configuration: only one of VAPID_PUBLIC_KEY/VAPID_PRIVATE_KEY is set. "
+                "Both must be provided, or neither (auto-generation will be used)."
+            )
+
+        if pub and priv and email:
+            object.__setattr__(self, "_vapid_config_cache", True)
             return True
-        # Check auto-generated keys
+
         from jenkins_job_insight.vapid import get_vapid_config
 
-        return bool(get_vapid_config())
+        result = bool(get_vapid_config())
+        object.__setattr__(self, "_vapid_config_cache", result)
+        return result
 
     @property
     def reportportal_enabled(self) -> bool:

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -255,6 +255,11 @@ class Settings(BaseSettings):
         description="Enable Report Portal integration. When None, enabled if REPORTPORTAL_URL, REPORTPORTAL_API_TOKEN, and REPORTPORTAL_PROJECT are configured.",
     )
 
+    # Web Push (VAPID) configuration (optional, server-only)
+    vapid_public_key: str = ""
+    vapid_private_key: str = Field(default="", repr=False)
+    vapid_claim_email: str = ""
+
     @model_validator(mode="after")
     def _normalize_optional_strings(self) -> "Settings":
         """Strip whitespace from optional string fields; blank becomes None."""
@@ -346,6 +351,13 @@ class Settings(BaseSettings):
                     "enable_github_issues is True but GITHUB_TOKEN is not configured"
                 )
         return bool(tests_repo_url and github_token)
+
+    @property
+    def web_push_enabled(self) -> bool:
+        """Check if Web Push is enabled (all three VAPID settings are non-empty)."""
+        return bool(
+            self.vapid_public_key and self.vapid_private_key and self.vapid_claim_email
+        )
 
     @property
     def reportportal_enabled(self) -> bool:

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -360,7 +360,6 @@ class Settings(BaseSettings):
 
         pub = self.vapid_public_key.strip()
         priv = self.vapid_private_key.strip()
-        email = self.vapid_claim_email.strip()
 
         # Detect partial env config
         if bool(pub) != bool(priv):
@@ -369,7 +368,7 @@ class Settings(BaseSettings):
                 "Both must be provided, or neither (auto-generation will be used)."
             )
 
-        if pub and priv and email:
+        if pub and priv:
             object.__setattr__(self, "_vapid_config_cache", True)
             return True
 

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -354,12 +354,17 @@ class Settings(BaseSettings):
 
     @property
     def web_push_enabled(self) -> bool:
-        """Check if Web Push is enabled (all three VAPID settings are non-empty)."""
-        return bool(
+        """Check if Web Push is enabled (env vars or auto-generated keys)."""
+        if (
             self.vapid_public_key.strip()
             and self.vapid_private_key.strip()
             and self.vapid_claim_email.strip()
-        )
+        ):
+            return True
+        # Check auto-generated keys
+        from jenkins_job_insight.vapid import get_vapid_config
+
+        return bool(get_vapid_config())
 
     @property
     def reportportal_enabled(self) -> bool:

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -356,7 +356,9 @@ class Settings(BaseSettings):
     def web_push_enabled(self) -> bool:
         """Check if Web Push is enabled (all three VAPID settings are non-empty)."""
         return bool(
-            self.vapid_public_key and self.vapid_private_key and self.vapid_claim_email
+            self.vapid_public_key.strip()
+            and self.vapid_private_key.strip()
+            and self.vapid_claim_email.strip()
         )
 
     @property

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -642,6 +642,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/api/health",
             "/metrics",
             "/favicon.ico",
+            "/sw.js",
         }
     )
 
@@ -717,7 +718,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # 3. Fall back to jji_username cookie (regular users)
         if not username:
-            username = request.cookies.get("jji_username", "")
+            cookie_username = request.cookies.get("jji_username", "")
+            if cookie_username.lower() == "admin":
+                # Reserved username — only valid via session/bearer auth
+                cookie_username = ""
+            username = cookie_username
 
         request.state.username = username
         request.state.is_admin = is_admin
@@ -3852,6 +3857,22 @@ async def favicon() -> Response:
         content=FAVICON_SVG,
         media_type="image/svg+xml",
         headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@app.get("/sw.js", include_in_schema=False)
+async def service_worker() -> Response:
+    """Serve the service worker for push notifications."""
+    sw_file = _FRONTEND_DIR / "sw.js"
+    if not sw_file.is_file():
+        # Fallback to public/ during development
+        sw_file = _FRONTEND_DIR.parent / "public" / "sw.js"
+    if not sw_file.is_file():
+        raise HTTPException(status_code=404, detail="Service worker not found")
+    return Response(
+        content=sw_file.read_text(encoding="utf-8"),
+        media_type="application/javascript",
+        headers={"Cache-Control": "no-cache", "Service-Worker-Allowed": "/"},
     )
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -65,6 +65,8 @@ from jenkins_job_insight.bug_creation import (
     search_github_duplicates,
     search_jira_duplicates,
 )
+from jenkins_job_insight.comment_enrichment import detect_mentions
+from jenkins_job_insight.notifications import send_mention_notifications
 from jenkins_job_insight.models import (
     AddCommentRequest,
     AnalyzeFailuresRequest,
@@ -80,8 +82,10 @@ from jenkins_job_insight.models import (
     JobMetadataInput,
     OverrideClassificationRequest,
     PreviewIssueRequest,
+    PushSubscriptionRequest,
     ReportPortalPushResult,
     SetReviewedRequest,
+    UnsubscribeRequest,
 )
 from jenkins_job_insight.utils import (
     _is_sensitive_key,
@@ -2074,6 +2078,26 @@ async def add_comment(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Detect @mentions and send notifications (best-effort, fire-and-forget)
+    settings = get_settings()
+    if settings.web_push_enabled:
+        mentioned = detect_mentions(body.comment)
+        if mentioned:
+            task = asyncio.create_task(
+                send_mention_notifications(
+                    mentioned_usernames=mentioned,
+                    comment_author=username,
+                    job_id=job_id,
+                    test_name=body.test_name,
+                    vapid_private_key=settings.vapid_private_key,
+                    vapid_claim_email=settings.vapid_claim_email,
+                    public_base_url=settings.public_base_url,
+                )
+            )
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+
     return {"id": comment_id}
 
 
@@ -4353,6 +4377,62 @@ async def api_dashboard_filtered(
             job["metadata"] = None
 
     return jobs
+
+
+# --- Notification endpoints ---
+
+
+@app.get("/api/notifications/vapid-public-key")
+async def get_vapid_public_key():
+    """Return the VAPID public key for frontend push subscription."""
+    settings = get_settings()
+    if not settings.web_push_enabled:
+        raise HTTPException(
+            status_code=404, detail="Web Push notifications not configured"
+        )
+    return {"vapid_public_key": settings.vapid_public_key}
+
+
+@app.post("/api/notifications/subscribe")
+async def subscribe_notifications(body: PushSubscriptionRequest, request: Request):
+    """Register a push subscription for the current user."""
+    settings = get_settings()
+    if not settings.web_push_enabled:
+        raise HTTPException(
+            status_code=404, detail="Web Push notifications not configured"
+        )
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    await storage.save_push_subscription(
+        username=username,
+        endpoint=body.endpoint,
+        p256dh_key=body.p256dh_key,
+        auth_key=body.auth_key,
+    )
+    return {"status": "subscribed"}
+
+
+@app.post("/api/notifications/unsubscribe")
+async def unsubscribe_notifications(body: UnsubscribeRequest, request: Request):
+    """Remove a push subscription."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    deleted = await storage.delete_push_subscription(body.endpoint, username)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return {"status": "unsubscribed"}
+
+
+@app.get("/api/users/mentionable")
+async def get_mentionable_users(request: Request):
+    """Return list of usernames that can be mentioned in comments."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    users = await storage.list_users()
+    return {"usernames": [u["username"] for u in users]}
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4405,6 +4405,9 @@ async def subscribe_notifications(body: PushSubscriptionRequest, request: Reques
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
     _check_allow_list(request)
+    user = await storage.get_user_by_username(username)
+    if not user:
+        raise HTTPException(status_code=400, detail="Username not registered")
     await storage.save_push_subscription(
         username=username,
         endpoint=body.endpoint,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2081,7 +2081,7 @@ async def add_comment(
 
     # Detect @mentions and send notifications (best-effort, fire-and-forget)
     settings = get_settings()
-    if settings.web_push_enabled:
+    if settings.web_push_enabled and username:
         mentioned = detect_mentions(body.comment)
         if mentioned:
             task = asyncio.create_task(
@@ -4405,9 +4405,6 @@ async def subscribe_notifications(body: PushSubscriptionRequest, request: Reques
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
     _check_allow_list(request)
-    user = await storage.get_user_by_username(username)
-    if not user:
-        raise HTTPException(status_code=400, detail="Username not registered")
     await storage.save_push_subscription(
         username=username,
         endpoint=body.endpoint,
@@ -4420,6 +4417,11 @@ async def subscribe_notifications(body: PushSubscriptionRequest, request: Reques
 @app.post("/api/notifications/unsubscribe")
 async def unsubscribe_notifications(body: UnsubscribeRequest, request: Request):
     """Remove a push subscription."""
+    settings = get_settings()
+    if not settings.web_push_enabled:
+        raise HTTPException(
+            status_code=404, detail="Web Push notifications not configured"
+        )
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -67,6 +67,7 @@ from jenkins_job_insight.bug_creation import (
 )
 from jenkins_job_insight.comment_enrichment import detect_mentions
 from jenkins_job_insight.notifications import send_mention_notifications
+from jenkins_job_insight.vapid import get_vapid_config
 from jenkins_job_insight.models import (
     AddCommentRequest,
     AnalyzeFailuresRequest,
@@ -2084,19 +2085,21 @@ async def add_comment(
     if settings.web_push_enabled and username:
         mentioned = detect_mentions(body.comment)
         if mentioned:
-            task = asyncio.create_task(
-                send_mention_notifications(
-                    mentioned_usernames=mentioned,
-                    comment_author=username,
-                    job_id=job_id,
-                    test_name=body.test_name,
-                    vapid_private_key=settings.vapid_private_key,
-                    vapid_claim_email=settings.vapid_claim_email,
-                    public_base_url=settings.public_base_url,
+            vapid_cfg = get_vapid_config()
+            if vapid_cfg:
+                task = asyncio.create_task(
+                    send_mention_notifications(
+                        mentioned_usernames=mentioned,
+                        comment_author=username,
+                        job_id=job_id,
+                        test_name=body.test_name,
+                        vapid_private_key=vapid_cfg["private_key"],
+                        vapid_claim_email=vapid_cfg["claim_email"],
+                        public_base_url=settings.public_base_url,
+                    )
                 )
-            )
-            _background_tasks.add(task)
-            task.add_done_callback(_background_tasks.discard)
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
 
     return {"id": comment_id}
 
@@ -4390,7 +4393,8 @@ async def get_vapid_public_key():
         raise HTTPException(
             status_code=404, detail="Web Push notifications not configured"
         )
-    return {"vapid_public_key": settings.vapid_public_key}
+    vapid_cfg = get_vapid_config()
+    return {"vapid_public_key": vapid_cfg["public_key"]}
 
 
 @app.post("/api/notifications/subscribe")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4404,6 +4404,7 @@ async def subscribe_notifications(body: PushSubscriptionRequest, request: Reques
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
     await storage.save_push_subscription(
         username=username,
         endpoint=body.endpoint,
@@ -4419,6 +4420,7 @@ async def unsubscribe_notifications(body: UnsubscribeRequest, request: Request):
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
     deleted = await storage.delete_push_subscription(body.endpoint, username)
     if not deleted:
         raise HTTPException(status_code=404, detail="Subscription not found")
@@ -4431,6 +4433,7 @@ async def get_mentionable_users(request: Request):
     username = request.state.username
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
     users = await storage.list_users()
     return {"usernames": [u["username"] for u in users]}
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2091,7 +2091,7 @@ async def add_comment(
         mentioned = detect_mentions(body.comment)
         if mentioned:
             vapid_cfg = get_vapid_config()
-            if vapid_cfg:
+            if vapid_cfg and "private_key" in vapid_cfg and "claim_email" in vapid_cfg:
                 task = asyncio.create_task(
                     send_mention_notifications(
                         mentioned_usernames=mentioned,
@@ -4055,16 +4055,21 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
         raise HTTPException(status_code=404, detail="User not found. Register first.")
     body = await _read_json_object(request)
 
-    kwargs: dict[str, str | None] = {}
-    if "github_token" in body:
-        kwargs["github_token"] = body["github_token"]
-    if "jira_email" in body:
-        kwargs["jira_email"] = body["jira_email"]
-    if "jira_token" in body:
-        kwargs["jira_token"] = body["jira_token"]
+    gh = str(body.get("github_token", "")).strip()
+    je = str(body.get("jira_email", "")).strip()
+    jt = str(body.get("jira_token", "")).strip()
 
-    if not kwargs:
+    # If all empty, skip save — don't overwrite existing tokens
+    if not gh and not je and not jt:
         return JSONResponse(content={"ok": True})
+
+    # Merge with existing: only overwrite fields that have new values
+    existing = await storage.get_user_tokens(username)
+    kwargs: dict[str, str | None] = {
+        "github_token": gh if gh else existing.get("github_token", ""),
+        "jira_email": je if je else existing.get("jira_email", ""),
+        "jira_token": jt if jt else existing.get("jira_token", ""),
+    }
 
     await storage.save_user_tokens(username, **kwargs)
     logger.debug(f"Saved tokens for user '{username}'")
@@ -4415,6 +4420,8 @@ async def get_vapid_public_key():
             status_code=404, detail="Web Push notifications not configured"
         )
     vapid_cfg = get_vapid_config()
+    if not vapid_cfg or "public_key" not in vapid_cfg:
+        raise HTTPException(status_code=503, detail="VAPID keys unavailable")
     return {"vapid_public_key": vapid_cfg["public_key"]}
 
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -722,36 +722,30 @@ class ReportPortalPushResult(BaseModel):
     launch_id: int | None = Field(default=None, description="Report Portal launch ID")
 
 
-class PushSubscriptionRequest(BaseModel):
-    """Request body for subscribing to Web Push notifications."""
+class _PushEndpointMixin(BaseModel):
+    """Shared validation for Web Push endpoint URLs (HTTPS-only, length-bounded)."""
 
     endpoint: str = Field(max_length=2048, description="Push service endpoint URL")
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint_url(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("Push endpoint must use HTTPS")
+        return v
+
+
+class PushSubscriptionRequest(_PushEndpointMixin):
+    """Request body for subscribing to Web Push notifications."""
+
     p256dh_key: str = Field(
         max_length=256, description="Client public key for message encryption"
     )
     auth_key: str = Field(max_length=256, description="Client authentication secret")
 
-    @field_validator("endpoint")
-    @classmethod
-    def validate_endpoint_url(cls, v: str) -> str:
-        if not v.startswith("https://"):
-            raise ValueError("Push endpoint must use HTTPS")
-        return v
 
-
-class UnsubscribeRequest(BaseModel):
+class UnsubscribeRequest(_PushEndpointMixin):
     """Request body for unsubscribing from Web Push notifications."""
-
-    endpoint: str = Field(
-        max_length=2048, description="Push service endpoint URL to remove"
-    )
-
-    @field_validator("endpoint")
-    @classmethod
-    def validate_endpoint_url(cls, v: str) -> str:
-        if not v.startswith("https://"):
-            raise ValueError("Push endpoint must use HTTPS")
-        return v
 
 
 class BulkDeleteRequest(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -722,6 +722,36 @@ class ReportPortalPushResult(BaseModel):
     launch_id: int | None = Field(default=None, description="Report Portal launch ID")
 
 
+class PushSubscriptionRequest(BaseModel):
+    """Request body for subscribing to Web Push notifications."""
+
+    endpoint: str = Field(description="Push service endpoint URL")
+    p256dh_key: str = Field(
+        max_length=256, description="Client public key for message encryption"
+    )
+    auth_key: str = Field(max_length=256, description="Client authentication secret")
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint_url(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("Push endpoint must use HTTPS")
+        return v
+
+
+class UnsubscribeRequest(BaseModel):
+    """Request body for unsubscribing from Web Push notifications."""
+
+    endpoint: str = Field(description="Push service endpoint URL to remove")
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint_url(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("Push endpoint must use HTTPS")
+        return v
+
+
 class BulkDeleteRequest(BaseModel):
     """Request body for bulk-deleting jobs."""
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -725,7 +725,7 @@ class ReportPortalPushResult(BaseModel):
 class PushSubscriptionRequest(BaseModel):
     """Request body for subscribing to Web Push notifications."""
 
-    endpoint: str = Field(description="Push service endpoint URL")
+    endpoint: str = Field(max_length=2048, description="Push service endpoint URL")
     p256dh_key: str = Field(
         max_length=256, description="Client public key for message encryption"
     )
@@ -742,7 +742,9 @@ class PushSubscriptionRequest(BaseModel):
 class UnsubscribeRequest(BaseModel):
     """Request body for unsubscribing from Web Push notifications."""
 
-    endpoint: str = Field(description="Push service endpoint URL to remove")
+    endpoint: str = Field(
+        max_length=2048, description="Push service endpoint URL to remove"
+    )
 
     @field_validator("endpoint")
     @classmethod

--- a/src/jenkins_job_insight/monitoring.py
+++ b/src/jenkins_job_insight/monitoring.py
@@ -485,8 +485,8 @@ class AlertThrottler:
     def should_alert(self, event_type: str) -> bool:
         now = time.monotonic()
         with self._lock:
-            last = self._last_sent.get(event_type, 0.0)
-            if now - last >= self.cooldown_seconds:
+            last = self._last_sent.get(event_type)
+            if last is None or now - last >= self.cooldown_seconds:
                 self._last_sent[event_type] = now
                 return True
         return False

--- a/src/jenkins_job_insight/notifications.py
+++ b/src/jenkins_job_insight/notifications.py
@@ -34,7 +34,11 @@ async def _send_one(
             },
             data=payload_str,
             vapid_private_key=vapid_private_key,
-            vapid_claims={"sub": f"mailto:{vapid_claim_email}"},
+            vapid_claims={
+                "sub": vapid_claim_email
+                if vapid_claim_email.startswith("mailto:")
+                else f"mailto:{vapid_claim_email}"
+            },
         )
         logger.debug(
             "send_mention_notifications: sent to %s at %s",

--- a/src/jenkins_job_insight/notifications.py
+++ b/src/jenkins_job_insight/notifications.py
@@ -57,7 +57,7 @@ async def _send_one(
             sub["username"],
             exc,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 — best-effort delivery; log and continue
         logger.warning(
             "send_mention_notifications: unexpected error sending to %s: %s",
             sub["username"],
@@ -118,7 +118,7 @@ async def send_mention_notifications(
         if stale_endpoints:
             await delete_stale_push_subscriptions(stale_endpoints)
 
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort dispatch; never propagate
         logger.warning(
             "send_mention_notifications: unexpected error in notification dispatch",
             exc_info=True,

--- a/src/jenkins_job_insight/notifications.py
+++ b/src/jenkins_job_insight/notifications.py
@@ -1,0 +1,106 @@
+"""Web Push notification dispatch for @mentions in comments."""
+
+import asyncio
+import json
+import os
+
+from pywebpush import WebPushException, webpush
+from simple_logger.logger import get_logger
+
+from jenkins_job_insight.storage import (
+    delete_stale_push_subscriptions,
+    get_push_subscriptions_for_users,
+)
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+async def send_mention_notifications(
+    mentioned_usernames: list[str],
+    comment_author: str,
+    job_id: str,
+    test_name: str,
+    vapid_private_key: str,
+    vapid_claim_email: str,
+    public_base_url: str | None = None,
+) -> None:
+    """Send Web Push notifications to mentioned users.
+
+    Best-effort — failures are logged but never raised.
+    Removes stale subscriptions (410 Gone) automatically.
+    Does not notify the comment author if they mention themselves.
+    """
+    try:
+        recipients = [u for u in mentioned_usernames if u != comment_author]
+        if not recipients:
+            return
+
+        subscriptions = await get_push_subscriptions_for_users(recipients)
+        if not subscriptions:
+            logger.debug(
+                f"send_mention_notifications: no subscriptions for {recipients}"
+            )
+            return
+
+        report_path = f"/report/{job_id}"
+        url = (
+            f"{public_base_url.rstrip('/')}{report_path}"
+            if public_base_url
+            else report_path
+        )
+        payload = json.dumps(
+            {
+                "title": f"Mentioned by @{comment_author}",
+                "body": f"@{comment_author} mentioned you in a comment on {test_name}",
+                "url": url,
+            }
+        )
+        vapid_claims = {"sub": f"mailto:{vapid_claim_email}"}
+
+        stale_endpoints: list[str] = []
+
+        for sub in subscriptions:
+            try:
+                await asyncio.to_thread(
+                    webpush,
+                    subscription_info={
+                        "endpoint": sub["endpoint"],
+                        "keys": {
+                            "p256dh": sub["p256dh_key"],
+                            "auth": sub["auth_key"],
+                        },
+                    },
+                    data=payload,
+                    vapid_private_key=vapid_private_key,
+                    vapid_claims=vapid_claims,
+                )
+                logger.debug(
+                    f"send_mention_notifications: sent to {sub['username']} at {sub['endpoint'][:60]}..."
+                )
+            except WebPushException as exc:
+                if (
+                    hasattr(exc, "response")
+                    and exc.response is not None
+                    and exc.response.status_code == 410
+                ):
+                    logger.info(
+                        f"send_mention_notifications: stale subscription (410) for {sub['username']}, scheduling removal"
+                    )
+                    stale_endpoints.append(sub["endpoint"])
+                else:
+                    logger.warning(
+                        f"send_mention_notifications: failed to send to {sub['username']}: {exc}"
+                    )
+            except Exception as exc:
+                logger.warning(
+                    f"send_mention_notifications: unexpected error sending to {sub['username']}: {exc}"
+                )
+
+        if stale_endpoints:
+            await delete_stale_push_subscriptions(stale_endpoints)
+
+    except Exception:
+        logger.warning(
+            "send_mention_notifications: unexpected error in notification dispatch",
+            exc_info=True,
+        )

--- a/src/jenkins_job_insight/notifications.py
+++ b/src/jenkins_job_insight/notifications.py
@@ -15,6 +15,57 @@ from jenkins_job_insight.storage import (
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
 
+async def _send_one(
+    sub: dict,
+    payload_str: str,
+    vapid_private_key: str,
+    vapid_claim_email: str,
+) -> str | None:
+    """Send a single push notification. Returns endpoint if stale (410), else None."""
+    try:
+        await asyncio.to_thread(
+            webpush,
+            subscription_info={
+                "endpoint": sub["endpoint"],
+                "keys": {
+                    "p256dh": sub["p256dh_key"],
+                    "auth": sub["auth_key"],
+                },
+            },
+            data=payload_str,
+            vapid_private_key=vapid_private_key,
+            vapid_claims={"sub": f"mailto:{vapid_claim_email}"},
+        )
+        logger.debug(
+            "send_mention_notifications: sent to %s at %s",
+            sub["username"],
+            sub["endpoint"],
+        )
+    except WebPushException as exc:
+        if (
+            hasattr(exc, "response")
+            and exc.response is not None
+            and exc.response.status_code == 410
+        ):
+            logger.info(
+                "send_mention_notifications: stale subscription (410) for %s, scheduling removal",
+                sub["username"],
+            )
+            return sub["endpoint"]
+        logger.warning(
+            "send_mention_notifications: failed to send to %s: %s",
+            sub["username"],
+            exc,
+        )
+    except Exception as exc:
+        logger.warning(
+            "send_mention_notifications: unexpected error sending to %s: %s",
+            sub["username"],
+            exc,
+        )
+    return None
+
+
 async def send_mention_notifications(
     mentioned_usernames: list[str],
     comment_author: str,
@@ -55,46 +106,14 @@ async def send_mention_notifications(
                 "url": url,
             }
         )
-        vapid_claims = {"sub": f"mailto:{vapid_claim_email}"}
-
-        stale_endpoints: list[str] = []
-
-        for sub in subscriptions:
-            try:
-                await asyncio.to_thread(
-                    webpush,
-                    subscription_info={
-                        "endpoint": sub["endpoint"],
-                        "keys": {
-                            "p256dh": sub["p256dh_key"],
-                            "auth": sub["auth_key"],
-                        },
-                    },
-                    data=payload,
-                    vapid_private_key=vapid_private_key,
-                    vapid_claims=vapid_claims,
-                )
-                logger.debug(
-                    f"send_mention_notifications: sent to {sub['username']} at {sub['endpoint'][:60]}..."
-                )
-            except WebPushException as exc:
-                if (
-                    hasattr(exc, "response")
-                    and exc.response is not None
-                    and exc.response.status_code == 410
-                ):
-                    logger.info(
-                        f"send_mention_notifications: stale subscription (410) for {sub['username']}, scheduling removal"
-                    )
-                    stale_endpoints.append(sub["endpoint"])
-                else:
-                    logger.warning(
-                        f"send_mention_notifications: failed to send to {sub['username']}: {exc}"
-                    )
-            except Exception as exc:
-                logger.warning(
-                    f"send_mention_notifications: unexpected error sending to {sub['username']}: {exc}"
-                )
+        results = await asyncio.gather(
+            *[
+                _send_one(sub, payload, vapid_private_key, vapid_claim_email)
+                for sub in subscriptions
+            ],
+            return_exceptions=True,
+        )
+        stale_endpoints = [r for r in results if isinstance(r, str)]
 
         if stale_endpoints:
             await delete_stale_push_subscriptions(stale_endpoints)

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3179,7 +3179,7 @@ async def save_push_subscription(
 
     Upserts by endpoint — a user can have multiple subscriptions (multiple browsers/devices).
     """
-    logger.debug(f"save_push_subscription: username={username}, endpoint={endpoint}")
+    logger.debug(f"save_push_subscription: username={username}")
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("BEGIN IMMEDIATE")
         await db.execute(
@@ -3195,7 +3195,7 @@ async def save_push_subscription(
         # Enforce per-user subscription limit: delete oldest beyond the cap
         await db.execute(
             "DELETE FROM push_subscriptions WHERE username = ? AND id NOT IN "
-            "(SELECT id FROM push_subscriptions WHERE username = ? ORDER BY id DESC LIMIT ?)",
+            "(SELECT id FROM push_subscriptions WHERE username = ? ORDER BY created_at DESC, id DESC LIMIT ?)",
             (username, username, MAX_PUSH_SUBSCRIPTIONS_PER_USER),
         )
         await db.commit()
@@ -3206,7 +3206,7 @@ async def delete_push_subscription(endpoint: str, username: str) -> bool:
 
     Returns True if deleted, False if not found or not owned by username.
     """
-    logger.debug(f"delete_push_subscription: endpoint={endpoint}, username={username}")
+    logger.debug(f"delete_push_subscription: username={username}")
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             "DELETE FROM push_subscriptions WHERE endpoint = ? AND username = ?",
@@ -3231,7 +3231,7 @@ async def get_push_subscriptions_for_users(usernames: list[str]) -> list[dict]:
         placeholders = ",".join("?" for _ in usernames)
         cursor = await db.execute(
             f"SELECT username, endpoint, p256dh_key, auth_key "  # noqa: S608
-            f"FROM push_subscriptions WHERE username IN ({placeholders})",
+            f"FROM push_subscriptions WHERE username IN ({placeholders})",  # noqa: S608
             usernames,
         )
         rows = await cursor.fetchall()

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3177,10 +3177,9 @@ async def save_push_subscription(
 
     Upserts by endpoint — a user can have multiple subscriptions (multiple browsers/devices).
     """
-    logger.debug(
-        f"save_push_subscription: username={username}, endpoint={endpoint[:60]}..."
-    )
+    logger.debug(f"save_push_subscription: username={username}, endpoint={endpoint}")
     async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("BEGIN IMMEDIATE")
         await db.execute(
             "INSERT INTO push_subscriptions (username, endpoint, p256dh_key, auth_key) "
             "VALUES (?, ?, ?, ?) "
@@ -3205,9 +3204,7 @@ async def delete_push_subscription(endpoint: str, username: str) -> bool:
 
     Returns True if deleted, False if not found or not owned by username.
     """
-    logger.debug(
-        f"delete_push_subscription: endpoint={endpoint[:60]}..., username={username}"
-    )
+    logger.debug(f"delete_push_subscription: endpoint={endpoint}, username={username}")
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             "DELETE FROM push_subscriptions WHERE endpoint = ? AND username = ?",
@@ -3231,7 +3228,7 @@ async def get_push_subscriptions_for_users(usernames: list[str]) -> list[dict]:
         db.row_factory = aiosqlite.Row
         placeholders = ",".join("?" for _ in usernames)
         cursor = await db.execute(
-            f"SELECT username, endpoint, p256dh_key, auth_key "
+            f"SELECT username, endpoint, p256dh_key, auth_key "  # noqa: S608
             f"FROM push_subscriptions WHERE username IN ({placeholders})",
             usernames,
         )
@@ -3249,7 +3246,7 @@ async def delete_stale_push_subscriptions(endpoints: list[str]) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
         placeholders = ",".join("?" for _ in endpoints)
         await db.execute(
-            f"DELETE FROM push_subscriptions WHERE endpoint IN ({placeholders})",
+            f"DELETE FROM push_subscriptions WHERE endpoint IN ({placeholders})",  # noqa: S608
             endpoints,
         )
         await db.commit()

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3137,6 +3137,8 @@ async def get_token_usage_dashboard_summary() -> dict:
             cursor = await db.execute(
                 f"SELECT COUNT(*) as calls, "  # noqa: S608
                 f"COALESCE(SUM(total_tokens), 0) as tokens, "
+                f"COALESCE(SUM(input_tokens), 0) as input_tokens, "
+                f"COALESCE(SUM(output_tokens), 0) as output_tokens, "
                 f"COALESCE(SUM(cost_usd), 0) as cost_usd "
                 f"FROM ai_token_usage WHERE {condition}"
             )

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -421,6 +421,21 @@ async def init_db() -> None:
             "CREATE INDEX IF NOT EXISTS idx_token_usage_call_type ON ai_token_usage (call_type)"
         )
 
+        # Push notification subscriptions
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS push_subscriptions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL,
+                endpoint TEXT NOT NULL UNIQUE,
+                p256dh_key TEXT NOT NULL,
+                auth_key TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_push_subscriptions_username ON push_subscriptions (username)"
+        )
+
         await db.commit()
 
     # Backfill failure_history from existing results (runs once when table is empty).
@@ -3148,3 +3163,93 @@ async def get_token_usage_dashboard_summary() -> dict:
         result["top_jobs"] = [dict(row) for row in await cursor.fetchall()]
 
         return result
+
+
+# --- Push Subscriptions ---
+
+MAX_PUSH_SUBSCRIPTIONS_PER_USER = 10
+
+
+async def save_push_subscription(
+    username: str, endpoint: str, p256dh_key: str, auth_key: str
+) -> None:
+    """Save or update a push subscription for a user.
+
+    Upserts by endpoint — a user can have multiple subscriptions (multiple browsers/devices).
+    """
+    logger.debug(
+        f"save_push_subscription: username={username}, endpoint={endpoint[:60]}..."
+    )
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO push_subscriptions (username, endpoint, p256dh_key, auth_key) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(endpoint) DO UPDATE SET "
+            "username = excluded.username, "
+            "p256dh_key = excluded.p256dh_key, "
+            "auth_key = excluded.auth_key, "
+            "created_at = CURRENT_TIMESTAMP",
+            (username, endpoint, p256dh_key, auth_key),
+        )
+        # Enforce per-user subscription limit: delete oldest beyond the cap
+        await db.execute(
+            "DELETE FROM push_subscriptions WHERE username = ? AND id NOT IN "
+            "(SELECT id FROM push_subscriptions WHERE username = ? ORDER BY id DESC LIMIT ?)",
+            (username, username, MAX_PUSH_SUBSCRIPTIONS_PER_USER),
+        )
+        await db.commit()
+
+
+async def delete_push_subscription(endpoint: str, username: str) -> bool:
+    """Remove a push subscription by endpoint, scoped to the owning user.
+
+    Returns True if deleted, False if not found or not owned by username.
+    """
+    logger.debug(
+        f"delete_push_subscription: endpoint={endpoint[:60]}..., username={username}"
+    )
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM push_subscriptions WHERE endpoint = ? AND username = ?",
+            (endpoint, username),
+        )
+        await db.commit()
+        deleted = cursor.rowcount > 0
+        logger.debug(f"delete_push_subscription: deleted={deleted}")
+        return deleted
+
+
+async def get_push_subscriptions_for_users(usernames: list[str]) -> list[dict]:
+    """Get all push subscriptions for a list of usernames.
+
+    Returns list of dicts with: username, endpoint, p256dh_key, auth_key.
+    """
+    if not usernames:
+        return []
+    logger.debug(f"get_push_subscriptions_for_users: usernames_count={len(usernames)}")
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        placeholders = ",".join("?" for _ in usernames)
+        cursor = await db.execute(
+            f"SELECT username, endpoint, p256dh_key, auth_key "
+            f"FROM push_subscriptions WHERE username IN ({placeholders})",
+            usernames,
+        )
+        rows = await cursor.fetchall()
+        result = [dict(row) for row in rows]
+        logger.debug(f"get_push_subscriptions_for_users: count={len(result)}")
+        return result
+
+
+async def delete_stale_push_subscriptions(endpoints: list[str]) -> None:
+    """Remove expired/invalid push subscriptions by endpoint."""
+    if not endpoints:
+        return
+    logger.debug(f"delete_stale_push_subscriptions: endpoints_count={len(endpoints)}")
+    async with aiosqlite.connect(DB_PATH) as db:
+        placeholders = ",".join("?" for _ in endpoints)
+        await db.execute(
+            f"DELETE FROM push_subscriptions WHERE endpoint IN ({placeholders})",
+            endpoints,
+        )
+        await db.commit()

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3182,23 +3182,27 @@ async def save_push_subscription(
     logger.debug(f"save_push_subscription: username={username}")
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("BEGIN IMMEDIATE")
-        await db.execute(
-            "INSERT INTO push_subscriptions (username, endpoint, p256dh_key, auth_key) "
-            "VALUES (?, ?, ?, ?) "
-            "ON CONFLICT(endpoint) DO UPDATE SET "
-            "username = excluded.username, "
-            "p256dh_key = excluded.p256dh_key, "
-            "auth_key = excluded.auth_key, "
-            "created_at = CURRENT_TIMESTAMP",
-            (username, endpoint, p256dh_key, auth_key),
-        )
-        # Enforce per-user subscription limit: delete oldest beyond the cap
-        await db.execute(
-            "DELETE FROM push_subscriptions WHERE username = ? AND id NOT IN "
-            "(SELECT id FROM push_subscriptions WHERE username = ? ORDER BY created_at DESC, id DESC LIMIT ?)",
-            (username, username, MAX_PUSH_SUBSCRIPTIONS_PER_USER),
-        )
-        await db.commit()
+        try:
+            await db.execute(
+                "INSERT INTO push_subscriptions (username, endpoint, p256dh_key, auth_key) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(endpoint) DO UPDATE SET "
+                "username = excluded.username, "
+                "p256dh_key = excluded.p256dh_key, "
+                "auth_key = excluded.auth_key, "
+                "created_at = CURRENT_TIMESTAMP",
+                (username, endpoint, p256dh_key, auth_key),
+            )
+            # Enforce per-user subscription limit: delete oldest beyond the cap
+            await db.execute(
+                "DELETE FROM push_subscriptions WHERE username = ? AND id NOT IN "
+                "(SELECT id FROM push_subscriptions WHERE username = ? ORDER BY created_at DESC, id DESC LIMIT ?)",
+                (username, username, MAX_PUSH_SUBSCRIPTIONS_PER_USER),
+            )
+            await db.commit()
+        except Exception:
+            await db.execute("ROLLBACK")
+            raise
 
 
 async def delete_push_subscription(endpoint: str, username: str) -> bool:

--- a/src/jenkins_job_insight/vapid.py
+++ b/src/jenkins_job_insight/vapid.py
@@ -1,0 +1,159 @@
+"""VAPID key management for Web Push notifications.
+
+VAPID keys are read from environment variables (VAPID_PUBLIC_KEY,
+VAPID_PRIVATE_KEY). When not set, a key pair is auto-generated on
+first use and persisted to $XDG_DATA_HOME/jji/.vapid_keys.json
+(defaults to ~/.local/share/jji/.vapid_keys.json).
+
+The claim email defaults to 'mailto:noreply@jji.local' if
+VAPID_CLAIM_EMAIL is not set.
+"""
+
+import base64
+import json
+import os
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from simple_logger.logger import get_logger
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+DEFAULT_CLAIM_EMAIL = "mailto:noreply@jji.local"
+
+
+def _get_data_dir() -> Path:
+    """Return the JJI data directory (same as encryption.py)."""
+    return (
+        Path(os.environ.get("XDG_DATA_HOME", ""))
+        if os.environ.get("XDG_DATA_HOME")
+        else Path.home() / ".local" / "share"
+    ) / "jji"
+
+
+def _generate_vapid_keys() -> dict:
+    """Generate a new VAPID key pair.
+
+    Returns dict with ``public_key`` and ``private_key`` as URL-safe
+    base64 strings (unpadded).
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+
+    # Private key: raw 32-byte scalar, URL-safe base64
+    priv_numbers = private_key.private_numbers()
+    priv_bytes = priv_numbers.private_value.to_bytes(32, "big")
+    priv_b64 = base64.urlsafe_b64encode(priv_bytes).rstrip(b"=").decode()
+
+    # Public key: uncompressed point (65 bytes), URL-safe base64
+    pub_bytes = private_key.public_key().public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+    pub_b64 = base64.urlsafe_b64encode(pub_bytes).rstrip(b"=").decode()
+
+    return {"public_key": pub_b64, "private_key": priv_b64}
+
+
+def _read_key_file_when_ready(
+    key_file: Path, retries: int = 20, delay_seconds: float = 0.05
+) -> dict:
+    """Read VAPID keys from file, retrying briefly for a racing writer.
+
+    Another process may have created the file but not yet written the
+    keys.  We retry with short sleeps before treating the file as corrupt.
+
+    Raises ``RuntimeError`` if the file remains empty/corrupt after all
+    retries.
+    """
+    for attempt in range(retries):
+        try:
+            keys = json.loads(key_file.read_text(encoding="utf-8"))
+            if keys.get("public_key") and keys.get("private_key"):
+                return keys
+            raise RuntimeError("missing keys")
+        except (json.JSONDecodeError, RuntimeError, OSError):
+            if attempt == retries - 1:
+                raise RuntimeError(f"VAPID key file {key_file} is empty or corrupt")
+            time.sleep(delay_seconds)
+    raise RuntimeError(
+        f"VAPID key file {key_file} is empty or corrupt"
+    )  # pragma: no cover
+
+
+def _ensure_private_key_file(key_file: Path) -> None:
+    """Tighten permissions to 0600 if the file is group/world-readable."""
+    if key_file.stat().st_mode & 0o077:
+        key_file.chmod(0o600)
+
+
+def _get_or_create_vapid_keys() -> dict:
+    """Return VAPID keys from file, generating on first use.
+
+    The key file is stored at ``$XDG_DATA_HOME/jji/.vapid_keys.json``
+    (defaults to ``~/.local/share/jji/.vapid_keys.json``) and is only
+    readable by the owning user (mode 0600).
+
+    Returns dict with ``public_key`` and ``private_key``.
+    """
+    data_dir = _get_data_dir()
+    key_file = data_dir / ".vapid_keys.json"
+
+    if key_file.exists():
+        _ensure_private_key_file(key_file)
+        try:
+            return _read_key_file_when_ready(key_file)
+        except RuntimeError:
+            logger.warning("VAPID key file %s is corrupt, regenerating", key_file)
+            key_file.unlink(missing_ok=True)
+
+    # Generate new keys
+    keys = _generate_vapid_keys()
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use O_CREAT|O_EXCL for atomic exclusive creation to avoid TOCTOU races.
+    try:
+        fd = os.open(str(key_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(keys, f)
+        logger.info("Generated VAPID keys at %s", key_file)
+    except FileExistsError:
+        # Another process created the file — read theirs
+        _ensure_private_key_file(key_file)
+        return _read_key_file_when_ready(key_file)
+
+    return keys
+
+
+def get_vapid_config() -> dict:
+    """Return the full VAPID configuration.
+
+    Priority: env vars > auto-generated file.
+
+    Returns dict with ``public_key``, ``private_key``, ``claim_email``.
+    Returns empty dict if keys cannot be resolved.
+    """
+    pub = os.environ.get("VAPID_PUBLIC_KEY", "").strip()
+    priv = os.environ.get("VAPID_PRIVATE_KEY", "").strip()
+    email = os.environ.get("VAPID_CLAIM_EMAIL", "").strip()
+
+    if pub and priv:
+        # Env vars take priority
+        return {
+            "public_key": pub,
+            "private_key": priv,
+            "claim_email": email or DEFAULT_CLAIM_EMAIL,
+        }
+
+    # Auto-generate
+    try:
+        keys = _get_or_create_vapid_keys()
+        return {
+            "public_key": keys["public_key"],
+            "private_key": keys["private_key"],
+            "claim_email": email or DEFAULT_CLAIM_EMAIL,
+        }
+    except Exception:
+        logger.warning("Failed to resolve VAPID keys", exc_info=True)
+        return {}

--- a/src/jenkins_job_insight/vapid.py
+++ b/src/jenkins_job_insight/vapid.py
@@ -73,9 +73,11 @@ def _read_key_file_when_ready(
             if keys.get("public_key") and keys.get("private_key"):
                 return keys
             raise RuntimeError("missing keys")
-        except (json.JSONDecodeError, RuntimeError, OSError):
+        except (json.JSONDecodeError, RuntimeError, OSError) as err:
             if attempt == retries - 1:
-                raise RuntimeError(f"VAPID key file {key_file} is empty or corrupt")
+                raise RuntimeError(
+                    f"VAPID key file {key_file} is empty or corrupt"
+                ) from err
             time.sleep(delay_seconds)
     raise RuntimeError(
         f"VAPID key file {key_file} is empty or corrupt"
@@ -154,6 +156,6 @@ def get_vapid_config() -> dict:
             "private_key": keys["private_key"],
             "claim_email": email or DEFAULT_CLAIM_EMAIL,
         }
-    except Exception:
+    except Exception:  # noqa: BLE001 — VAPID resolution must never raise; callers gate on truthy dict
         logger.warning("Failed to resolve VAPID keys", exc_info=True)
         return {}

--- a/src/jenkins_job_insight/vapid.py
+++ b/src/jenkins_job_insight/vapid.py
@@ -2,8 +2,9 @@
 
 VAPID keys are read from environment variables (VAPID_PUBLIC_KEY,
 VAPID_PRIVATE_KEY). When not set, a key pair is auto-generated on
-first use and persisted to $XDG_DATA_HOME/jji/.vapid_keys.json
-(defaults to ~/.local/share/jji/.vapid_keys.json).
+first use and persisted alongside the database (parent of DB_PATH).
+Falls back to $XDG_DATA_HOME/jji/ or ~/.local/share/jji/ when
+DB_PATH is not set.
 
 The claim email defaults to 'mailto:noreply@jji.local' if
 VAPID_CLAIM_EMAIL is not set.
@@ -25,7 +26,15 @@ DEFAULT_CLAIM_EMAIL = "mailto:noreply@jji.local"
 
 
 def _get_data_dir() -> Path:
-    """Return the JJI data directory (same as encryption.py)."""
+    """Return the data directory for persistent files.
+
+    Uses the parent directory of DB_PATH (same volume as the database).
+    Falls back to $XDG_DATA_HOME/jji/ or ~/.local/share/jji/.
+    """
+    db_path = os.getenv("DB_PATH", "")
+    if db_path:
+        return Path(db_path).parent
+
     return (
         Path(os.environ.get("XDG_DATA_HOME", ""))
         if os.environ.get("XDG_DATA_HOME")

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -101,21 +101,6 @@ class TestSubscribeNotifications:
         assert resp.status_code == 401
         assert "username" in resp.json()["detail"].lower()
 
-    def test_subscribe_400_unregistered_username(self, client_with_push):
-        # Patch track_user so the middleware doesn't auto-register the user
-        with patch.object(storage, "track_user", new_callable=AsyncMock):
-            resp = client_with_push.post(
-                "/api/notifications/subscribe",
-                json={
-                    "endpoint": "https://push.example.com/sub/test-1",
-                    "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
-                    "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
-                },
-                cookies={"jji_username": "unknown_user"},
-            )
-        assert resp.status_code == 400
-        assert "not registered" in resp.json()["detail"].lower()
-
     def test_subscribe_404_when_push_not_configured(self, client_no_push):
         resp = client_no_push.post(
             "/api/notifications/subscribe",
@@ -188,6 +173,14 @@ class TestUnsubscribeNotifications:
             json={"endpoint": "https://push.example.com/sub/test-1"},
         )
         assert resp.status_code == 401
+
+    def test_unsubscribe_404_when_push_not_configured(self, client_no_push):
+        resp = client_no_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "https://push.example.com/sub/test-1"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 404
 
 
 class TestEndpointHttpsValidation:

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -1,0 +1,335 @@
+"""Tests for notification and mention API endpoints."""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.config import get_settings
+
+
+@pytest.fixture
+def _init_db(temp_db_path):
+    """Initialize database with test path."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(storage.init_db())
+        yield
+
+
+def _make_client(temp_db_path, vapid_env: dict | None = None):
+    """Create a test client with optional VAPID config."""
+    env = {
+        "SECURE_COOKIES": "false",
+        "DB_PATH": str(temp_db_path),
+    }
+    if vapid_env:
+        env.update(vapid_env)
+    with patch.dict(os.environ, env, clear=False):
+        get_settings.cache_clear()
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as c:
+                yield c
+        get_settings.cache_clear()
+
+
+_VAPID_ENV = {
+    "VAPID_PUBLIC_KEY": "BFakePublicKeyForTesting123456789012345678901234567890",  # pragma: allowlist secret
+    "VAPID_PRIVATE_KEY": "fake-private-key-for-testing",  # pragma: allowlist secret
+    "VAPID_CLAIM_EMAIL": "admin@example.com",
+}
+
+
+@pytest.fixture
+def client_with_push(_init_db, temp_db_path):
+    """Client with VAPID/push configured."""
+    yield from _make_client(temp_db_path, vapid_env=_VAPID_ENV)
+
+
+@pytest.fixture
+def client_no_push(_init_db, temp_db_path):
+    """Client without VAPID/push configured."""
+    yield from _make_client(temp_db_path)
+
+
+class TestVapidPublicKey:
+    """Tests for GET /api/notifications/vapid-public-key."""
+
+    def test_returns_key_when_configured(self, client_with_push):
+        resp = client_with_push.get("/api/notifications/vapid-public-key")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["vapid_public_key"] == _VAPID_ENV["VAPID_PUBLIC_KEY"]
+
+    def test_returns_404_when_not_configured(self, client_no_push):
+        resp = client_no_push.get("/api/notifications/vapid-public-key")
+        assert resp.status_code == 404
+        assert "not configured" in resp.json()["detail"].lower()
+
+
+class TestSubscribeNotifications:
+    """Tests for POST /api/notifications/subscribe."""
+
+    def test_subscribe_success(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "https://push.example.com/sub/test-1",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "subscribed"
+
+    def test_subscribe_401_without_username(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "https://push.example.com/sub/test-1",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        )
+        assert resp.status_code == 401
+        assert "username" in resp.json()["detail"].lower()
+
+    def test_subscribe_404_when_push_not_configured(self, client_no_push):
+        resp = client_no_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "https://push.example.com/sub/test-1",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 404
+
+
+class TestUnsubscribeNotifications:
+    """Tests for POST /api/notifications/unsubscribe."""
+
+    def test_unsubscribe_success(self, client_with_push):
+        # First subscribe
+        client_with_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "https://push.example.com/sub/unsub-test",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            cookies={"jji_username": "alice"},
+        )
+        # Then unsubscribe
+        resp = client_with_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "https://push.example.com/sub/unsub-test"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unsubscribed"
+
+    def test_unsubscribe_404_for_nonexistent(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "https://push.example.com/sub/nonexistent"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_unsubscribe_only_own_subscription(self, client_with_push):
+        """A user cannot unsubscribe another user's endpoint."""
+        # alice subscribes
+        client_with_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "https://push.example.com/sub/alice-only",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            cookies={"jji_username": "alice"},
+        )
+        # bob tries to unsubscribe alice's endpoint
+        resp = client_with_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "https://push.example.com/sub/alice-only"},
+            cookies={"jji_username": "bob"},
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_unsubscribe_401_without_username(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "https://push.example.com/sub/test-1"},
+        )
+        assert resp.status_code == 401
+
+
+class TestEndpointHttpsValidation:
+    """Tests for HTTPS endpoint validation."""
+
+    def test_subscribe_rejects_http_endpoint(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/subscribe",
+            json={
+                "endpoint": "http://push.example.com/sub/insecure",
+                "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 422
+
+    def test_unsubscribe_rejects_http_endpoint(self, client_with_push):
+        resp = client_with_push.post(
+            "/api/notifications/unsubscribe",
+            json={"endpoint": "http://push.example.com/sub/insecure"},
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 422
+
+
+class TestMentionableUsers:
+    """Tests for GET /api/users/mentionable."""
+
+    def test_returns_user_list(self, client_with_push):
+        """Returns list of tracked users."""
+        # Make a request as alice to trigger user tracking, then wait
+        client_with_push.get(
+            "/api/notifications/vapid-public-key",
+            cookies={"jji_username": "alice"},
+        )
+        # Give background task time to track user
+        import time
+
+        time.sleep(0.2)
+
+        resp = client_with_push.get(
+            "/api/users/mentionable",
+            cookies={"jji_username": "alice"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "usernames" in data
+        assert isinstance(data["usernames"], list)
+
+    def test_401_without_username(self, client_with_push):
+        resp = client_with_push.get("/api/users/mentionable")
+        assert resp.status_code == 401
+
+
+class TestCommentMentionNotification:
+    """Tests for mention detection in POST /results/{job_id}/comments."""
+
+    @pytest.fixture
+    def _seed_result(self, _init_db, temp_db_path):
+        """Create a completed result with a failure for comment testing."""
+        result_data = {
+            "status": "completed",
+            "summary": "1 failure",
+            "failures": [
+                {
+                    "test_name": "test_foo",
+                    "error": "AssertionError",
+                    "analysis": {"classification": "CODE ISSUE", "details": "test"},
+                }
+            ],
+        }
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(
+                storage.save_result(
+                    "job-mention", "http://jenkins/1", "completed", result_data
+                )
+            )
+
+    def test_comment_with_mention_triggers_notification(
+        self, _seed_result, temp_db_path
+    ):
+        """Adding a comment with @mention triggers send_mention_notifications."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SECURE_COOKIES": "false",
+                    "DB_PATH": str(temp_db_path),
+                    **_VAPID_ENV,
+                },
+                clear=False,
+            ),
+            patch.object(storage, "DB_PATH", temp_db_path),
+        ):
+            get_settings.cache_clear()
+            with patch(
+                "jenkins_job_insight.main.send_mention_notifications",
+                new_callable=AsyncMock,
+            ) as mock_send:
+                from jenkins_job_insight.main import app
+
+                with TestClient(app) as client:
+                    resp = client.post(
+                        "/results/job-mention/comments",
+                        json={
+                            "test_name": "test_foo",
+                            "comment": "Hey @bob, can you check this?",
+                        },
+                        cookies={"jji_username": "alice"},
+                    )
+                    assert resp.status_code == 201
+                    # Give the fire-and-forget task time to run
+                    import time
+
+                    time.sleep(0.2)
+
+                mock_send.assert_called_once()
+                call_kwargs = mock_send.call_args.kwargs
+                assert call_kwargs["mentioned_usernames"] == ["bob"]
+                assert call_kwargs["comment_author"] == "alice"
+                assert call_kwargs["job_id"] == "job-mention"
+                assert call_kwargs["test_name"] == "test_foo"
+            get_settings.cache_clear()
+
+    def test_comment_without_mention_no_notification(self, _seed_result, temp_db_path):
+        """A comment without @mentions does not trigger notifications."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "SECURE_COOKIES": "false",
+                    "DB_PATH": str(temp_db_path),
+                    **_VAPID_ENV,
+                },
+                clear=False,
+            ),
+            patch.object(storage, "DB_PATH", temp_db_path),
+        ):
+            get_settings.cache_clear()
+            with patch(
+                "jenkins_job_insight.main.send_mention_notifications",
+                new_callable=AsyncMock,
+            ) as mock_send:
+                from jenkins_job_insight.main import app
+
+                with TestClient(app) as client:
+                    resp = client.post(
+                        "/results/job-mention/comments",
+                        json={
+                            "test_name": "test_foo",
+                            "comment": "Looks good, no issues here.",
+                        },
+                        cookies={"jji_username": "alice"},
+                    )
+                    assert resp.status_code == 201
+                    import time
+
+                    time.sleep(0.2)
+
+                mock_send.assert_not_called()
+            get_settings.cache_clear()

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -16,6 +16,8 @@ def _init_db(temp_db_path):
     """Initialize database with test path."""
     with patch.object(storage, "DB_PATH", temp_db_path):
         asyncio.run(storage.init_db())
+        asyncio.run(storage.track_user("alice"))
+        asyncio.run(storage.track_user("bob"))
         yield
 
 
@@ -98,6 +100,21 @@ class TestSubscribeNotifications:
         )
         assert resp.status_code == 401
         assert "username" in resp.json()["detail"].lower()
+
+    def test_subscribe_400_unregistered_username(self, client_with_push):
+        # Patch track_user so the middleware doesn't auto-register the user
+        with patch.object(storage, "track_user", new_callable=AsyncMock):
+            resp = client_with_push.post(
+                "/api/notifications/subscribe",
+                json={
+                    "endpoint": "https://push.example.com/sub/test-1",
+                    "p256dh_key": "p256dh-test",  # pragma: allowlist secret  # gitleaks:allow
+                    "auth_key": "auth-test",  # pragma: allowlist secret  # gitleaks:allow
+                },
+                cookies={"jji_username": "unknown_user"},
+            )
+        assert resp.status_code == 400
+        assert "not registered" in resp.json()["detail"].lower()
 
     def test_subscribe_404_when_push_not_configured(self, client_no_push):
         resp = client_no_push.post(

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -56,8 +56,10 @@ def _make_client(
                 from jenkins_job_insight.main import app
 
                 with TestClient(app) as c:
-                    yield c
-        get_settings.cache_clear()
+                    try:
+                        yield c
+                    finally:
+                        get_settings.cache_clear()
 
 
 _VAPID_ENV = {
@@ -317,10 +319,13 @@ class TestCommentMentionNotification:
                         cookies={"jji_username": "alice"},
                     )
                     assert resp.status_code == 201
-                    # Give the fire-and-forget task time to run
                     import time
 
-                    time.sleep(0.2)
+                    deadline = time.monotonic() + 2.0
+                    while time.monotonic() < deadline:
+                        if mock_send.call_count > 0:
+                            break
+                        time.sleep(0.05)
 
                 mock_send.assert_called_once()
                 call_kwargs = mock_send.call_args.kwargs
@@ -366,7 +371,7 @@ class TestCommentMentionNotification:
                     assert resp.status_code == 201
                     import time
 
-                    time.sleep(0.2)
+                    time.sleep(0.3)  # Brief wait — then assert not called
 
                 mock_send.assert_not_called()
             get_settings.cache_clear()

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -95,6 +95,13 @@ class TestVapidPublicKey:
         assert resp.status_code == 404
         assert "not configured" in resp.json()["detail"].lower()
 
+    def test_returns_503_when_keys_unavailable(self, client_with_push):
+        """Returns 503 when web_push_enabled is True but VAPID keys become unavailable."""
+        with patch("jenkins_job_insight.main.get_vapid_config", return_value={}):
+            resp = client_with_push.get("/api/notifications/vapid-public-key")
+            assert resp.status_code == 503
+            assert "unavailable" in resp.json()["detail"].lower()
+
 
 class TestSubscribeNotifications:
     """Tests for POST /api/notifications/subscribe."""

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -24,12 +24,15 @@ def _init_db(temp_db_path):
 def _make_client(temp_db_path, vapid_env: dict | None = None):
     """Create a test client with optional VAPID config."""
     env = {
+        "AI_PROVIDER": "claude",
+        "AI_MODEL": "test",
         "SECURE_COOKIES": "false",
         "DB_PATH": str(temp_db_path),
+        "ALLOWED_USERS": "",
     }
     if vapid_env:
         env.update(vapid_env)
-    with patch.dict(os.environ, env, clear=False):
+    with patch.dict(os.environ, env, clear=True):
         get_settings.cache_clear()
         with patch.object(storage, "DB_PATH", temp_db_path):
             from jenkins_job_insight.main import app
@@ -268,11 +271,14 @@ class TestCommentMentionNotification:
             patch.dict(
                 os.environ,
                 {
+                    "AI_PROVIDER": "claude",
+                    "AI_MODEL": "test",
                     "SECURE_COOKIES": "false",
                     "DB_PATH": str(temp_db_path),
+                    "ALLOWED_USERS": "",
                     **_VAPID_ENV,
                 },
-                clear=False,
+                clear=True,
             ),
             patch.object(storage, "DB_PATH", temp_db_path),
         ):
@@ -312,11 +318,14 @@ class TestCommentMentionNotification:
             patch.dict(
                 os.environ,
                 {
+                    "AI_PROVIDER": "claude",
+                    "AI_MODEL": "test",
                     "SECURE_COOKIES": "false",
                     "DB_PATH": str(temp_db_path),
+                    "ALLOWED_USERS": "",
                     **_VAPID_ENV,
                 },
-                clear=False,
+                clear=True,
             ),
             patch.object(storage, "DB_PATH", temp_db_path),
         ):

--- a/tests/test_api_notifications.py
+++ b/tests/test_api_notifications.py
@@ -4,11 +4,17 @@ import asyncio
 import os
 from unittest.mock import AsyncMock, patch
 
+import contextlib
+
 import pytest
 from fastapi.testclient import TestClient
 
 from jenkins_job_insight import storage
 from jenkins_job_insight.config import get_settings
+
+
+def _nullcontext():
+    return contextlib.nullcontext()
 
 
 @pytest.fixture
@@ -21,8 +27,14 @@ def _init_db(temp_db_path):
         yield
 
 
-def _make_client(temp_db_path, vapid_env: dict | None = None):
-    """Create a test client with optional VAPID config."""
+def _make_client(
+    temp_db_path, vapid_env: dict | None = None, disable_vapid_auto: bool = False
+):
+    """Create a test client with optional VAPID config.
+
+    When *disable_vapid_auto* is True, patches ``get_vapid_config`` to
+    return ``{}`` so that auto-generation does not kick in.
+    """
     env = {
         "AI_PROVIDER": "claude",
         "AI_MODEL": "test",
@@ -35,10 +47,16 @@ def _make_client(temp_db_path, vapid_env: dict | None = None):
     with patch.dict(os.environ, env, clear=True):
         get_settings.cache_clear()
         with patch.object(storage, "DB_PATH", temp_db_path):
-            from jenkins_job_insight.main import app
+            ctx = (
+                patch("jenkins_job_insight.vapid.get_vapid_config", return_value={})
+                if disable_vapid_auto
+                else _nullcontext()
+            )
+            with ctx:
+                from jenkins_job_insight.main import app
 
-            with TestClient(app) as c:
-                yield c
+                with TestClient(app) as c:
+                    yield c
         get_settings.cache_clear()
 
 
@@ -57,8 +75,8 @@ def client_with_push(_init_db, temp_db_path):
 
 @pytest.fixture
 def client_no_push(_init_db, temp_db_path):
-    """Client without VAPID/push configured."""
-    yield from _make_client(temp_db_path)
+    """Client without VAPID/push configured (auto-generation disabled)."""
+    yield from _make_client(temp_db_path, disable_vapid_auto=True)
 
 
 class TestVapidPublicKey:

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -431,6 +431,28 @@ class TestJJIClientCapabilities:
         assert result["jira_issues_enabled"] is False
 
 
+class TestJJIClientMentionableUsers:
+    def test_get_mentionable_users(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/users/mentionable"
+            return httpx.Response(200, json={"usernames": ["alice", "bob", "charlie"]})
+
+        client = _make_client(handler)
+        result = client.get_mentionable_users()
+        assert result["usernames"] == ["alice", "bob", "charlie"]
+
+    def test_get_mentionable_users_empty(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/users/mentionable"
+            return httpx.Response(200, json={"usernames": []})
+
+        client = _make_client(handler)
+        result = client.get_mentionable_users()
+        assert result["usernames"] == []
+
+
 class TestJJIClientAiConfigs:
     def test_get_ai_configs(self):
         sample = [

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1048,6 +1048,32 @@ class TestAiConfigsCommand:
         assert "No AI configurations found" in result.output
 
 
+class TestMentionableUsersCommand:
+    def test_mentionable_users(self, mock_client):
+        mock_client.get_mentionable_users.return_value = {
+            "usernames": ["alice", "bob", "charlie"]
+        }
+        result = runner.invoke(app, ["mentionable-users"])
+        assert result.exit_code == 0
+        assert "alice" in result.output
+        assert "bob" in result.output
+        assert "charlie" in result.output
+        mock_client.get_mentionable_users.assert_called_once()
+
+    def test_mentionable_users_json(self, mock_client):
+        mock_client.get_mentionable_users.return_value = {"usernames": ["alice", "bob"]}
+        result = runner.invoke(app, ["--json", "mentionable-users"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["usernames"] == ["alice", "bob"]
+
+    def test_mentionable_users_empty(self, mock_client):
+        mock_client.get_mentionable_users.return_value = {"usernames": []}
+        result = runner.invoke(app, ["mentionable-users"])
+        assert result.exit_code == 0
+        assert "No mentionable users found" in result.output
+
+
 class TestPreviewIssueCommand:
     def test_preview_github(self, mock_client):
         mock_client.preview_github_issue.return_value = {

--- a/tests/test_comment_enrichment.py
+++ b/tests/test_comment_enrichment.py
@@ -8,6 +8,7 @@ from jenkins_job_insight.comment_enrichment import (
     detect_github_issues,
     detect_github_prs,
     detect_jira_keys,
+    detect_mentions,
     fetch_github_issue_status,
     fetch_github_pr_status,
     fetch_jira_ticket_status,
@@ -68,6 +69,44 @@ class TestDetectJiraKeys:
     def test_no_keys(self):
         keys = detect_jira_keys("no jira here")
         assert keys == []
+
+
+class TestDetectMentions:
+    def test_detect_single_mention(self):
+        result = detect_mentions("Hey @alice, can you check this?")
+        assert result == ["alice"]
+
+    def test_detect_multiple_mentions(self):
+        result = detect_mentions("@bob and @carol please review")
+        assert result == ["bob", "carol"]
+
+    def test_deduplication_preserves_order(self):
+        result = detect_mentions("@alice @bob @alice @carol @bob")
+        assert result == ["alice", "bob", "carol"]
+
+    def test_no_mentions(self):
+        result = detect_mentions("just a regular comment")
+        assert result == []
+
+    def test_excludes_email_addresses(self):
+        result = detect_mentions("Contact user@domain.com for help")
+        assert result == []
+
+    def test_mention_with_hyphens_and_underscores(self):
+        result = detect_mentions("@my-user and @another_user")
+        assert result == ["my-user", "another_user"]
+
+    def test_mention_with_numbers(self):
+        result = detect_mentions("@user123 did this")
+        assert result == ["user123"]
+
+    def test_mention_at_start_of_text(self):
+        result = detect_mentions("@admin please fix")
+        assert result == ["admin"]
+
+    def test_mixed_mentions_and_emails(self):
+        result = detect_mentions("@alice and user@domain.com and @bob")
+        assert result == ["alice", "bob"]
 
 
 class TestFetchGitHubPRStatus:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -447,28 +447,19 @@ class TestDispatchAlert:
             monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.reset()
 
-    async def test_dispatch_throttled(self):
+    async def test_dispatch_throttled(self, monkeypatch):
         from jenkins_job_insight import monitoring
 
         monitoring.alert_throttler.reset()
-        original_cooldown = monitoring.alert_throttler.cooldown_seconds
-        monitoring.alert_throttler.cooldown_seconds = 9999.0
-        original_slack = monitoring.send_slack_alert
-        original_email = monitoring.send_email_alert_async
+        monkeypatch.setattr(monitoring.alert_throttler, "cooldown_seconds", 9999.0)
         mock_slack = AsyncMock()
-        monitoring.send_slack_alert = mock_slack
-        monitoring.send_email_alert_async = AsyncMock()
+        monkeypatch.setattr(monitoring, "send_slack_alert", mock_slack)
+        monkeypatch.setattr(monitoring, "send_email_alert_async", AsyncMock())
         try:
             await dispatch_alert("test_throttle_direct", "first")
             await dispatch_alert("test_throttle_direct", "second")
-            # Only first call should go through
             mock_slack.assert_called_once()
         finally:
-            monitoring.send_slack_alert = original_slack
-            monitoring.send_email_alert_async = original_email
-            monitoring.alert_throttler.cooldown_seconds = original_cooldown
-            monitoring.send_slack_alert = original_slack
-            monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.reset()
 
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -469,6 +469,7 @@ class TestDispatchAlert:
             monitoring.alert_throttler.cooldown_seconds = original_cooldown
             monitoring.send_slack_alert = original_slack
             monitoring.send_email_alert_async = original_email
+            monitoring.alert_throttler.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -467,7 +467,8 @@ class TestDispatchAlert:
             monitoring.send_slack_alert = original_slack
             monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.cooldown_seconds = original_cooldown
-            monitoring.alert_throttler.reset()
+            monitoring.send_slack_alert = original_slack
+            monitoring.send_email_alert_async = original_email
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,295 @@
+"""Tests for Web Push notification dispatch."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jenkins_job_insight.notifications import send_mention_notifications
+
+
+class TestSendMentionNotifications:
+    """Tests for send_mention_notifications."""
+
+    @pytest.mark.asyncio
+    async def test_self_mention_filtered(self) -> None:
+        """Comment author mentioning themselves should not trigger any push."""
+        with patch(
+            "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            await send_mention_notifications(
+                mentioned_usernames=["alice"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_mentioned_list(self) -> None:
+        """Empty mentioned list should return early without fetching subscriptions."""
+        with patch(
+            "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            await send_mention_notifications(
+                mentioned_usernames=[],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_subscriptions_found(self) -> None:
+        """When no subscriptions exist for mentioned users, return early."""
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "jenkins_job_insight.notifications.webpush",
+            ) as mock_webpush,
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            mock_webpush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_push_to_subscribed_users(self) -> None:
+        """Push notifications are sent to subscribed mentioned users."""
+        subscriptions = [
+            {
+                "username": "bob",
+                "endpoint": "https://push.example.com/sub/bob-1",
+                "p256dh_key": "p256dh-bob",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-bob",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        ]
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=subscriptions,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+            ) as mock_to_thread,
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+                public_base_url="https://jji.example.com",
+            )
+            mock_to_thread.assert_called_once()
+            call_args = mock_to_thread.call_args
+            # First positional arg is the webpush function
+            # Check kwargs passed to webpush via to_thread
+            assert (
+                call_args.kwargs["subscription_info"]["endpoint"]
+                == "https://push.example.com/sub/bob-1"
+            )
+            payload = json.loads(call_args.kwargs["data"])
+            assert payload["title"] == "Mentioned by @alice"
+            assert "test_foo" in payload["body"]
+            assert payload["url"] == "https://jji.example.com/report/job-1"
+
+    @pytest.mark.asyncio
+    async def test_stale_subscriptions_cleaned_up(self) -> None:
+        """Subscriptions returning 410 Gone are deleted."""
+        from pywebpush import WebPushException
+
+        subscriptions = [
+            {
+                "username": "bob",
+                "endpoint": "https://push.example.com/sub/bob-stale",
+                "p256dh_key": "p256dh-bob",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-bob",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        ]
+        # Create a 410 response mock
+        mock_response = MagicMock()
+        mock_response.status_code = 410
+        exc = WebPushException("Gone")
+        exc.response = mock_response
+
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=subscriptions,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.delete_stale_push_subscriptions",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            mock_delete.assert_called_once_with(
+                ["https://push.example.com/sub/bob-stale"]
+            )
+
+    @pytest.mark.asyncio
+    async def test_errors_do_not_propagate(self) -> None:
+        """Any unexpected error is caught and logged, never raised."""
+        with patch(
+            "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB connection failed"),
+        ):
+            # Should not raise
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+
+    @pytest.mark.asyncio
+    async def test_multiple_recipients_multiple_subscriptions(self) -> None:
+        """Multiple mentioned users with multiple subscriptions each get notified."""
+        subscriptions = [
+            {
+                "username": "bob",
+                "endpoint": "https://push.example.com/sub/bob-1",
+                "p256dh_key": "p256dh-bob1",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-bob1",  # pragma: allowlist secret  # gitleaks:allow
+            },
+            {
+                "username": "carol",
+                "endpoint": "https://push.example.com/sub/carol-1",
+                "p256dh_key": "p256dh-carol1",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-carol1",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        ]
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=subscriptions,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+            ) as mock_to_thread,
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["bob", "carol"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_bar",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            assert mock_to_thread.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_webpush_non_410_error_logged_not_raised(self) -> None:
+        """WebPushException with non-410 status is logged but does not raise."""
+        from pywebpush import WebPushException
+
+        subscriptions = [
+            {
+                "username": "bob",
+                "endpoint": "https://push.example.com/sub/bob-err",
+                "p256dh_key": "p256dh-bob",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-bob",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        ]
+        exc = WebPushException("Server error")
+        exc.response = MagicMock()
+        exc.response.status_code = 500
+
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=subscriptions,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.delete_stale_push_subscriptions",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            # Should not raise
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            # Should NOT delete — it wasn't a 410
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_url_without_public_base_url(self) -> None:
+        """When public_base_url is None, URL is a relative path."""
+        subscriptions = [
+            {
+                "username": "bob",
+                "endpoint": "https://push.example.com/sub/bob-1",
+                "p256dh_key": "p256dh-bob",  # pragma: allowlist secret  # gitleaks:allow
+                "auth_key": "auth-bob",  # pragma: allowlist secret  # gitleaks:allow
+            },
+        ]
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=subscriptions,
+            ),
+            patch(
+                "jenkins_job_insight.notifications.asyncio.to_thread",
+                new_callable=AsyncMock,
+            ) as mock_to_thread,
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+                public_base_url=None,
+            )
+            payload = json.loads(mock_to_thread.call_args.kwargs["data"])
+            assert payload["url"] == "/report/job-1"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -29,6 +29,27 @@ class TestSendMentionNotifications:
             mock_get.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_self_filtered_from_mixed_list(self) -> None:
+        """Author is removed from a mixed mentioned list before subscription lookup."""
+        with (
+            patch(
+                "jenkins_job_insight.notifications.get_push_subscriptions_for_users",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_get,
+            patch("jenkins_job_insight.notifications.webpush"),
+        ):
+            await send_mention_notifications(
+                mentioned_usernames=["alice", "bob"],
+                comment_author="alice",
+                job_id="job-1",
+                test_name="test_foo",
+                vapid_private_key="fake-key",  # pragma: allowlist secret
+                vapid_claim_email="admin@example.com",
+            )
+            mock_get.assert_called_once_with(["bob"])
+
+    @pytest.mark.asyncio
     async def test_empty_mentioned_list(self) -> None:
         """Empty mentioned list should return early without fetching subscriptions."""
         with patch(

--- a/tests/test_storage_push.py
+++ b/tests/test_storage_push.py
@@ -1,0 +1,215 @@
+"""Tests for push subscription storage functions."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jenkins_job_insight import storage
+
+
+@pytest.fixture
+async def setup_test_db(temp_db_path: Path):
+    """Set up a test database with the path patched."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        await storage.init_db()
+        yield temp_db_path
+
+
+class TestSavePushSubscription:
+    """Tests for save_push_subscription."""
+
+    async def test_insert_new_subscription(self, setup_test_db: Path) -> None:
+        """Saving a new subscription creates a row."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint="https://push.example.com/sub/alice-1",
+                p256dh_key="p256dh-alice",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="auth-alice",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == 1
+            assert subs[0]["username"] == "alice"
+            assert subs[0]["endpoint"] == "https://push.example.com/sub/alice-1"
+            assert subs[0]["p256dh_key"] == "p256dh-alice"  # pragma: allowlist secret  # gitleaks:allow  # fmt: skip
+            assert subs[0]["auth_key"] == "auth-alice"  # pragma: allowlist secret  # gitleaks:allow  # fmt: skip
+
+    async def test_upsert_existing_endpoint(self, setup_test_db: Path) -> None:
+        """Saving with an existing endpoint upserts the record."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            endpoint = "https://push.example.com/sub/shared"
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint=endpoint,
+                p256dh_key="old-key",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="old-auth",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            # Update with same endpoint but different keys/user
+            await storage.save_push_subscription(
+                username="bob",
+                endpoint=endpoint,
+                p256dh_key="new-key",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="new-auth",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            # Should only have one record for this endpoint
+            subs_alice = await storage.get_push_subscriptions_for_users(["alice"])
+            subs_bob = await storage.get_push_subscriptions_for_users(["bob"])
+            assert len(subs_alice) == 0  # alice no longer owns it
+            assert len(subs_bob) == 1
+            assert subs_bob[0]["p256dh_key"] == "new-key"  # pragma: allowlist secret  # gitleaks:allow  # fmt: skip
+
+    async def test_multiple_subscriptions_per_user(self, setup_test_db: Path) -> None:
+        """A user can have multiple subscriptions (different browsers/devices)."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint="https://push.example.com/sub/alice-browser1",
+                p256dh_key="key1",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="auth1",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint="https://push.example.com/sub/alice-browser2",
+                p256dh_key="key2",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="auth2",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == 2
+
+
+class TestDeletePushSubscription:
+    """Tests for delete_push_subscription."""
+
+    async def test_delete_existing(self, setup_test_db: Path) -> None:
+        """Deleting an existing subscription returns True."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            endpoint = "https://push.example.com/sub/to-delete"
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint=endpoint,
+                p256dh_key="key",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="auth",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            deleted = await storage.delete_push_subscription(endpoint, "alice")
+            assert deleted is True
+            # Verify it's gone
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == 0
+
+    async def test_delete_nonexistent_returns_false(self, setup_test_db: Path) -> None:
+        """Deleting a non-existent endpoint returns False."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            deleted = await storage.delete_push_subscription(
+                "https://push.example.com/sub/nonexistent", "alice"
+            )
+            assert deleted is False
+
+    async def test_delete_wrong_user_returns_false(self, setup_test_db: Path) -> None:
+        """Deleting another user's subscription returns False."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            endpoint = "https://push.example.com/sub/alice-owned"
+            await storage.save_push_subscription(
+                username="alice",
+                endpoint=endpoint,
+                p256dh_key="key",  # pragma: allowlist secret  # gitleaks:allow
+                auth_key="auth",  # pragma: allowlist secret  # gitleaks:allow
+            )
+            deleted = await storage.delete_push_subscription(endpoint, "bob")
+            assert deleted is False
+            # Verify it's still there
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == 1
+
+
+class TestSubscriptionLimit:
+    """Tests for per-user subscription limit."""
+
+    async def test_oldest_deleted_when_limit_exceeded(
+        self, setup_test_db: Path
+    ) -> None:
+        """Adding beyond MAX_PUSH_SUBSCRIPTIONS_PER_USER deletes the oldest."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            # Create MAX + 1 subscriptions
+            limit = storage.MAX_PUSH_SUBSCRIPTIONS_PER_USER
+            for i in range(limit + 1):
+                await storage.save_push_subscription(
+                    username="alice",
+                    endpoint=f"https://push.example.com/sub/alice-{i}",
+                    p256dh_key=f"key-{i}",  # pragma: allowlist secret  # gitleaks:allow
+                    auth_key=f"auth-{i}",  # pragma: allowlist secret  # gitleaks:allow
+                )
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == limit
+            # The oldest (alice-0) should have been evicted
+            endpoints = {s["endpoint"] for s in subs}
+            assert "https://push.example.com/sub/alice-0" not in endpoints
+            assert f"https://push.example.com/sub/alice-{limit}" in endpoints
+
+
+class TestGetPushSubscriptionsForUsers:
+    """Tests for get_push_subscriptions_for_users."""
+
+    async def test_get_subscriptions_for_multiple_users(
+        self, setup_test_db: Path
+    ) -> None:
+        """Returns subscriptions for multiple users."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.save_push_subscription(
+                "alice", "https://push.example.com/alice", "k1", "a1"
+            )
+            await storage.save_push_subscription(
+                "bob", "https://push.example.com/bob", "k2", "a2"
+            )
+            await storage.save_push_subscription(
+                "carol", "https://push.example.com/carol", "k3", "a3"
+            )
+            subs = await storage.get_push_subscriptions_for_users(["alice", "bob"])
+            assert len(subs) == 2
+            usernames = {s["username"] for s in subs}
+            assert usernames == {"alice", "bob"}
+
+    async def test_empty_usernames_returns_empty(self, setup_test_db: Path) -> None:
+        """Empty usernames list returns empty list without DB query."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            subs = await storage.get_push_subscriptions_for_users([])
+            assert subs == []
+
+    async def test_no_subscriptions_returns_empty(self, setup_test_db: Path) -> None:
+        """Returns empty list when users have no subscriptions."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            subs = await storage.get_push_subscriptions_for_users(["nobody"])
+            assert subs == []
+
+
+class TestDeleteStalePushSubscriptions:
+    """Tests for delete_stale_push_subscriptions."""
+
+    async def test_remove_stale_endpoints(self, setup_test_db: Path) -> None:
+        """Stale endpoints are removed from the database."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            ep1 = "https://push.example.com/stale1"
+            ep2 = "https://push.example.com/stale2"
+            ep3 = "https://push.example.com/valid"
+            await storage.save_push_subscription("alice", ep1, "k1", "a1")
+            await storage.save_push_subscription("bob", ep2, "k2", "a2")
+            await storage.save_push_subscription("carol", ep3, "k3", "a3")
+
+            await storage.delete_stale_push_subscriptions([ep1, ep2])
+
+            # Only carol's subscription should remain
+            subs = await storage.get_push_subscriptions_for_users(
+                ["alice", "bob", "carol"]
+            )
+            assert len(subs) == 1
+            assert subs[0]["username"] == "carol"
+
+    async def test_empty_endpoints_noop(self, setup_test_db: Path) -> None:
+        """Empty endpoints list is a no-op."""
+        with patch.object(storage, "DB_PATH", setup_test_db):
+            await storage.save_push_subscription(
+                "alice", "https://push.example.com/keep", "k1", "a1"
+            )
+            await storage.delete_stale_push_subscriptions([])
+            subs = await storage.get_push_subscriptions_for_users(["alice"])
+            assert len(subs) == 1

--- a/tests/test_vapid.py
+++ b/tests/test_vapid.py
@@ -82,15 +82,23 @@ class TestGetOrCreateVapidKeys:
         assert keys["public_key"]
         assert keys["private_key"]
 
-    def test_handles_race_condition(self, tmp_path):
+    def test_handles_race_condition(self, tmp_path, monkeypatch):
         """When another process wins the O_EXCL race, falls back to reading their file."""
         jji_dir = tmp_path / "jji"
         jji_dir.mkdir()
-        # Pre-create the file to simulate a race
         key_file = jji_dir / ".vapid_keys.json"
         existing_keys = _generate_vapid_keys()
         key_file.write_text(json.dumps(existing_keys))
         key_file.chmod(0o600)
+
+        from pathlib import Path as _Path
+
+        real_exists = _Path.exists
+        monkeypatch.setattr(
+            _Path,
+            "exists",
+            lambda self: False if self == key_file else real_exists(self),
+        )
         with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
             keys = _get_or_create_vapid_keys()
         assert keys == existing_keys

--- a/tests/test_vapid.py
+++ b/tests/test_vapid.py
@@ -1,0 +1,174 @@
+"""Tests for VAPID key auto-generation and configuration."""
+
+import json
+import os
+from unittest.mock import patch
+
+from jenkins_job_insight.vapid import (
+    DEFAULT_CLAIM_EMAIL,
+    _generate_vapid_keys,
+    _get_or_create_vapid_keys,
+    get_vapid_config,
+)
+
+
+class TestGenerateVapidKeys:
+    """Tests for _generate_vapid_keys()."""
+
+    def test_returns_public_and_private(self):
+        keys = _generate_vapid_keys()
+        assert "public_key" in keys
+        assert "private_key" in keys
+        assert isinstance(keys["public_key"], str)
+        assert isinstance(keys["private_key"], str)
+        assert len(keys["public_key"]) > 0
+        assert len(keys["private_key"]) > 0
+
+    def test_keys_are_unique(self):
+        k1 = _generate_vapid_keys()
+        k2 = _generate_vapid_keys()
+        assert k1["public_key"] != k2["public_key"]
+        assert k1["private_key"] != k2["private_key"]
+
+
+class TestGetOrCreateVapidKeys:
+    """Tests for _get_or_create_vapid_keys() file persistence."""
+
+    def test_creates_key_file_on_first_use(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            keys = _get_or_create_vapid_keys()
+        key_file = tmp_path / "jji" / ".vapid_keys.json"
+        assert key_file.exists()
+        stored = json.loads(key_file.read_text())
+        assert stored["public_key"] == keys["public_key"]
+        assert stored["private_key"] == keys["private_key"]
+
+    def test_reuses_existing_key_file(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            keys1 = _get_or_create_vapid_keys()
+            keys2 = _get_or_create_vapid_keys()
+        assert keys1 == keys2
+
+    def test_file_permissions_0600(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            _get_or_create_vapid_keys()
+        key_file = tmp_path / "jji" / ".vapid_keys.json"
+        mode = key_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_tightens_loose_permissions(self, tmp_path):
+        """If the file was created with loose permissions, they get tightened."""
+        jji_dir = tmp_path / "jji"
+        jji_dir.mkdir()
+        key_file = jji_dir / ".vapid_keys.json"
+        keys = _generate_vapid_keys()
+        key_file.write_text(json.dumps(keys))
+        key_file.chmod(0o644)
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            result = _get_or_create_vapid_keys()
+        assert result == keys
+        mode = key_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_handles_corrupt_file(self, tmp_path):
+        """Corrupt file triggers regeneration."""
+        jji_dir = tmp_path / "jji"
+        jji_dir.mkdir()
+        key_file = jji_dir / ".vapid_keys.json"
+        key_file.write_text("not valid json")
+        key_file.chmod(0o600)
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            keys = _get_or_create_vapid_keys()
+        assert keys["public_key"]
+        assert keys["private_key"]
+
+    def test_handles_race_condition(self, tmp_path):
+        """When another process wins the O_EXCL race, falls back to reading their file."""
+        jji_dir = tmp_path / "jji"
+        jji_dir.mkdir()
+        # Pre-create the file to simulate a race
+        key_file = jji_dir / ".vapid_keys.json"
+        existing_keys = _generate_vapid_keys()
+        key_file.write_text(json.dumps(existing_keys))
+        key_file.chmod(0o600)
+        with patch.dict(os.environ, {"XDG_DATA_HOME": str(tmp_path)}, clear=False):
+            keys = _get_or_create_vapid_keys()
+        assert keys == existing_keys
+
+
+class TestGetVapidConfig:
+    """Tests for get_vapid_config()."""
+
+    def test_returns_env_vars_when_set(self):
+        env = {
+            "VAPID_PUBLIC_KEY": "test-pub",
+            "VAPID_PRIVATE_KEY": "test-priv",  # pragma: allowlist secret  # gitleaks:allow
+            "VAPID_CLAIM_EMAIL": "test@example.com",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = get_vapid_config()
+        assert cfg["public_key"] == "test-pub"
+        _priv = "test-priv"  # pragma: allowlist secret  # gitleaks:allow
+        assert cfg["private_key"] == _priv
+        assert cfg["claim_email"] == "test@example.com"
+
+    def test_env_vars_take_priority(self, tmp_path):
+        """Even if a key file exists, env vars are used."""
+        env = {
+            "VAPID_PUBLIC_KEY": "env-pub",
+            "VAPID_PRIVATE_KEY": "env-priv",  # pragma: allowlist secret  # gitleaks:allow
+            "VAPID_CLAIM_EMAIL": "env@example.com",
+            "XDG_DATA_HOME": str(tmp_path),
+        }
+        # Create a key file with different values
+        jji_dir = tmp_path / "jji"
+        jji_dir.mkdir()
+        _priv = "file-priv"  # pragma: allowlist secret  # gitleaks:allow
+        key_data = {"public_key": "file-pub", "private_key": _priv}
+        (jji_dir / ".vapid_keys.json").write_text(json.dumps(key_data))
+        with patch.dict(os.environ, env, clear=False):
+            cfg = get_vapid_config()
+        assert cfg["public_key"] == "env-pub"
+        _priv = "env-priv"  # pragma: allowlist secret  # gitleaks:allow
+        assert cfg["private_key"] == _priv
+
+    def test_default_claim_email_when_not_set(self, tmp_path):
+        """Uses default claim email when VAPID_CLAIM_EMAIL is not set."""
+        env = {
+            "VAPID_PUBLIC_KEY": "pub",
+            "VAPID_PRIVATE_KEY": "priv",  # pragma: allowlist secret  # gitleaks:allow
+            "VAPID_CLAIM_EMAIL": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = get_vapid_config()
+        assert cfg["claim_email"] == DEFAULT_CLAIM_EMAIL
+
+    def test_auto_generates_when_no_env_vars(self, tmp_path):
+        """Auto-generates keys when env vars are empty."""
+        env = {
+            "VAPID_PUBLIC_KEY": "",
+            "VAPID_PRIVATE_KEY": "",  # pragma: allowlist secret  # gitleaks:allow
+            "VAPID_CLAIM_EMAIL": "",
+            "XDG_DATA_HOME": str(tmp_path),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            cfg = get_vapid_config()
+        assert cfg["public_key"]
+        assert cfg["private_key"]
+        assert cfg["claim_email"] == DEFAULT_CLAIM_EMAIL
+
+    def test_returns_empty_dict_on_failure(self):
+        """Returns {} when key generation fails."""
+        with (
+            patch(
+                "jenkins_job_insight.vapid._get_or_create_vapid_keys",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.dict(
+                os.environ,
+                {"VAPID_PUBLIC_KEY": "", "VAPID_PRIVATE_KEY": ""},
+                clear=False,
+            ),
+        ):
+            cfg = get_vapid_config()
+        assert cfg == {}

--- a/uv.lock
+++ b/uv.lock
@@ -524,6 +524,15 @@ wheels = [
 ]
 
 [[package]]
+name = "http-ece"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/af/249d1576653b69c20b9ac30e284b63bd94af6a175d72d87813235caf2482/http_ece-1.2.1.tar.gz", hash = "sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff", size = 8830, upload-time = "2024-08-08T00:10:47.301Z" }
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -585,6 +594,7 @@ dependencies = [
     { name = "python-jenkins" },
     { name = "python-multipart" },
     { name = "python-simple-logger" },
+    { name = "pywebpush" },
     { name = "reportportal-client" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -617,6 +627,7 @@ requires-dist = [
     { name = "python-jenkins" },
     { name = "python-multipart" },
     { name = "python-simple-logger" },
+    { name = "pywebpush" },
     { name = "reportportal-client", specifier = ">=5.7.4" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "uvicorn" },
@@ -870,6 +881,18 @@ wheels = [
 ]
 
 [[package]]
+name = "py-vapid"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ed/c648c8018fab319951764f4babe68ddcbbff7f2bbcd7ff7e531eac1788c8/py_vapid-1.9.4.tar.gz", hash = "sha256:a004023560cbc54e34fc06380a0580f04ffcc788e84fb6d19e9339eeb6551a28", size = 74750, upload-time = "2026-01-05T22:13:25.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/15/f9d0171e1ad863ca49e826d5afb6b50566f20dc9b4f76965096d3555ce9e/py_vapid-1.9.4-py2.py3-none-any.whl", hash = "sha256:f165a5bf90dcf966b226114f01f178f137579a09784c7f0628fa2f0a299741b6", size = 23912, upload-time = "2026-01-05T20:42:05.455Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,6 +1079,22 @@ dependencies = [
     { name = "colorlog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/5b/e97b2209a7de9763c50ef073620630aff8ffc546206e519f1d4330293f9c/python_simple_logger-2.0.19.tar.gz", hash = "sha256:1a26cf71da4bea84ac3093a90a2476555a8dde5cce69c8271143eea7675ca9e1", size = 9953, upload-time = "2026-02-26T09:36:04.764Z" }
+
+[[package]]
+name = "pywebpush"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cryptography" },
+    { name = "http-ece" },
+    { name = "py-vapid" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d9/e497a24bc9f659bfc0e570382a41e6b2d6726fbcfa4d85aaa23fe9c81ba2/pywebpush-2.3.0.tar.gz", hash = "sha256:d1e27db8de9e6757c1875f67292554bd54c41874c36f4b5c4ebb5442dce204f2", size = 28489, upload-time = "2026-02-09T23:30:18.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d8/ac21241cf8007cb93255eabf318da4f425ec0f75d28c366992253aa8c1b2/pywebpush-2.3.0-py3-none-any.whl", hash = "sha256:3d97469fb14d4323c362319d438183737249a4115b50e146ce233e7f01e3cf98", size = 22851, upload-time = "2026-02-09T23:30:16.093Z" },
+]
 
 [[package]]
 name = "reportportal-client"


### PR DESCRIPTION
Closes #106

## Summary

Adds Web Push notification support so users get notified when mentioned in comments via `@username`.

## Changes

### Backend
- **Config**: VAPID key settings (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_CLAIM_EMAIL`) with `web_push_enabled` computed property
- **Database**: `push_subscriptions` table with per-user limit (max 10 subscriptions)
- **Mention detection**: `detect_mentions()` in `comment_enrichment.py` with negative lookbehind to avoid email false positives
- **Notifications**: `notifications.py` — fire-and-forget Web Push dispatch via `pywebpush`, stale subscription cleanup
- **API endpoints**:
  - `GET /api/notifications/vapid-public-key` — public key for frontend
  - `POST /api/notifications/subscribe` — register push subscription
  - `POST /api/notifications/unsubscribe` — remove subscription (ownership verified)
  - `GET /api/users/mentionable` — list of known usernames for autocomplete
- **Comment hook**: Mention detection + notification dispatch on comment creation (background task)

### Frontend
- **Service worker** (`sw.js`) for push event handling + notification click
- **Notification opt-in** toggle in ProfileForm/RegisterPage
- **@mention autocomplete** (`MentionTextarea` component) with keyboard navigation
- **Mention highlighting** in rendered comments (blue styling, email-safe regex)

### CLI
- `jji mentionable-users` command
- Push subscribe/unsubscribe are web-only (browser-specific)

### Security
- Push endpoints validated (HTTPS only)
- Unsubscribe verifies subscription ownership
- Per-user subscription limit (10)
- Key field length limits (256 chars)
- `vapid_private_key` added to sensitive fields

### Documentation
- AGENTS.md: VAPID settings in server-only exceptions, sensitive fields updated
- README.md: Web Push feature documentation

## Tests
- 1,538 tests pass (1,428 backend + 110 frontend)
- New test files: `test_notifications.py`, `test_storage_push.py`, `test_api_notifications.py`
- Updated: `test_comment_enrichment.py`, `test_cli_main.py`, `test_cli_client.py`, `CommentsSection.test.tsx`, `MentionTextarea.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser Web Push for @mentions: service worker, subscribe/unsubscribe flow, client opt-in prompt, CLI command to list mentionable users
  * Mention UX: autocomplete textarea and mention highlighting
  * Token usage: per-range input/output breakdowns on dashboard cards

* **Bug Fixes / UX**
  * Reserved "admin" cookie hardened; token save preserves existing tokens and reduces noisy errors

* **Documentation**
  * Web Push/VAPID setup and sensitive-key guidance

* **Tests**
  * Extensive coverage for mentions, notifications, storage, CLI, VAPID, and UI prompts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->