### PR TITLE
fix(auth): sliding window session renewal prevents silent admin expiry

### DIFF
--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 import hmac
 import json
 import logging
@@ -654,6 +655,24 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 username = str(session["username"])
                 authenticated_admin = is_admin
 
+                # Renew session (sliding window) — only when <50% TTL remains
+                expires_at_str = session.get("expires_at", "")
+                if expires_at_str:
+                    try:
+                        expires_at = datetime.strptime(
+                            str(expires_at_str), "%Y-%m-%d %H:%M:%S"
+                        ).replace(tzinfo=timezone.utc)
+                        remaining = expires_at - datetime.now(timezone.utc)
+                        if remaining < timedelta(hours=storage.SESSION_TTL_HOURS / 2):
+                            task = asyncio.create_task(
+                                storage.renew_session(session_token)
+                            )
+                            _background_tasks.add(task)
+                            task.add_done_callback(_background_tasks.discard)
+                            request.state.renew_session_token = session_token
+                    except (ValueError, TypeError):
+                        pass
+
         # 2. Check Bearer token — admin API key or admin_key
         if not authenticated_admin:
             auth_header = request.headers.get("authorization", "")
@@ -699,7 +718,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if "text/html" in accept:
                 return RedirectResponse(url="/register", status_code=303)
 
-        return await call_next(request)
+        response = await call_next(request)
+
+        # Refresh session cookie max_age if session was renewed
+        if getattr(request.state, "renew_session_token", None):
+            response.set_cookie(
+                "jji_session",
+                request.state.renew_session_token,
+                httponly=True,
+                samesite="strict",
+                secure=settings.secure_cookies,
+                max_age=storage.SESSION_TTL_SECONDS,
+            )
+
+        return response
 
 
 app.add_middleware(AuthMiddleware)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -666,8 +666,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         if remaining < timedelta(hours=storage.SESSION_TTL_HOURS / 2):
                             # Await renewal so cookie refresh is only set after confirmed DB update
                             try:
-                                await storage.renew_session(session_token)
-                                request.state.renew_session_token = session_token
+                                renewed = await storage.renew_session(session_token)
+                                if renewed:
+                                    request.state.renew_session_token = session_token
                             except Exception:
                                 pass  # Renewal failed — don't refresh cookie
                     except (ValueError, TypeError):

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -664,12 +664,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         ).replace(tzinfo=timezone.utc)
                         remaining = expires_at - datetime.now(timezone.utc)
                         if remaining < timedelta(hours=storage.SESSION_TTL_HOURS / 2):
-                            task = asyncio.create_task(
-                                storage.renew_session(session_token)
-                            )
-                            _background_tasks.add(task)
-                            task.add_done_callback(_background_tasks.discard)
-                            request.state.renew_session_token = session_token
+                            # Await renewal so cookie refresh is only set after confirmed DB update
+                            try:
+                                await storage.renew_session(session_token)
+                                request.state.renew_session_token = session_token
+                            except Exception:
+                                pass  # Renewal failed — don't refresh cookie
                     except (ValueError, TypeError):
                         pass
 
@@ -722,14 +722,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # Refresh session cookie max_age if session was renewed
         if getattr(request.state, "renew_session_token", None):
-            response.set_cookie(
-                "jji_session",
-                request.state.renew_session_token,
-                httponly=True,
-                samesite="strict",
-                secure=settings.secure_cookies,
-                max_age=storage.SESSION_TTL_SECONDS,
-            )
+            # Skip if downstream handler already set/cleared jji_session
+            # (e.g., login sets a new session, logout deletes it)
+            path = request.url.path
+            if path not in ("/api/auth/login", "/api/auth/logout"):
+                settings = get_settings()
+                response.set_cookie(
+                    "jji_session",
+                    request.state.renew_session_token,
+                    httponly=True,
+                    samesite="strict",
+                    secure=settings.secure_cookies,
+                    max_age=storage.SESSION_TTL_SECONDS,
+                )
 
         return response
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -670,9 +670,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
                                 if renewed:
                                     request.state.renew_session_token = session_token
                             except Exception:
-                                pass  # Renewal failed — don't refresh cookie
+                                logger.debug("Session renewal failed", exc_info=True)
                     except (ValueError, TypeError):
-                        pass
+                        logger.debug(
+                            "Failed to parse session expires_at for renewal",
+                            exc_info=True,
+                        )
 
         # 2. Check Bearer token — admin API key or admin_key
         if not authenticated_admin:

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2618,20 +2618,23 @@ async def get_session(token: str) -> dict | None:
         return dict(row) if row else None
 
 
-async def renew_session(token: str) -> None:
+async def renew_session(token: str) -> bool:
     """Extend a session's expiry by SESSION_TTL_HOURS (sliding window).
 
     Called on each authenticated request to keep active sessions alive.
+
+    Returns True if the session was found and renewed, False otherwise.
     """
     token_hash = _hash_session_token(token)
     new_expires = datetime.now(timezone.utc) + timedelta(hours=SESSION_TTL_HOURS)
     expires_str = new_expires.strftime("%Y-%m-%d %H:%M:%S")
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+        cursor = await db.execute(
             "UPDATE sessions SET expires_at = ? WHERE token = ?",
             (expires_str, token_hash),
         )
         await db.commit()
+        return cursor.rowcount > 0
 
 
 async def delete_session(token: str) -> None:

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2630,7 +2630,8 @@ async def renew_session(token: str) -> bool:
     expires_str = new_expires.strftime("%Y-%m-%d %H:%M:%S")
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
-            "UPDATE sessions SET expires_at = ? WHERE token = ?",
+            "UPDATE sessions SET expires_at = ? "
+            "WHERE token = ? AND expires_at > datetime('now')",
             (expires_str, token_hash),
         )
         await db.commit()

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2618,6 +2618,22 @@ async def get_session(token: str) -> dict | None:
         return dict(row) if row else None
 
 
+async def renew_session(token: str) -> None:
+    """Extend a session's expiry by SESSION_TTL_HOURS (sliding window).
+
+    Called on each authenticated request to keep active sessions alive.
+    """
+    token_hash = _hash_session_token(token)
+    new_expires = datetime.now(timezone.utc) + timedelta(hours=SESSION_TTL_HOURS)
+    expires_str = new_expires.strftime("%Y-%m-%d %H:%M:%S")
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE sessions SET expires_at = ? WHERE token = ?",
+            (expires_str, token_hash),
+        )
+        await db.commit()
+
+
 async def delete_session(token: str) -> None:
     """Delete a session (logout)."""
     token_hash = _hash_session_token(token)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,8 @@
 """Tests for admin authentication and user tracking."""
 
+import asyncio
 import os
+import time
 from unittest.mock import patch
 
 import pytest
@@ -623,3 +625,240 @@ class TestUserTracking:
         client.get("/api/dashboard", cookies={"jji_username": "trackeduser"})
         # Poll until the fire-and-forget task completes
         _wait_for_user_tracked(client, "trackeduser")
+
+
+class TestSessionRenewalStorage:
+    """Tests for the renew_session() storage function."""
+
+    def test_renew_session_extends_expiry(self, _init_db, temp_db_path):
+        """renew_session() should extend the session's expires_at."""
+        import aiosqlite
+
+        async def run():
+            # Create a session with a short TTL so we can see the difference
+            token = await storage.create_session("admin", is_admin=True, ttl_hours=1)
+            token_hash = storage._hash_session_token(token)
+
+            # Read original expiry
+            async with aiosqlite.connect(temp_db_path) as db:
+                cursor = await db.execute(
+                    "SELECT expires_at FROM sessions WHERE token = ?",
+                    (token_hash,),
+                )
+                row = await cursor.fetchone()
+                original_expires = row[0]
+
+            # Renew — this uses SESSION_TTL_HOURS (8h) from now
+            await storage.renew_session(token)
+
+            # Read new expiry
+            async with aiosqlite.connect(temp_db_path) as db:
+                cursor = await db.execute(
+                    "SELECT expires_at FROM sessions WHERE token = ?",
+                    (token_hash,),
+                )
+                row = await cursor.fetchone()
+                renewed_expires = row[0]
+
+            # The renewed expiry should be later than the original (1h vs 8h)
+            assert renewed_expires > original_expires
+
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(run())
+
+    def test_session_valid_after_renewal(self, _init_db, temp_db_path):
+        """Session should still be valid (get_session returns data) after renewal."""
+
+        async def run():
+            token = await storage.create_session("admin", is_admin=True, ttl_hours=1)
+
+            # Verify session is valid before renewal
+            session_before = await storage.get_session(token)
+            assert session_before is not None
+            assert session_before["username"] == "admin"
+
+            # Renew
+            await storage.renew_session(token)
+
+            # Verify session is still valid after renewal
+            session_after = await storage.get_session(token)
+            assert session_after is not None
+            assert session_after["username"] == "admin"
+            assert session_after["is_admin"]
+
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(run())
+
+
+class TestSessionRenewalMiddleware:
+    """Integration tests for session renewal in AuthMiddleware."""
+
+    def test_authenticated_request_refreshes_session_cookie(self, client, temp_db_path):
+        """An authenticated request should return a refreshed jji_session cookie
+        when less than 50% of the session TTL remains."""
+        import aiosqlite
+
+        # Login to get a session
+        login_resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "test-admin-key-16chars",  # pragma: allowlist secret
+            },
+        )
+        assert login_resp.status_code == 200
+        session_cookie = login_resp.cookies.get("jji_session")
+        assert session_cookie
+
+        # Shorten expiry so <50% TTL remains, triggering renewal
+        token_hash = storage._hash_session_token(session_cookie)
+
+        async def shorten_expiry():
+            from datetime import datetime, timedelta, timezone
+
+            short_expires = datetime.now(timezone.utc) + timedelta(hours=1)
+            expires_str = short_expires.strftime("%Y-%m-%d %H:%M:%S")
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "UPDATE sessions SET expires_at = ? WHERE token = ?",
+                    (expires_str, token_hash),
+                )
+                await db.commit()
+
+        asyncio.run(shorten_expiry())
+
+        # Make an authenticated request
+        resp = client.get("/api/auth/me", cookies={"jji_session": session_cookie})
+        assert resp.status_code == 200
+        assert resp.json()["is_admin"] is True
+
+        # The response should have a refreshed jji_session cookie
+        refreshed = resp.cookies.get("jji_session")
+        assert refreshed is not None
+        # The cookie value should be the same token (renewal doesn't rotate)
+        assert refreshed == session_cookie
+
+    def test_no_renewal_when_over_half_ttl_remains(self, client):
+        """No renewal should trigger when >50% of session TTL remains (fresh session)."""
+        # Login to get a fresh session (full 8h TTL)
+        login_resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "test-admin-key-16chars",  # pragma: allowlist secret
+            },
+        )
+        assert login_resp.status_code == 200
+        session_cookie = login_resp.cookies.get("jji_session")
+        assert session_cookie
+
+        # Make an authenticated request — no renewal expected
+        resp = client.get("/api/auth/me", cookies={"jji_session": session_cookie})
+        assert resp.status_code == 200
+        assert resp.json()["is_admin"] is True
+
+        # No refreshed cookie should be set (renewal was skipped)
+        refreshed = resp.cookies.get("jji_session")
+        assert refreshed is None
+
+    def test_session_renewal_updates_db_expiry(self, client, temp_db_path):
+        """Session renewal in middleware should update expires_at in the DB."""
+        import aiosqlite
+
+        # Login to get a session
+        login_resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "test-admin-key-16chars",  # pragma: allowlist secret
+            },
+        )
+        session_cookie = login_resp.cookies.get("jji_session")
+        token_hash = storage._hash_session_token(session_cookie)
+
+        # Read initial expiry
+        async def get_expiry():
+            async with aiosqlite.connect(temp_db_path) as db:
+                cursor = await db.execute(
+                    "SELECT expires_at FROM sessions WHERE token = ?",
+                    (token_hash,),
+                )
+                row = await cursor.fetchone()
+                return row[0] if row else None
+
+        initial_expires = asyncio.run(get_expiry())
+        assert initial_expires is not None
+
+        # Manually set expiry to 1 hour from now (shorter than SESSION_TTL_HOURS)
+        async def shorten_expiry():
+            from datetime import datetime, timedelta, timezone
+
+            short_expires = datetime.now(timezone.utc) + timedelta(hours=1)
+            expires_str = short_expires.strftime("%Y-%m-%d %H:%M:%S")
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "UPDATE sessions SET expires_at = ? WHERE token = ?",
+                    (expires_str, token_hash),
+                )
+                await db.commit()
+
+        asyncio.run(shorten_expiry())
+        shortened_expires = asyncio.run(get_expiry())
+
+        # Make an authenticated request — middleware should renew
+        client.get("/api/auth/me", cookies={"jji_session": session_cookie})
+
+        # Wait for the fire-and-forget background task to complete
+        time.sleep(0.1)
+
+        # The DB expiry should now be extended beyond the shortened value
+        renewed_expires = asyncio.run(get_expiry())
+        assert renewed_expires > shortened_expires
+
+    def test_expired_session_not_renewed(self, client, temp_db_path):
+        """An expired session should NOT be renewed; user falls back to non-admin."""
+        import aiosqlite
+
+        # Login to get a session
+        login_resp = client.post(
+            "/api/auth/login",
+            json={
+                "username": "admin",
+                "api_key": "test-admin-key-16chars",  # pragma: allowlist secret
+            },
+        )
+        session_cookie = login_resp.cookies.get("jji_session")
+        token_hash = storage._hash_session_token(session_cookie)
+
+        # Manually expire the session in the DB
+        async def expire_session():
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "UPDATE sessions SET expires_at = '2000-01-01 00:00:00' WHERE token = ?",
+                    (token_hash,),
+                )
+                await db.commit()
+
+        asyncio.run(expire_session())
+
+        # Make a request with the expired session — should NOT be admin
+        resp = client.get("/api/auth/me", cookies={"jji_session": session_cookie})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_admin"] is False
+
+        # The response should NOT have a refreshed jji_session cookie
+        assert "jji_session" not in resp.cookies
+
+        # Verify the session is still expired in DB (not renewed)
+        async def check_still_expired():
+            async with aiosqlite.connect(temp_db_path) as db:
+                cursor = await db.execute(
+                    "SELECT expires_at FROM sessions WHERE token = ?",
+                    (token_hash,),
+                )
+                row = await cursor.fetchone()
+                assert row is not None
+                assert row[0] == "2000-01-01 00:00:00"
+
+        asyncio.run(check_still_expired())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -808,12 +808,17 @@ class TestSessionRenewalMiddleware:
         # Make an authenticated request — middleware should renew
         client.get("/api/auth/me", cookies={"jji_session": session_cookie})
 
-        # Wait for the fire-and-forget background task to complete
-        time.sleep(0.1)
-
-        # The DB expiry should now be extended beyond the shortened value
-        renewed_expires = asyncio.run(get_expiry())
-        assert renewed_expires > shortened_expires
+        # Poll until the renewal updates the DB (now synchronous, should be immediate)
+        deadline = time.monotonic() + 2.0
+        renewed_expires = shortened_expires
+        while time.monotonic() < deadline:
+            renewed_expires = asyncio.run(get_expiry())
+            if renewed_expires > shortened_expires:
+                break
+            time.sleep(0.05)
+        assert renewed_expires > shortened_expires, (
+            "Session renewal did not update DB expires_at within timeout"
+        )
 
     def test_expired_session_not_renewed(self, client, temp_db_path):
         """An expired session should NOT be renewed; user falls back to non-admin."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -649,7 +649,8 @@ class TestSessionRenewalStorage:
                 original_expires = row[0]
 
             # Renew — this uses SESSION_TTL_HOURS (8h) from now
-            await storage.renew_session(token)
+            result = await storage.renew_session(token)
+            assert result is True
 
             # Read new expiry
             async with aiosqlite.connect(temp_db_path) as db:
@@ -662,6 +663,16 @@ class TestSessionRenewalStorage:
 
             # The renewed expiry should be later than the original (1h vs 8h)
             assert renewed_expires > original_expires
+
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(run())
+
+    def test_renew_session_returns_false_for_nonexistent(self, _init_db, temp_db_path):
+        """renew_session() should return False when token doesn't exist."""
+
+        async def run():
+            result = await storage.renew_session("nonexistent-token-abc123")
+            assert result is False
 
         with patch.object(storage, "DB_PATH", temp_db_path):
             asyncio.run(run())

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -432,23 +432,19 @@ class TestDispatchAlert:
         from jenkins_job_insight import monitoring
 
         monitoring.alert_throttler.reset()
+        original_slack = monitoring.send_slack_alert
+        original_email = monitoring.send_email_alert_async
+        mock_slack = AsyncMock(return_value=True)
+        mock_email = AsyncMock(return_value=True)
+        monitoring.send_slack_alert = mock_slack
+        monitoring.send_email_alert_async = mock_email
         try:
-            with (
-                patch(
-                    "jenkins_job_insight.monitoring.send_slack_alert",
-                    new_callable=AsyncMock,
-                ) as mock_slack,
-                patch(
-                    "jenkins_job_insight.monitoring.send_email_alert_async",
-                    new_callable=AsyncMock,
-                ) as mock_email,
-            ):
-                mock_slack.return_value = True
-                mock_email.return_value = True
-                await dispatch_alert("test_dispatch_event", "test message")
+            await dispatch_alert("test_dispatch_event", "test message")
             mock_slack.assert_called_once_with("test message")
             mock_email.assert_called_once()
         finally:
+            monitoring.send_slack_alert = original_slack
+            monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.reset()
 
     async def test_dispatch_throttled(self):
@@ -457,22 +453,19 @@ class TestDispatchAlert:
         monitoring.alert_throttler.reset()
         original_cooldown = monitoring.alert_throttler.cooldown_seconds
         monitoring.alert_throttler.cooldown_seconds = 9999.0
+        original_slack = monitoring.send_slack_alert
+        original_email = monitoring.send_email_alert_async
+        mock_slack = AsyncMock()
+        monitoring.send_slack_alert = mock_slack
+        monitoring.send_email_alert_async = AsyncMock()
         try:
-            with (
-                patch(
-                    "jenkins_job_insight.monitoring.send_slack_alert",
-                    new_callable=AsyncMock,
-                ) as mock_slack,
-                patch(
-                    "jenkins_job_insight.monitoring.send_email_alert_async",
-                    new_callable=AsyncMock,
-                ),
-            ):
-                await dispatch_alert("test_throttle_event", "first")
-                await dispatch_alert("test_throttle_event", "second")
+            await dispatch_alert("test_throttle_direct", "first")
+            await dispatch_alert("test_throttle_direct", "second")
             # Only first call should go through
             mock_slack.assert_called_once()
         finally:
+            monitoring.send_slack_alert = original_slack
+            monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.cooldown_seconds = original_cooldown
             monitoring.alert_throttler.reset()
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -429,41 +429,52 @@ class TestDispatchAlert:
     """Tests for dispatch_alert."""
 
     async def test_dispatch_sends_to_all_channels(self):
-        throttler = AlertThrottler(cooldown_seconds=0.0)
-        with (
-            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
-            patch(
-                "jenkins_job_insight.monitoring.send_slack_alert",
-                new_callable=AsyncMock,
-            ) as mock_slack,
-            patch(
-                "jenkins_job_insight.monitoring.send_email_alert_async",
-                new_callable=AsyncMock,
-            ) as mock_email,
-        ):
-            mock_slack.return_value = True
-            mock_email.return_value = True
-            await dispatch_alert("test_event", "test message")
-        mock_slack.assert_called_once_with("test message")
-        mock_email.assert_called_once()
+        from jenkins_job_insight import monitoring
+
+        monitoring.alert_throttler.reset()
+        try:
+            with (
+                patch(
+                    "jenkins_job_insight.monitoring.send_slack_alert",
+                    new_callable=AsyncMock,
+                ) as mock_slack,
+                patch(
+                    "jenkins_job_insight.monitoring.send_email_alert_async",
+                    new_callable=AsyncMock,
+                ) as mock_email,
+            ):
+                mock_slack.return_value = True
+                mock_email.return_value = True
+                await dispatch_alert("test_dispatch_event", "test message")
+            mock_slack.assert_called_once_with("test message")
+            mock_email.assert_called_once()
+        finally:
+            monitoring.alert_throttler.reset()
 
     async def test_dispatch_throttled(self):
-        throttler = AlertThrottler(cooldown_seconds=9999.0)
-        with (
-            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
-            patch(
-                "jenkins_job_insight.monitoring.send_slack_alert",
-                new_callable=AsyncMock,
-            ) as mock_slack,
-            patch(
-                "jenkins_job_insight.monitoring.send_email_alert_async",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await dispatch_alert("test_event", "first")
-            await dispatch_alert("test_event", "second")
-        # Only first call should go through
-        mock_slack.assert_called_once()
+        from jenkins_job_insight import monitoring
+
+        monitoring.alert_throttler.reset()
+        original_cooldown = monitoring.alert_throttler.cooldown_seconds
+        monitoring.alert_throttler.cooldown_seconds = 9999.0
+        try:
+            with (
+                patch(
+                    "jenkins_job_insight.monitoring.send_slack_alert",
+                    new_callable=AsyncMock,
+                ) as mock_slack,
+                patch(
+                    "jenkins_job_insight.monitoring.send_email_alert_async",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                await dispatch_alert("test_throttle_event", "first")
+                await dispatch_alert("test_throttle_event", "second")
+            # Only first call should go through
+            mock_slack.assert_called_once()
+        finally:
+            monitoring.alert_throttler.cooldown_seconds = original_cooldown
+            monitoring.alert_throttler.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -455,6 +455,10 @@ class TestDispatchAlert:
                 "jenkins_job_insight.monitoring.send_slack_alert",
                 new_callable=AsyncMock,
             ) as mock_slack,
+            patch(
+                "jenkins_job_insight.monitoring.send_email_alert_async",
+                new_callable=AsyncMock,
+            ),
         ):
             await dispatch_alert("test_event", "first")
             await dispatch_alert("test_event", "second")


### PR DESCRIPTION
Closes #166

## Problem

Admin sessions silently expired after 8 hours (fixed TTL). The `jji_username` cookie (1 year TTL) kept users logged in, but they lost admin privileges without notice. Re-entering the API key restored admin — the only workaround.

## Root Cause

`jji_session` cookie had a fixed 8-hour TTL with no renewal. When expired:
1. `get_session()` returned `None` (DB `expires_at` check failed)
2. AuthMiddleware fell through to `jji_username` cookie (no admin info)
3. `/api/auth/me` returned `is_admin: false` → frontend dropped admin UI

## Fix

Sliding window session renewal:
- **`renew_session()`** in `storage.py` — extends `expires_at` by `SESSION_TTL_HOURS`
- **Threshold-based** — only renews when <50% TTL remains (avoids DB write on every request)
- **Cookie sync** — refreshes `jji_session` cookie `max_age` on response
- **Fire-and-forget** — renewal runs as background task (same pattern as `track_user()`)

Sessions now expire after 8 hours of **inactivity**, not 8 hours since login.

## Tests

- `test_renew_session_extends_expiry` — storage function unit test
- `test_session_valid_after_renewal` — session still valid after renewal
- `test_authenticated_request_refreshes_session_cookie` — middleware integration
- `test_session_renewal_updates_db_expiry` — DB expiry extended
- `test_expired_session_not_renewed` — expired sessions stay expired
- `test_no_renewal_when_over_half_ttl_remains` — threshold optimization
- All 1,384 backend + 98 frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sliding-window renewal for active admin sessions, transparently extending expiry during continued use.
* **Enhancements**
  * Client session cookie is refreshed only after confirmed backend renewal and skipped on login/logout to avoid unnecessary updates.
  * Renewal failures are handled gracefully to avoid impacting normal requests.
* **Tests**
  * Added unit and integration tests for session renewal scenarios and more reliable dispatch alert tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->