### PR TITLE
feat(analytics): AI token usage tracking and reporting for admins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ This project uses AI CLI tools (Claude CLI, Gemini CLI, Cursor Agent CLI) instea
 | `JiraClient` | Searches Jira for matching bugs (Cloud + Server/DC) |
 | `enrich_with_jira_matches()` | Post-processing: attaches Jira matches to PRODUCT BUG failures |
 | `_filter_matches_with_ai()` | AI-powered relevance filtering of Jira candidates |
+| `token_tracking` | Records AI CLI token usage and builds per-job summaries |
 
 ### Frontend (React + TypeScript)
 
@@ -102,6 +103,7 @@ The frontend is in `/frontend/` — a Vite + React 19 + TypeScript + Tailwind CS
 | `frontend/src/components/layout/` | Layout shell (NavBar, UserBadge) |
 | `frontend/src/lib/` | Utilities (api.ts, cookies.ts, grouping.ts) |
 | `frontend/src/types/` | TypeScript types mirroring Python models |
+| `frontend/src/pages/TokenUsagePage.tsx` | Admin token usage dashboard |
 
 Key patterns:
 - **State**: Report page uses `useReducer` via `ReportContext` (page-scoped, not global)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ docker run -d -p 8000:8000 -v ./data:/data \
   ghcr.io/myk-org/jenkins-job-insight:latest
 ```
 
+## Features
+
+- **AI-Powered Failure Analysis** — Classifies test failures as code issues or product bugs
+- **AI Token Usage Tracking** — Track token consumption, costs, and duration for all AI CLI calls. Admin dashboard shows usage by provider/model/time period with CSV export.
+
 ## CLI
 
 ```bash
@@ -30,9 +35,23 @@ export JJI_SERVER=http://localhost:8000
 jji health
 jji analyze --job-name my-job --build-number 42
 jji results list
+jji admin token-usage              # Summary dashboard
+jji admin token-usage --group-by model  # Grouped breakdown
+jji admin token-usage --job-id <uuid>   # Per-job usage
+jji admin token-usage --period month --format csv  # CSV export
 ```
 
 Run `jji --help` for all commands.
+
+## API
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/admin/token-usage` | Aggregated token usage with filters and grouping (admin only) |
+| `GET /api/admin/token-usage/summary` | Dashboard summary: today/week/month stats (admin only) |
+| `GET /api/admin/token-usage/{job_id}` | Per-job token usage breakdown (admin only) |
+
+See the [API reference](https://myk-org.github.io/jenkins-job-insight/) for all endpoints.
 
 ## Development
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { HistoryPage } from '@/pages/HistoryPage'
 import { ReportPage } from '@/pages/ReportPage'
 import { TestHistoryPage } from '@/pages/TestHistoryPage'
 import { UsersPage } from '@/pages/UsersPage'
+import { TokenUsagePage } from '@/pages/TokenUsagePage'
 
 export default function App() {
   return (
@@ -28,6 +29,7 @@ export default function App() {
             <Route path="/status/:jobId" element={<ProtectedRoute><StatusPage /></ProtectedRoute>} />
             <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
             <Route path="/admin/users" element={<ProtectedRoute adminOnly><UsersPage /></ProtectedRoute>} />
+            <Route path="/admin/token-usage" element={<ProtectedRoute adminOnly><TokenUsagePage /></ProtectedRoute>} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -27,7 +27,7 @@ export function NavBar() {
   const { isAdmin } = useAuth()
 
   const navLinks = isAdmin
-    ? [...BASE_NAV_LINKS, { to: '/admin/users', label: 'Users' }]
+    ? [...BASE_NAV_LINKS, { to: '/admin/users', label: 'Users' }, { to: '/admin/token-usage', label: 'Token Usage' }]
     : BASE_NAV_LINKS
 
   return (

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { formatCompactNumber, formatCost } from '../format'
+
+describe('formatCompactNumber', () => {
+  it('returns plain number below 1000', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(999)).toBe('999')
+  })
+
+  it('formats thousands as K', () => {
+    expect(formatCompactNumber(1_000)).toBe('1K')
+    expect(formatCompactNumber(1_500)).toBe('1.5K')
+    expect(formatCompactNumber(15_000)).toBe('15K')
+  })
+
+  it('formats millions as M', () => {
+    expect(formatCompactNumber(1_000_000)).toBe('1M')
+    expect(formatCompactNumber(1_500_000)).toBe('1.5M')
+    expect(formatCompactNumber(10_000_000)).toBe('10M')
+  })
+})
+
+describe('formatCost', () => {
+  it('returns $0.00 for null/undefined/zero', () => {
+    expect(formatCost(null)).toBe('$0.00')
+    expect(formatCost(undefined)).toBe('$0.00')
+    expect(formatCost(0)).toBe('$0.00')
+  })
+
+  it('uses 4 decimal places for values under $0.01', () => {
+    expect(formatCost(0.005)).toBe('$0.0050')
+    expect(formatCost(0.0012)).toBe('$0.0012')
+  })
+
+  it('uses 2 decimal places for values >= $0.01', () => {
+    expect(formatCost(0.01)).toBe('$0.01')
+    expect(formatCost(1.5)).toBe('$1.50')
+    expect(formatCost(123.456)).toBe('$123.46')
+  })
+})

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,19 @@
+/** Format a number with K/M suffixes (e.g. 15000 → "15K", 1500000 → "1.5M"). */
+export function formatCompactNumber(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000
+    return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`
+  }
+  return String(n)
+}
+
+/** Format USD cost for display. Returns '$0.00' for null/zero/undefined. */
+export function formatCost(value: number | null | undefined): string {
+  if (value == null || value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button'
 import { ExternalLink, CheckCircle2, Clock, Calendar, Cpu, Timer, FolderGit2, RotateCw, Copy, Check } from 'lucide-react'
 import { ReAnalyzeDialog } from './report/ReAnalyzeDialog'
 import { ReportPortalButton } from './report/ReportPortalButton'
+import { TokenUsageBadge } from './report/TokenUsageBadge'
 import { reviewKey } from './report/ReportContext'
 import type { ChildJobAnalysis } from '@/types'
 
@@ -416,6 +417,9 @@ function ReportContent() {
             <Badge variant="outline" className="text-[10px]">
               {formatAiLabel(result.ai_provider, result.ai_model)}
             </Badge>
+          )}
+          {result.token_usage && (
+            <TokenUsageBadge usage={result.token_usage} />
           )}
           <div className="ml-auto flex items-center gap-3">
             {state.reportportalAvailable && (result.child_job_analyses ?? []).length === 0 && (

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { api } from '@/lib/api'
 import { formatCompactNumber, formatCost } from '@/lib/format'
 import { Input } from '@/components/ui/input'
@@ -126,7 +126,13 @@ export function TokenUsagePage() {
   const [dateFrom, setDateFrom] = useState('')
   const [dateTo, setDateTo] = useState('')
   const [providerInput, setProviderInput] = useState('')
-  const debouncedProvider = useDeferredValue(providerInput)
+  const [debouncedProvider, setDebouncedProvider] = useState('')
+
+  // Debounce provider filter input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedProvider(providerInput), 300)
+    return () => clearTimeout(timer)
+  }, [providerInput])
 
   const { sortKey, sortDir, handleSort } = useTableSort('token-usage', 'cost_usd', 'desc', ['cost_usd', 'calls', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_write_tokens', 'avg_duration_ms'])
 
@@ -146,42 +152,46 @@ export function TokenUsagePage() {
   }, [])
 
   // Fetch breakdown table
-  const fetchBreakdown = useCallback(async () => {
+  useEffect(() => {
+    let cancelled = false
     const requestId = ++latestRequestIdRef.current
     setBreakdownLoading(true)
-    try {
-      const params = new URLSearchParams()
-      params.set('group_by', groupBy)
-      if (dateFrom) params.set('start_date', dateFrom)
-      if (dateTo) params.set('end_date', dateTo)
-      if (debouncedProvider.trim()) params.set('ai_provider', debouncedProvider.trim())
-      const data = await api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
-      // Discard stale responses from earlier requests
-      if (requestId !== latestRequestIdRef.current) return
-      setBreakdown(
-        data.breakdown.map((row) => ({
-          group: row.group_key,
-          calls: row.call_count,
-          input_tokens: row.input_tokens,
-          output_tokens: row.output_tokens,
-          cache_read_tokens: row.cache_read_tokens,
-          cache_write_tokens: row.cache_write_tokens,
-          cost_usd: row.cost_usd,
-          avg_duration_ms: row.avg_duration_ms,
-        }))
-      )
-      setBreakdownError(null)
-    } catch (err) {
-      if (requestId !== latestRequestIdRef.current) return
-      setBreakdownError(err instanceof Error ? err.message : 'Failed to load breakdown')
-    } finally {
-      if (requestId === latestRequestIdRef.current) {
-        setBreakdownLoading(false)
-      }
-    }
-  }, [groupBy, dateFrom, dateTo, debouncedProvider])
 
-  useEffect(() => { fetchBreakdown() }, [fetchBreakdown])
+    const params = new URLSearchParams()
+    params.set('group_by', groupBy)
+    if (dateFrom) params.set('start_date', dateFrom)
+    if (dateTo) params.set('end_date', dateTo)
+    if (debouncedProvider.trim()) params.set('ai_provider', debouncedProvider.trim())
+
+    api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
+      .then((data) => {
+        if (cancelled || requestId !== latestRequestIdRef.current) return
+        setBreakdown(
+          data.breakdown.map((row) => ({
+            group: row.group_key,
+            calls: row.call_count,
+            input_tokens: row.input_tokens,
+            output_tokens: row.output_tokens,
+            cache_read_tokens: row.cache_read_tokens,
+            cache_write_tokens: row.cache_write_tokens,
+            cost_usd: row.cost_usd,
+            avg_duration_ms: row.avg_duration_ms,
+          }))
+        )
+        setBreakdownError(null)
+      })
+      .catch((err) => {
+        if (cancelled || requestId !== latestRequestIdRef.current) return
+        setBreakdownError(err instanceof Error ? err.message : 'Failed to load breakdown')
+      })
+      .finally(() => {
+        if (!cancelled && requestId === latestRequestIdRef.current) {
+          setBreakdownLoading(false)
+        }
+      })
+
+    return () => { cancelled = true }
+  }, [groupBy, dateFrom, dateTo, debouncedProvider])
 
   const sorted = useMemo(() => {
     const copy = [...breakdown]

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -61,6 +61,7 @@ const GROUP_BY_OPTIONS = [
   { value: 'day', label: 'Day' },
   { value: 'week', label: 'Week' },
   { value: 'month', label: 'Month' },
+  { value: 'job', label: 'Job' },
 ] as const
 
 type GroupByValue = typeof GROUP_BY_OPTIONS[number]['value']
@@ -116,7 +117,8 @@ export function TokenUsagePage() {
   const [breakdown, setBreakdown] = useState<BreakdownRow[]>([])
   const [summaryLoading, setSummaryLoading] = useState(true)
   const [breakdownLoading, setBreakdownLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [summaryError, setSummaryError] = useState<string | null>(null)
+  const [breakdownError, setBreakdownError] = useState<string | null>(null)
 
   const [groupBy, setGroupBy] = useState<GroupByValue>('model')
   const [dateFrom, setDateFrom] = useState('')
@@ -131,9 +133,9 @@ export function TokenUsagePage() {
     api.get<TokenUsageDashboard>('/api/admin/token-usage/summary')
       .then((data) => {
         setSummary(data)
-        setError(null)
+        setSummaryError(null)
       })
-      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load summary'))
+      .catch((err) => setSummaryError(err instanceof Error ? err.message : 'Failed to load summary'))
       .finally(() => setSummaryLoading(false))
   }, [])
 
@@ -158,9 +160,9 @@ export function TokenUsagePage() {
           avg_duration_ms: row.avg_duration_ms,
         }))
       )
-      setError(null)
+      setBreakdownError(null)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load breakdown')
+      setBreakdownError(err instanceof Error ? err.message : 'Failed to load breakdown')
     } finally {
       setBreakdownLoading(false)
     }
@@ -201,9 +203,12 @@ export function TokenUsagePage() {
         <p className="mt-0.5 text-sm text-text-tertiary">AI provider token consumption and costs</p>
       </div>
 
-      {/* Error */}
-      {error && (
-        <p role="alert" className="text-center text-signal-red py-4">{error}</p>
+      {/* Errors */}
+      {summaryError && (
+        <p role="alert" className="text-center text-signal-red py-4">{summaryError}</p>
+      )}
+      {breakdownError && (
+        <p role="alert" className="text-center text-signal-red py-4">{breakdownError}</p>
       )}
 
       {/* Summary cards */}

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -94,13 +94,19 @@ function SummaryCard({ title, icon, calls, tokens, cost }: {
           <div className="flex items-center justify-between">
             <span className="text-xs text-text-tertiary">Cost</span>
             <span className="font-mono text-sm font-medium text-signal-green">
-              {cost > 0 ? `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}` : '—'}
+              {cost > 0 ? formatCost(cost) : '—'}
             </span>
           </div>
         </div>
       </CardContent>
     </Card>
   )
+}
+
+function formatCost(value: number | null | undefined): string {
+  if (value == null || value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
 }
 
 function formatDurationMs(ms: number): string {
@@ -111,7 +117,7 @@ function formatDurationMs(ms: number): string {
 
 function formatCostCell(cost: number): string {
   if (cost <= 0) return '—'
-  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
+  return formatCost(cost)
 }
 
 export function TokenUsagePage() {

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { api } from '@/lib/api'
 import { formatCompactNumber } from '@/pages/report/TokenUsageBadge'
 import { Input } from '@/components/ui/input'
@@ -31,6 +31,7 @@ interface BreakdownRow {
   input_tokens: number
   output_tokens: number
   cache_read_tokens: number
+  cache_write_tokens: number
   cost_usd: number
   avg_duration_ms: number
 }
@@ -49,6 +50,7 @@ interface TokenUsageBreakdownResponse {
     input_tokens: number
     output_tokens: number
     cache_read_tokens: number
+    cache_write_tokens: number
     cost_usd: number
     avg_duration_ms: number
   }>
@@ -125,7 +127,10 @@ export function TokenUsagePage() {
   const [dateTo, setDateTo] = useState('')
   const [providerFilter, setProviderFilter] = useState('')
 
-  const { sortKey, sortDir, handleSort } = useTableSort('token-usage', 'cost_usd', 'desc', ['cost_usd', 'calls', 'input_tokens', 'output_tokens', 'avg_duration_ms'])
+  const { sortKey, sortDir, handleSort } = useTableSort('token-usage', 'cost_usd', 'desc', ['cost_usd', 'calls', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_write_tokens', 'avg_duration_ms'])
+
+  // Guard against stale responses when filters change rapidly
+  const latestRequestIdRef = useRef(0)
 
   // Fetch summary cards
   useEffect(() => {
@@ -141,6 +146,7 @@ export function TokenUsagePage() {
 
   // Fetch breakdown table
   const fetchBreakdown = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current
     setBreakdownLoading(true)
     try {
       const params = new URLSearchParams()
@@ -149,6 +155,8 @@ export function TokenUsagePage() {
       if (dateTo) params.set('end_date', dateTo)
       if (providerFilter.trim()) params.set('ai_provider', providerFilter.trim())
       const data = await api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
+      // Discard stale responses from earlier requests
+      if (requestId !== latestRequestIdRef.current) return
       setBreakdown(
         data.breakdown.map((row) => ({
           group: row.group_key,
@@ -156,15 +164,19 @@ export function TokenUsagePage() {
           input_tokens: row.input_tokens,
           output_tokens: row.output_tokens,
           cache_read_tokens: row.cache_read_tokens,
+          cache_write_tokens: row.cache_write_tokens,
           cost_usd: row.cost_usd,
           avg_duration_ms: row.avg_duration_ms,
         }))
       )
       setBreakdownError(null)
     } catch (err) {
+      if (requestId !== latestRequestIdRef.current) return
       setBreakdownError(err instanceof Error ? err.message : 'Failed to load breakdown')
     } finally {
-      setBreakdownLoading(false)
+      if (requestId === latestRequestIdRef.current) {
+        setBreakdownLoading(false)
+      }
     }
   }, [groupBy, dateFrom, dateTo, providerFilter])
 
@@ -181,6 +193,7 @@ export function TokenUsagePage() {
         case 'input_tokens': cmp = a.input_tokens - b.input_tokens; break
         case 'output_tokens': cmp = a.output_tokens - b.output_tokens; break
         case 'cache_read_tokens': cmp = a.cache_read_tokens - b.cache_read_tokens; break
+        case 'cache_write_tokens': cmp = a.cache_write_tokens - b.cache_write_tokens; break
         case 'cost_usd': cmp = a.cost_usd - b.cost_usd; break
         case 'avg_duration_ms': cmp = a.avg_duration_ms - b.avg_duration_ms; break
         default: cmp = 0
@@ -331,6 +344,7 @@ export function TokenUsagePage() {
               <SortableHeader label="Input Tokens" sortKey="input_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Output Tokens" sortKey="output_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cache Read" sortKey="cache_read_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Cache Write" sortKey="cache_write_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cost" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Avg Duration" sortKey="avg_duration_ms" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
             </TableRow>
@@ -346,6 +360,7 @@ export function TokenUsagePage() {
                 <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.input_tokens)}</TableCell>
                 <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.output_tokens)}</TableCell>
                 <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.cache_read_tokens)}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.cache_write_tokens)}</TableCell>
                 <TableCell className="text-right font-mono text-xs text-signal-green">{formatCostCell(row.cost_usd)}</TableCell>
                 <TableCell className="text-right font-mono text-xs text-text-tertiary">{formatDurationMs(row.avg_duration_ms)}</TableCell>
               </TableRow>

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { api } from '@/lib/api'
 import { formatCompactNumber } from '@/pages/report/TokenUsageBadge'
 import { Input } from '@/components/ui/input'
@@ -94,7 +94,7 @@ function SummaryCard({ title, icon, calls, tokens, cost }: {
           <div className="flex items-center justify-between">
             <span className="text-xs text-text-tertiary">Cost</span>
             <span className="font-mono text-sm font-medium text-signal-green">
-              {cost > 0 ? formatCost(cost) : '—'}
+              {formatCostCell(cost)}
             </span>
           </div>
         </div>
@@ -131,7 +131,8 @@ export function TokenUsagePage() {
   const [groupBy, setGroupBy] = useState<GroupByValue>('model')
   const [dateFrom, setDateFrom] = useState('')
   const [dateTo, setDateTo] = useState('')
-  const [providerFilter, setProviderFilter] = useState('')
+  const [providerInput, setProviderInput] = useState('')
+  const debouncedProvider = useDeferredValue(providerInput)
 
   const { sortKey, sortDir, handleSort } = useTableSort('token-usage', 'cost_usd', 'desc', ['cost_usd', 'calls', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_write_tokens', 'avg_duration_ms'])
 
@@ -159,7 +160,7 @@ export function TokenUsagePage() {
       params.set('group_by', groupBy)
       if (dateFrom) params.set('start_date', dateFrom)
       if (dateTo) params.set('end_date', dateTo)
-      if (providerFilter.trim()) params.set('ai_provider', providerFilter.trim())
+      if (debouncedProvider.trim()) params.set('ai_provider', debouncedProvider.trim())
       const data = await api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
       // Discard stale responses from earlier requests
       if (requestId !== latestRequestIdRef.current) return
@@ -184,7 +185,7 @@ export function TokenUsagePage() {
         setBreakdownLoading(false)
       }
     }
-  }, [groupBy, dateFrom, dateTo, providerFilter])
+  }, [groupBy, dateFrom, dateTo, debouncedProvider])
 
   useEffect(() => { fetchBreakdown() }, [fetchBreakdown])
 
@@ -322,8 +323,8 @@ export function TokenUsagePage() {
         </div>
         <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} onClear={clearDates} />
         <Input
-          value={providerFilter}
-          onChange={(e) => setProviderFilter(e.target.value)}
+          value={providerInput}
+          onChange={(e) => setProviderInput(e.target.value)}
           placeholder="Filter by provider..."
           className="h-9 w-full sm:w-44 text-xs"
           aria-label="Filter by provider"

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -35,6 +35,25 @@ interface BreakdownRow {
   avg_duration_ms: number
 }
 
+interface TokenUsageBreakdownResponse {
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_read_tokens: number
+  total_cache_write_tokens: number
+  total_cost_usd: number
+  total_calls: number
+  total_duration_ms: number
+  breakdown: Array<{
+    group_key: string
+    call_count: number
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cost_usd: number
+    avg_duration_ms: number
+  }>
+}
+
 const GROUP_BY_OPTIONS = [
   { value: 'model', label: 'Model' },
   { value: 'provider', label: 'Provider' },
@@ -126,9 +145,19 @@ export function TokenUsagePage() {
       params.set('group_by', groupBy)
       if (dateFrom) params.set('start_date', dateFrom)
       if (dateTo) params.set('end_date', dateTo)
-      if (providerFilter.trim()) params.set('provider', providerFilter.trim())
-      const data = await api.get<BreakdownRow[]>(`/api/admin/token-usage?${params.toString()}`)
-      setBreakdown(data)
+      if (providerFilter.trim()) params.set('ai_provider', providerFilter.trim())
+      const data = await api.get<TokenUsageBreakdownResponse>(`/api/admin/token-usage?${params.toString()}`)
+      setBreakdown(
+        data.breakdown.map((row) => ({
+          group: row.group_key,
+          calls: row.call_count,
+          input_tokens: row.input_tokens,
+          output_tokens: row.output_tokens,
+          cache_read_tokens: row.cache_read_tokens,
+          cost_usd: row.cost_usd,
+          avg_duration_ms: row.avg_duration_ms,
+        }))
+      )
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load breakdown')
@@ -194,14 +223,14 @@ export function TokenUsagePage() {
             cost={summary.today.cost_usd}
           />
           <SummaryCard
-            title="This Week"
+            title="Last 7 Days"
             icon={<TrendingUp className="h-4 w-4 text-signal-green" />}
             calls={summary.this_week.calls}
             tokens={summary.this_week.tokens}
             cost={summary.this_week.cost_usd}
           />
           <SummaryCard
-            title="This Month"
+            title="Last 30 Days"
             icon={<Calendar className="h-4 w-4 text-signal-orange" />}
             calls={summary.this_month.calls}
             tokens={summary.this_month.tokens}

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { api } from '@/lib/api'
-import { formatCompactNumber } from '@/pages/report/TokenUsageBadge'
+import { formatCompactNumber, formatCost } from '@/lib/format'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent } from '@/components/ui/card'
@@ -101,12 +101,6 @@ function SummaryCard({ title, icon, calls, tokens, cost }: {
       </CardContent>
     </Card>
   )
-}
-
-function formatCost(value: number | null | undefined): string {
-  if (value == null || value === 0) return '$0.00'
-  if (value < 0.01) return `$${value.toFixed(4)}`
-  return `$${value.toFixed(2)}`
 }
 
 function formatDurationMs(ms: number): string {
@@ -276,7 +270,7 @@ export function TokenUsagePage() {
                     <div key={m.model} className="flex items-center justify-between">
                       <span className="font-mono text-xs text-text-secondary truncate">{m.model}</span>
                       <div className="flex items-center gap-3">
-                        <span className="font-mono text-xs text-text-tertiary">{m.calls} calls</span>
+                        <span className="font-mono text-xs text-text-tertiary">{m.calls.toLocaleString()} calls</span>
                         <span className="font-mono text-xs text-signal-green">{formatCostCell(m.cost_usd)}</span>
                       </div>
                     </div>
@@ -294,7 +288,7 @@ export function TokenUsagePage() {
                     <div key={j.job_id} className="flex items-center justify-between">
                       <span className="font-mono text-xs text-text-secondary truncate">{j.job_id}</span>
                       <div className="flex items-center gap-3">
-                        <span className="font-mono text-xs text-text-tertiary">{j.calls} calls</span>
+                        <span className="font-mono text-xs text-text-tertiary">{j.calls.toLocaleString()} calls</span>
                         <span className="font-mono text-xs text-signal-green">{formatCostCell(j.cost_usd)}</span>
                       </div>
                     </div>

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -1,0 +1,324 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { api } from '@/lib/api'
+import { formatCompactNumber } from '@/pages/report/TokenUsageBadge'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { SortableHeader } from '@/components/shared/SortableHeader'
+import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
+import { useTableSort } from '@/lib/useTableSort'
+import type { TokenUsageDashboard } from '@/types'
+import { Zap, TrendingUp, Calendar, DollarSign } from 'lucide-react'
+
+interface BreakdownRow {
+  group: string
+  calls: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cost_usd: number
+  avg_duration_ms: number
+}
+
+const GROUP_BY_OPTIONS = [
+  { value: 'model', label: 'Model' },
+  { value: 'provider', label: 'Provider' },
+  { value: 'call_type', label: 'Call Type' },
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+] as const
+
+type GroupByValue = typeof GROUP_BY_OPTIONS[number]['value']
+
+function SummaryCard({ title, icon, calls, tokens, cost }: {
+  title: string
+  icon: React.ReactNode
+  calls: number
+  tokens: number
+  cost: number
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2 mb-3">
+          {icon}
+          <h3 className="text-sm font-display font-medium text-text-primary">{title}</h3>
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-tertiary">Calls</span>
+            <span className="font-mono text-sm font-medium text-text-primary">{calls.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-tertiary">Tokens</span>
+            <span className="font-mono text-sm font-medium text-text-primary">{formatCompactNumber(tokens)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-tertiary">Cost</span>
+            <span className="font-mono text-sm font-medium text-signal-green">
+              {cost > 0 ? `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}` : '—'}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms <= 0) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatCostCell(cost: number): string {
+  if (cost <= 0) return '—'
+  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
+}
+
+export function TokenUsagePage() {
+  const [summary, setSummary] = useState<TokenUsageDashboard | null>(null)
+  const [breakdown, setBreakdown] = useState<BreakdownRow[]>([])
+  const [summaryLoading, setSummaryLoading] = useState(true)
+  const [breakdownLoading, setBreakdownLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [groupBy, setGroupBy] = useState<GroupByValue>('model')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [providerFilter, setProviderFilter] = useState('')
+
+  const { sortKey, sortDir, handleSort } = useTableSort('token-usage', 'cost_usd', 'desc', ['cost_usd', 'calls', 'input_tokens', 'output_tokens', 'avg_duration_ms'])
+
+  // Fetch summary cards
+  useEffect(() => {
+    setSummaryLoading(true)
+    api.get<TokenUsageDashboard>('/api/admin/token-usage/summary')
+      .then((data) => {
+        setSummary(data)
+        setError(null)
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load summary'))
+      .finally(() => setSummaryLoading(false))
+  }, [])
+
+  // Fetch breakdown table
+  const fetchBreakdown = useCallback(async () => {
+    setBreakdownLoading(true)
+    try {
+      const params = new URLSearchParams()
+      params.set('group_by', groupBy)
+      if (dateFrom) params.set('start_date', dateFrom)
+      if (dateTo) params.set('end_date', dateTo)
+      if (providerFilter.trim()) params.set('provider', providerFilter.trim())
+      const data = await api.get<BreakdownRow[]>(`/api/admin/token-usage?${params.toString()}`)
+      setBreakdown(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load breakdown')
+    } finally {
+      setBreakdownLoading(false)
+    }
+  }, [groupBy, dateFrom, dateTo, providerFilter])
+
+  useEffect(() => { fetchBreakdown() }, [fetchBreakdown])
+
+  const sorted = useMemo(() => {
+    const copy = [...breakdown]
+    const dir = sortDir === 'asc' ? 1 : -1
+    copy.sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'group': cmp = a.group.localeCompare(b.group); break
+        case 'calls': cmp = a.calls - b.calls; break
+        case 'input_tokens': cmp = a.input_tokens - b.input_tokens; break
+        case 'output_tokens': cmp = a.output_tokens - b.output_tokens; break
+        case 'cache_read_tokens': cmp = a.cache_read_tokens - b.cache_read_tokens; break
+        case 'cost_usd': cmp = a.cost_usd - b.cost_usd; break
+        case 'avg_duration_ms': cmp = a.avg_duration_ms - b.avg_duration_ms; break
+        default: cmp = 0
+      }
+      return cmp * dir
+    })
+    return copy
+  }, [breakdown, sortKey, sortDir])
+
+  const clearDates = useCallback(() => {
+    setDateFrom('')
+    setDateTo('')
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="font-display text-xl font-bold text-text-primary">Token Usage</h1>
+        <p className="mt-0.5 text-sm text-text-tertiary">AI provider token consumption and costs</p>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p role="alert" className="text-center text-signal-red py-4">{error}</p>
+      )}
+
+      {/* Summary cards */}
+      {summaryLoading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-32 w-full" />
+          ))}
+        </div>
+      ) : summary && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <SummaryCard
+            title="Today"
+            icon={<Zap className="h-4 w-4 text-signal-blue" />}
+            calls={summary.today.calls}
+            tokens={summary.today.tokens}
+            cost={summary.today.cost_usd}
+          />
+          <SummaryCard
+            title="This Week"
+            icon={<TrendingUp className="h-4 w-4 text-signal-green" />}
+            calls={summary.this_week.calls}
+            tokens={summary.this_week.tokens}
+            cost={summary.this_week.cost_usd}
+          />
+          <SummaryCard
+            title="This Month"
+            icon={<Calendar className="h-4 w-4 text-signal-orange" />}
+            calls={summary.this_month.calls}
+            tokens={summary.this_month.tokens}
+            cost={summary.this_month.cost_usd}
+          />
+        </div>
+      )}
+
+      {/* Top models & top jobs */}
+      {summary && (summary.top_models.length > 0 || summary.top_jobs.length > 0) && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {summary.top_models.length > 0 && (
+            <Card>
+              <CardContent className="p-4">
+                <h3 className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-3">Top Models</h3>
+                <div className="space-y-2">
+                  {summary.top_models.map((m) => (
+                    <div key={m.model} className="flex items-center justify-between">
+                      <span className="font-mono text-xs text-text-secondary truncate">{m.model}</span>
+                      <div className="flex items-center gap-3">
+                        <span className="font-mono text-xs text-text-tertiary">{m.calls} calls</span>
+                        <span className="font-mono text-xs text-signal-green">{formatCostCell(m.cost_usd)}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+          {summary.top_jobs.length > 0 && (
+            <Card>
+              <CardContent className="p-4">
+                <h3 className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-3">Top Jobs</h3>
+                <div className="space-y-2">
+                  {summary.top_jobs.map((j) => (
+                    <div key={j.job_id} className="flex items-center justify-between">
+                      <span className="font-mono text-xs text-text-secondary truncate">{j.job_id}</span>
+                      <div className="flex items-center gap-3">
+                        <span className="font-mono text-xs text-text-tertiary">{j.calls} calls</span>
+                        <span className="font-mono text-xs text-signal-green">{formatCostCell(j.cost_usd)}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-2">
+          <DollarSign className="h-3.5 w-3.5 text-text-tertiary" />
+          <Select value={groupBy} onValueChange={(v) => setGroupBy(v as GroupByValue)}>
+            <SelectTrigger aria-label="Group by" className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GROUP_BY_OPTIONS.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} onClear={clearDates} />
+        <Input
+          value={providerFilter}
+          onChange={(e) => setProviderFilter(e.target.value)}
+          placeholder="Filter by provider..."
+          className="h-9 w-full sm:w-44 text-xs"
+          aria-label="Filter by provider"
+        />
+      </div>
+
+      {/* Breakdown table */}
+      {breakdownLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-11 w-full" />
+          ))}
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-border-muted bg-surface-card py-16 text-center">
+          <p className="text-text-secondary">No token usage data found.</p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-surface-card hover:bg-surface-card">
+              <SortableHeader label="Group" sortKey="group" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} />
+              <SortableHeader label="Calls" sortKey="calls" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Input Tokens" sortKey="input_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Output Tokens" sortKey="output_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Cache Read" sortKey="cache_read_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Cost" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Avg Duration" sortKey="avg_duration_ms" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sorted.map((row, i) => (
+              <TableRow
+                key={row.group}
+                className={i % 2 === 0 ? 'bg-surface-card' : 'bg-surface-elevated/40'}
+              >
+                <TableCell className="font-mono text-sm text-text-primary">{row.group}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-secondary">{row.calls.toLocaleString()}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.input_tokens)}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.output_tokens)}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-secondary">{formatCompactNumber(row.cache_read_tokens)}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-signal-green">{formatCostCell(row.cost_usd)}</TableCell>
+                <TableCell className="text-right font-mono text-xs text-text-tertiary">{formatDurationMs(row.avg_duration_ms)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/report/TokenUsageBadge.tsx
+++ b/frontend/src/pages/report/TokenUsageBadge.tsx
@@ -25,7 +25,7 @@ export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
           <p>Input: {usage.total_input_tokens.toLocaleString()} · Output: {usage.total_output_tokens.toLocaleString()}</p>
           {usage.total_cache_read_tokens > 0 && <p>Cache read: {usage.total_cache_read_tokens.toLocaleString()}</p>}
           {usage.total_cache_write_tokens > 0 && <p>Cache write: {usage.total_cache_write_tokens.toLocaleString()}</p>}
-          <p>API calls: {usage.total_calls}</p>
+          <p>API calls: {usage.total_calls.toLocaleString()}</p>
           {usage.total_duration_ms > 0 && <p>Duration: {(usage.total_duration_ms / 1000).toFixed(1)}s</p>}
           {hasCost && <p>Cost: {formatCost(usage.total_cost_usd)}</p>}
         </div>

--- a/frontend/src/pages/report/TokenUsageBadge.tsx
+++ b/frontend/src/pages/report/TokenUsageBadge.tsx
@@ -1,0 +1,53 @@
+import { Zap } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { TokenUsageSummary } from '@/types'
+
+/** Format a number with K/M suffixes (e.g. 15000 → "15K", 1500000 → "1.5M"). */
+export function formatCompactNumber(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000
+    return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`
+  }
+  return String(n)
+}
+
+/** Format USD cost for display. */
+function formatCost(cost: number | null): string | null {
+  if (cost == null || cost === 0) return null
+  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
+}
+
+interface TokenUsageBadgeProps {
+  usage: TokenUsageSummary
+}
+
+export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
+  const costStr = formatCost(usage.total_cost_usd)
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 rounded-full bg-surface-elevated px-2.5 py-0.5 text-[10px] font-mono text-text-tertiary">
+          <Zap className="h-3 w-3" />
+          {formatCompactNumber(usage.total_input_tokens)} in / {formatCompactNumber(usage.total_output_tokens)} out
+          {costStr && <> · {costStr}</>}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        <div className="space-y-1 text-xs">
+          <p>Total tokens: {usage.total_tokens.toLocaleString()}</p>
+          <p>Input: {usage.total_input_tokens.toLocaleString()} · Output: {usage.total_output_tokens.toLocaleString()}</p>
+          {usage.total_cache_read_tokens > 0 && <p>Cache read: {usage.total_cache_read_tokens.toLocaleString()}</p>}
+          {usage.total_cache_write_tokens > 0 && <p>Cache write: {usage.total_cache_write_tokens.toLocaleString()}</p>}
+          <p>API calls: {usage.total_calls}</p>
+          {usage.total_duration_ms > 0 && <p>Duration: {(usage.total_duration_ms / 1000).toFixed(1)}s</p>}
+          {costStr && <p>Cost: {costStr}</p>}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/pages/report/TokenUsageBadge.tsx
+++ b/frontend/src/pages/report/TokenUsageBadge.tsx
@@ -1,32 +1,14 @@
 import { Zap } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { formatCompactNumber, formatCost } from '@/lib/format'
 import type { TokenUsageSummary } from '@/types'
-
-/** Format a number with K/M suffixes (e.g. 15000 → "15K", 1500000 → "1.5M"). */
-export function formatCompactNumber(n: number): string {
-  if (n >= 1_000_000) {
-    const m = n / 1_000_000
-    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`
-  }
-  if (n >= 1_000) {
-    const k = n / 1_000
-    return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`
-  }
-  return String(n)
-}
-
-/** Format USD cost for display. */
-function formatCost(cost: number | null): string | null {
-  if (cost == null || cost === 0) return null
-  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
-}
 
 interface TokenUsageBadgeProps {
   usage: TokenUsageSummary
 }
 
 export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
-  const costStr = formatCost(usage.total_cost_usd)
+  const hasCost = usage.total_cost_usd != null && usage.total_cost_usd > 0
 
   return (
     <Tooltip>
@@ -34,7 +16,7 @@ export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
         <span className="inline-flex items-center gap-1 rounded-full bg-surface-elevated px-2.5 py-0.5 text-[10px] font-mono text-text-tertiary">
           <Zap className="h-3 w-3" />
           {formatCompactNumber(usage.total_input_tokens)} in / {formatCompactNumber(usage.total_output_tokens)} out
-          {costStr && <> · {costStr}</>}
+          {hasCost && <> · {formatCost(usage.total_cost_usd)}</>}
         </span>
       </TooltipTrigger>
       <TooltipContent className="max-w-xs">
@@ -45,7 +27,7 @@ export function TokenUsageBadge({ usage }: TokenUsageBadgeProps) {
           {usage.total_cache_write_tokens > 0 && <p>Cache write: {usage.total_cache_write_tokens.toLocaleString()}</p>}
           <p>API calls: {usage.total_calls}</p>
           {usage.total_duration_ms > 0 && <p>Duration: {(usage.total_duration_ms / 1000).toFixed(1)}s</p>}
-          {costStr && <p>Cost: {costStr}</p>}
+          {hasCost && <p>Cost: {formatCost(usage.total_cost_usd)}</p>}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -130,6 +130,7 @@ export interface AnalysisResult {
   ai_model: string
   failures: FailureAnalysis[]
   child_job_analyses: ChildJobAnalysis[]
+  token_usage?: TokenUsageSummary
   error?: string
   progress_log?: Array<{ phase: string; timestamp: number }>
   progress_phase?: string
@@ -308,6 +309,59 @@ export interface CommentEnrichment {
   type: 'github_pr' | 'github_issue' | 'jira'
   key: string
   status: string
+}
+
+// -- Token Usage ----------------------------------------------------
+
+export interface TokenUsageEntry {
+  provider: string
+  model: string
+  call_type: string
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  total_tokens: number
+  cost_usd: number | null
+  duration_ms: number | null
+}
+
+export interface TokenUsageSummary {
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_read_tokens: number
+  total_cache_write_tokens: number
+  total_tokens: number
+  total_cost_usd: number | null
+  total_duration_ms: number
+  total_calls: number
+  calls: TokenUsageEntry[]
+}
+
+export interface TokenUsageDashboard {
+  today: { calls: number; tokens: number; cost_usd: number }
+  this_week: { calls: number; tokens: number; cost_usd: number }
+  this_month: { calls: number; tokens: number; cost_usd: number }
+  top_models: { model: string; calls: number; cost_usd: number }[]
+  top_jobs: { job_id: string; calls: number; cost_usd: number }[]
+}
+
+export interface TokenUsageRecord {
+  id: string
+  job_id: string
+  created_at: string
+  ai_provider: string
+  ai_model: string
+  call_type: string
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  total_tokens: number
+  cost_usd: number | null
+  duration_ms: number | null
+  prompt_chars: number
+  response_chars: number
 }
 
 // -- Job Metadata ---------------------------------------------------

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -170,6 +170,49 @@ _CONSOLE_ERROR_PATTERN = re.compile(
 )
 
 
+async def _call_ai_and_record(
+    prompt: str,
+    *,
+    job_id: str,
+    call_type: str,
+    cwd: Path | None = None,
+    ai_provider: str = "",
+    ai_model: str = "",
+    ai_cli_timeout: int | None = None,
+    cli_flags: list[str] | None = None,
+) -> tuple[AIResult, AnalysisDetail | None]:
+    """Call AI CLI with retry, record token usage, and parse the response.
+
+    Returns ``(result, parsed_analysis)``.  ``parsed_analysis`` is ``None``
+    when the AI call failed (``result.success is False``).
+    """
+    result = await _call_ai_cli_with_retry(
+        prompt,
+        cwd=cwd,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        ai_cli_timeout=ai_cli_timeout,
+        cli_flags=cli_flags,
+    )
+
+    await record_ai_usage(
+        job_id=job_id,
+        result=result,
+        call_type=call_type,
+        prompt_chars=len(prompt),
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+    )
+
+    parsed: AnalysisDetail | None = None
+    if result.success:
+        parsed = _parse_json_response(result.text)
+        if parsed is None:
+            parsed = AnalysisDetail(details=result.text)
+
+    return result, parsed
+
+
 async def _call_ai_cli_with_retry(
     prompt: str,
     *,
@@ -1064,8 +1107,10 @@ Note: Multiple tests failed with the same error. Provide ONE analysis that appli
         f"Calling {ai_provider.upper()} CLI for failure group ({len(failures)} tests with same error)"
     )
     logger.info(f"Calling AI CLI with {_format_timeout_log(ai_cli_timeout)}")
-    result = await _call_ai_cli_with_retry(
+    result, parsed = await _call_ai_and_record(
         prompt,
+        job_id=job_id,
+        call_type="primary",
         cwd=repo_path,
         ai_provider=ai_provider,
         ai_model=ai_model,
@@ -1073,18 +1118,7 @@ Note: Multiple tests failed with the same error. Provide ONE analysis that appli
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
     )
 
-    await record_ai_usage(
-        job_id=job_id,
-        result=result,
-        call_type="primary",
-        prompt_chars=len(prompt),
-        ai_provider=ai_provider,
-        ai_model=ai_model,
-    )
-
-    if result.success:
-        parsed = _parse_json_response(result.text)
-    else:
+    if parsed is None:
         parsed = AnalysisDetail(details=result.text)
 
     return parsed, error_signature
@@ -1456,8 +1490,10 @@ You have access to the repository if one was cloned. Explore to understand the f
 """
     logger.debug(f"AI prompt length: {len(prompt)} chars")
     logger.info(f"Calling AI CLI with {_format_timeout_log(ai_cli_timeout)}")
-    result = await _call_ai_cli_with_retry(
+    result, parsed_analysis = await _call_ai_and_record(
         prompt,
+        job_id=job_id,
+        call_type="child_console",
         cwd=repo_path,
         ai_provider=ai_provider,
         ai_model=ai_model,
@@ -1465,18 +1501,7 @@ You have access to the repository if one was cloned. Explore to understand the f
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
     )
 
-    await record_ai_usage(
-        job_id=job_id,
-        result=result,
-        call_type="child_console",
-        prompt_chars=len(prompt),
-        ai_provider=ai_provider,
-        ai_model=ai_model,
-    )
-
-    if result.success:
-        parsed_analysis = _parse_json_response(result.text)
-    else:
+    if parsed_analysis is None:
         parsed_analysis = AnalysisDetail(details=result.text)
 
     return ChildJobAnalysis(
@@ -1854,22 +1879,15 @@ You have access to the repository if one was cloned. Explore to understand the f
                 logger.info(
                     f"Calling AI CLI with {_format_timeout_log(settings.ai_cli_timeout)}"
                 )
-                result = await _call_ai_cli_with_retry(
+                result, parsed_console = await _call_ai_and_record(
                     prompt,
+                    job_id=job_id,
+                    call_type="main_console",
                     cwd=repo_path,
                     ai_provider=ai_provider,
                     ai_model=ai_model,
                     ai_cli_timeout=settings.ai_cli_timeout,
                     cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
-                )
-
-                await record_ai_usage(
-                    job_id=job_id,
-                    result=result,
-                    call_type="main_console",
-                    prompt_chars=len(prompt),
-                    ai_provider=ai_provider,
-                    ai_model=ai_model,
                 )
 
                 if not result.success:
@@ -1890,7 +1908,7 @@ You have access to the repository if one was cloned. Explore to understand the f
                     FailureAnalysis(
                         test_name=f"{job_name}#{build_number}",
                         error="Console-only analysis",
-                        analysis=_parse_json_response(result.text),
+                        analysis=parsed_console or AnalysisDetail(details=result.text),
                     )
                 ]
 

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Coroutine, NoReturn
 
 from ai_cli_runner import (
+    AIResult,
     call_ai_cli,
     check_ai_cli_available,
     run_parallel_with_limit,
@@ -44,6 +45,7 @@ from jenkins_job_insight.repository import (
     derive_test_repo_name,
 )
 from jenkins_job_insight.storage import update_progress_phase
+from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -177,7 +179,7 @@ async def _call_ai_cli_with_retry(
     ai_cli_timeout: int | None = None,
     cli_flags: list[str] | None = None,
     max_retries: int = 3,
-) -> tuple[bool, str]:
+) -> AIResult:
     """Call AI CLI with retry on known transient errors.
 
     Wraps :func:`call_ai_cli` with a simple retry loop that re-attempts the
@@ -193,31 +195,32 @@ async def _call_ai_cli_with_retry(
         max_retries: Maximum number of retry attempts after the initial call.
 
     Returns:
-        Tuple of ``(success, output)`` from the final attempt.
+        AIResult from the final attempt.
     """
-    success, output = False, ""
+    result = AIResult(success=False, text="")
     for attempt in range(max_retries + 1):
-        success, output = await call_ai_cli(
+        result = await call_ai_cli(
             prompt,
             cwd=cwd,
             ai_provider=ai_provider,
             ai_model=ai_model,
             ai_cli_timeout=ai_cli_timeout,
             cli_flags=cli_flags,
+            output_format="json",
         )
-        if success:
-            return success, output
+        if result.success:
+            return result
         # Check if the error matches a known retryable pattern
         if attempt < max_retries and any(
-            pattern in output for pattern in RETRYABLE_AI_CLI_PATTERNS
+            pattern in result.text for pattern in RETRYABLE_AI_CLI_PATTERNS
         ):
             logger.warning(
-                f"AI CLI transient error (attempt {attempt + 1}/{max_retries + 1}), retrying: {output}"
+                f"AI CLI transient error (attempt {attempt + 1}/{max_retries + 1}), retrying: {result.text}"
             )
             await asyncio.sleep(2**attempt)  # Exponential backoff: 1s, 2s, 4s
             continue
-        return success, output
-    return success, output  # Should not reach here, but satisfy type checker
+        return result
+    return result  # Should not reach here, but satisfy type checker
 
 
 _JSON_RESPONSE_SCHEMA = """CRITICAL: Your response must be ONLY a valid JSON object. No text before or after. No markdown code blocks. No explanation.
@@ -1061,7 +1064,7 @@ Note: Multiple tests failed with the same error. Provide ONE analysis that appli
         f"Calling {ai_provider.upper()} CLI for failure group ({len(failures)} tests with same error)"
     )
     logger.info(f"Calling AI CLI with {_format_timeout_log(ai_cli_timeout)}")
-    success, analysis_output = await _call_ai_cli_with_retry(
+    result = await _call_ai_cli_with_retry(
         prompt,
         cwd=repo_path,
         ai_provider=ai_provider,
@@ -1070,10 +1073,19 @@ Note: Multiple tests failed with the same error. Provide ONE analysis that appli
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
     )
 
-    if success:
-        parsed = _parse_json_response(analysis_output)
+    await record_ai_usage(
+        job_id=job_id,
+        result=result,
+        call_type="primary",
+        prompt_chars=len(prompt),
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+    )
+
+    if result.success:
+        parsed = _parse_json_response(result.text)
     else:
-        parsed = AnalysisDetail(details=analysis_output)
+        parsed = AnalysisDetail(details=result.text)
 
     return parsed, error_signature
 
@@ -1444,7 +1456,7 @@ You have access to the repository if one was cloned. Explore to understand the f
 """
     logger.debug(f"AI prompt length: {len(prompt)} chars")
     logger.info(f"Calling AI CLI with {_format_timeout_log(ai_cli_timeout)}")
-    success, analysis_output = await _call_ai_cli_with_retry(
+    result = await _call_ai_cli_with_retry(
         prompt,
         cwd=repo_path,
         ai_provider=ai_provider,
@@ -1453,10 +1465,19 @@ You have access to the repository if one was cloned. Explore to understand the f
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
     )
 
-    if success:
-        parsed_analysis = _parse_json_response(analysis_output)
+    await record_ai_usage(
+        job_id=job_id,
+        result=result,
+        call_type="child_console",
+        prompt_chars=len(prompt),
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+    )
+
+    if result.success:
+        parsed_analysis = _parse_json_response(result.text)
     else:
-        parsed_analysis = AnalysisDetail(details=analysis_output)
+        parsed_analysis = AnalysisDetail(details=result.text)
 
     return ChildJobAnalysis(
         job_name=job_name,
@@ -1632,10 +1653,10 @@ async def analyze_job(
                 cloned_repos.update(additional_repos_cloned)
 
             # Pre-flight: verify AI CLI is reachable before spawning parallel tasks
-            ok, err = await check_ai_cli_available(
+            preflight_result = await check_ai_cli_available(
                 ai_provider, ai_model, cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, [])
             )
-            if not ok:
+            if not preflight_result.success:
                 logger.error(
                     "AI CLI sanity check failed for job %s (%s/%s)",
                     job_id,
@@ -1648,7 +1669,7 @@ async def analyze_job(
                     build_number=request.build_number,
                     jenkins_url=HttpUrl(jenkins_build_url),
                     status="failed",
-                    summary=err,
+                    summary=preflight_result.text,
                     ai_provider=ai_provider,
                     ai_model=ai_model,
                     failures=[],
@@ -1833,7 +1854,7 @@ You have access to the repository if one was cloned. Explore to understand the f
                 logger.info(
                     f"Calling AI CLI with {_format_timeout_log(settings.ai_cli_timeout)}"
                 )
-                success, analysis_output = await _call_ai_cli_with_retry(
+                result = await _call_ai_cli_with_retry(
                     prompt,
                     cwd=repo_path,
                     ai_provider=ai_provider,
@@ -1842,14 +1863,23 @@ You have access to the repository if one was cloned. Explore to understand the f
                     cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
                 )
 
-                if not success:
+                await record_ai_usage(
+                    job_id=job_id,
+                    result=result,
+                    call_type="main_console",
+                    prompt_chars=len(prompt),
+                    ai_provider=ai_provider,
+                    ai_model=ai_model,
+                )
+
+                if not result.success:
                     return AnalysisResult(
                         job_id=job_id,
                         job_name=request.job_name,
                         build_number=request.build_number,
                         jenkins_url=HttpUrl(jenkins_build_url),
                         status="failed",
-                        summary=analysis_output,
+                        summary=result.text,
                         ai_provider=ai_provider,
                         ai_model=ai_model,
                         failures=[],
@@ -1860,7 +1890,7 @@ You have access to the repository if one was cloned. Explore to understand the f
                     FailureAnalysis(
                         test_name=f"{job_name}#{build_number}",
                         error="Console-only analysis",
-                        analysis=_parse_json_response(analysis_output),
+                        analysis=_parse_json_response(result.text),
                     )
                 ]
 

--- a/src/jenkins_job_insight/bug_creation.py
+++ b/src/jenkins_job_insight/bug_creation.py
@@ -19,6 +19,7 @@ from jenkins_job_insight.models import (
     FailureAnalysis,
     ProductBugReport,
 )
+from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -232,6 +233,7 @@ async def generate_github_issue_content(
     jenkins_url: str = "",
     ai_cli_timeout: int | None = None,
     include_links: bool = False,
+    job_id: str = "",
 ) -> dict:
     """Generate GitHub issue title and body from a failure analysis using AI.
 
@@ -246,6 +248,7 @@ async def generate_github_issue_content(
         ai_cli_timeout: AI CLI timeout in minutes.
         include_links: When True, include full URLs as clickable links.
             When False, include plain-text references only.
+        job_id: Job identifier for token usage tracking.
 
     Returns dict with "title" and "body" keys.
     """
@@ -323,24 +326,35 @@ Then a blank line, followed by the body in well-formatted markdown with sections
 
 Do not wrap in code blocks or JSON. Just the title on the first line, then the body."""
 
-    success, output = await call_ai_cli(
+    result = await call_ai_cli(
         prompt,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
     )
 
-    if success:
-        parsed = _parse_ai_issue_response(output)
+    if job_id:
+        await record_ai_usage(
+            job_id=job_id,
+            result=result,
+            call_type="github_preview",
+            prompt_chars=len(prompt),
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+        )
+
+    if result.success:
+        parsed = _parse_ai_issue_response(result.text)
         if parsed:
             return parsed
         logger.debug(
             "AI returned output but JSON parsing failed for GitHub issue, output=%s",
-            output,
+            result.text,
         )
     else:
-        logger.debug("AI CLI call failed for GitHub issue: %s", output)
+        logger.debug("AI CLI call failed for GitHub issue: %s", result.text)
 
     logger.warning(
         "AI content generation failed for GitHub issue, using fallback template"
@@ -356,6 +370,7 @@ async def generate_jira_bug_content(
     jenkins_url: str = "",
     ai_cli_timeout: int | None = None,
     include_links: bool = False,
+    job_id: str = "",
 ) -> dict:
     """Generate Jira bug summary and description from a failure analysis using AI.
 
@@ -370,6 +385,7 @@ async def generate_jira_bug_content(
         ai_cli_timeout: AI CLI timeout in minutes.
         include_links: When True, include full URLs as clickable links.
             When False, include plain-text references only.
+        job_id: Job identifier for token usage tracking.
 
     Returns dict with "title" and "body" keys.
     """
@@ -439,24 +455,35 @@ Then a blank line, followed by the description with sections:
 
 Do not wrap in code blocks or JSON. Just the summary on the first line, then the description."""
 
-    success, output = await call_ai_cli(
+    result = await call_ai_cli(
         prompt,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
     )
 
-    if success:
-        parsed = _parse_ai_issue_response(output)
+    if job_id:
+        await record_ai_usage(
+            job_id=job_id,
+            result=result,
+            call_type="jira_preview",
+            prompt_chars=len(prompt),
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+        )
+
+    if result.success:
+        parsed = _parse_ai_issue_response(result.text)
         if parsed:
             return parsed
         logger.debug(
             "AI returned output but JSON parsing failed for Jira bug, output=%s",
-            output,
+            result.text,
         )
     else:
-        logger.debug("AI CLI call failed for Jira bug: %s", output)
+        logger.debug("AI CLI call failed for Jira bug: %s", result.text)
 
     logger.warning("AI content generation failed for Jira bug, using fallback template")
     return _build_fallback_jira_content(ctx, jenkins_url, report_url, include_links)

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -668,6 +668,41 @@ class JJIClient:
         body = self._with_jira_auth_fields(body, jira_token, jira_email)
         return self._request("POST", "/api/jira-security-levels", json=body)
 
+    # -- Token Usage ----------------------------------------------------------
+
+    def get_token_usage(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        ai_provider: str | None = None,
+        ai_model: str | None = None,
+        call_type: str | None = None,
+        group_by: str | None = None,
+    ) -> dict:
+        """Get aggregated token usage with filters. GET /api/admin/token-usage"""
+        params: dict = {}
+        if start_date:
+            params["start_date"] = start_date
+        if end_date:
+            params["end_date"] = end_date
+        if ai_provider:
+            params["ai_provider"] = ai_provider
+        if ai_model:
+            params["ai_model"] = ai_model
+        if call_type:
+            params["call_type"] = call_type
+        if group_by:
+            params["group_by"] = group_by
+        return self._request("GET", "/api/admin/token-usage", params=params)
+
+    def get_token_usage_summary(self) -> dict:
+        """Get token usage dashboard summary. GET /api/admin/token-usage/summary"""
+        return self._request("GET", "/api/admin/token-usage/summary")
+
+    def get_token_usage_for_job(self, job_id: str) -> dict:
+        """Get token usage for a specific job. GET /api/admin/token-usage/{job_id}"""
+        return self._request("GET", f"/api/admin/token-usage/{job_id}")
+
     # -- AI Configs -----------------------------------------------------------
 
     def get_ai_configs(self) -> list[dict]:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1844,22 +1844,10 @@ def admin_users_change_role(
 # -- Token Usage (Admin) ------------------------------------------------------
 
 
-def _today() -> str:
-    from datetime import date
-
-    return date.today().isoformat()
-
-
-def _week_ago() -> str:
+def _date_offset(days: int = 0) -> str:
     from datetime import date, timedelta
 
-    return (date.today() - timedelta(days=7)).isoformat()
-
-
-def _month_ago() -> str:
-    from datetime import date, timedelta
-
-    return (date.today() - timedelta(days=30)).isoformat()
+    return (date.today() - timedelta(days=days)).isoformat()
 
 
 def _print_token_summary(data: dict) -> None:
@@ -1877,7 +1865,7 @@ def _print_token_summary(data: dict) -> None:
         typer.echo("\nTop Models (30 days):")
         for m in top_models:
             typer.echo(
-                f"  {m['model']}: {m['calls']} calls, ${m.get('cost_usd', 0):.2f}"
+                f"  {m.get('model', 'unknown')}: {m.get('calls', 0)} calls, ${m.get('cost_usd', 0):.2f}"
             )
 
 
@@ -1927,10 +1915,12 @@ def _print_token_usage_csv(rows: list[dict]) -> None:
     import sys
 
     if not rows:
+        typer.echo("No data")
         return
     writer = csv.DictWriter(sys.stdout, fieldnames=rows[0].keys())
     writer.writeheader()
-    writer.writerows(rows)
+    for row in rows:
+        writer.writerow({k: row.get(k, "") for k in rows[0].keys()})
 
 
 @admin_app.command("token-usage")
@@ -1960,6 +1950,19 @@ def token_usage_cmd(
     # --json flag overrides --format
     effective_format = "json" if _state.get("json", False) else output_format
 
+    valid_periods = {"today", "week", "month", "all"}
+    valid_formats = {"table", "json", "csv"}
+    if period and period not in valid_periods:
+        typer.echo(
+            f"Invalid --period: {period}. Valid: {', '.join(sorted(valid_periods))}"
+        )
+        raise typer.Exit(1)
+    if effective_format not in valid_formats:
+        typer.echo(
+            f"Invalid --format: {effective_format}. Valid: {', '.join(sorted(valid_formats))}"
+        )
+        raise typer.Exit(1)
+
     try:
         client = _get_client()
 
@@ -1974,11 +1977,11 @@ def token_usage_cmd(
             return
 
         if period == "today":
-            start_date = start_date or _today()
+            start_date = start_date or _date_offset(0)
         elif period == "week":
-            start_date = start_date or _week_ago()
+            start_date = start_date or _date_offset(7)
         elif period == "month":
-            start_date = start_date or _month_ago()
+            start_date = start_date or _date_offset(30)
         # period == "all" — no date filter, falls through to main query
 
         if (
@@ -1998,9 +2001,9 @@ def token_usage_cmd(
                 # Flatten period rows for CSV output
                 rows = []
                 for period_name in ["today", "this_week", "this_month"]:
-                    period = data.get(period_name, {})
-                    if isinstance(period, dict):
-                        rows.append({"period": period_name, **period})
+                    period_data = data.get(period_name, {})
+                    if isinstance(period_data, dict):
+                        rows.append({"period": period_name, **period_data})
                 _print_token_usage_csv(rows)
             else:
                 _print_token_summary(data)

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1845,9 +1845,16 @@ def admin_users_change_role(
 
 
 def _date_offset(days: int = 0) -> str:
-    from datetime import date, timedelta
+    from datetime import datetime, timedelta, timezone
 
-    return (date.today() - timedelta(days=days)).isoformat()
+    return (datetime.now(timezone.utc).date() - timedelta(days=days)).isoformat()
+
+
+def _format_cost(value: float | None, precision: int = 2) -> str:
+    """Format a USD cost value, returning 'N/A' when absent."""
+    if value is None:
+        return "N/A"
+    return f"${value:.{precision}f}"
 
 
 def _print_token_summary(data: dict) -> None:
@@ -1858,16 +1865,14 @@ def _print_token_summary(data: dict) -> None:
         typer.echo(f"\n{label}:")
         typer.echo(f"  Calls: {period.get('calls', 0)}")
         typer.echo(f"  Tokens: {period.get('tokens', 0):,}")
-        _cost = period.get("cost_usd")
-        typer.echo(f"  Cost: {f'${_cost:.2f}' if _cost is not None else 'N/A'}")
+        typer.echo(f"  Cost: {_format_cost(period.get('cost_usd'))}")
 
     top_models = data.get("top_models", [])
     if top_models:
         typer.echo("\nTop Models (30 days):")
         for m in top_models:
-            _mcost = m.get("cost_usd")
             typer.echo(
-                f"  {m.get('model', 'unknown')}: {m.get('calls', 0)} calls, {f'${_mcost:.2f}' if _mcost is not None else 'N/A'}"
+                f"  {m.get('model', 'unknown')}: {m.get('calls', 0)} calls, {_format_cost(m.get('cost_usd'))}"
             )
 
 
@@ -1878,8 +1883,7 @@ def _print_token_usage_table(data: dict) -> None:
     typer.echo(f"Output tokens: {data.get('total_output_tokens', 0):,}")
     typer.echo(f"Cache read: {data.get('total_cache_read_tokens', 0):,}")
     typer.echo(f"Cache write: {data.get('total_cache_write_tokens', 0):,}")
-    _tcost = data.get("total_cost_usd")
-    typer.echo(f"Cost: {f'${_tcost:.2f}' if _tcost is not None else 'N/A'}")
+    typer.echo(f"Cost: {_format_cost(data.get('total_cost_usd'))}")
     typer.echo(f"Duration: {data.get('total_duration_ms', 0):,}ms")
 
     breakdown = data.get("breakdown", [])
@@ -1889,7 +1893,7 @@ def _print_token_usage_table(data: dict) -> None:
             typer.echo(
                 f"  {row.get('group_key', 'N/A')}: "
                 f"{row.get('call_count', 0)} calls, "
-                f"{f'${row["cost_usd"]:.2f}' if row.get('cost_usd') is not None else 'N/A'}, "
+                f"{_format_cost(row.get('cost_usd'))}, "
                 f"avg {row.get('avg_duration_ms', 0)}ms"
             )
 
@@ -1907,9 +1911,9 @@ def _print_job_token_usage(data: dict) -> None:
             f"    Input: {rec.get('input_tokens', 0):,}  "
             f"Output: {rec.get('output_tokens', 0):,}"
         )
-        cost = rec.get("cost_usd")
-        cost_str = f"${cost:.4f}" if cost is not None else "N/A"
-        typer.echo(f"    Cost: {cost_str}  Duration: {rec.get('duration_ms', 0)}ms")
+        typer.echo(
+            f"    Cost: {_format_cost(rec.get('cost_usd'), precision=4)}  Duration: {rec.get('duration_ms', 0)}ms"
+        )
 
 
 def _print_token_usage_csv(rows: list[dict]) -> None:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1979,16 +1979,18 @@ def token_usage_cmd(
             start_date = start_date or _week_ago()
         elif period == "month":
             start_date = start_date or _month_ago()
+        # period == "all" — no date filter, falls through to main query
 
         if (
-            not start_date
+            period is None
+            and not start_date
             and not end_date
             and not provider
             and not model
             and not call_type
             and not group_by
         ):
-            # Summary mode — no filters specified
+            # Summary dashboard mode — only when no period or filters specified
             data = client.get_token_usage_summary()
             if effective_format == "json":
                 print_output(data, columns=[], as_json=True)

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1922,7 +1922,7 @@ def _print_token_usage_csv(rows: list[dict]) -> None:
     import sys
 
     if not rows:
-        typer.echo("No data")
+        typer.echo("No data", err=True)
         return
     writer = csv.DictWriter(sys.stdout, fieldnames=rows[0].keys())
     writer.writeheader()

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1841,6 +1841,179 @@ def admin_users_change_role(
             )
 
 
+# -- Token Usage (Admin) ------------------------------------------------------
+
+
+def _today() -> str:
+    from datetime import date
+
+    return date.today().isoformat()
+
+
+def _week_ago() -> str:
+    from datetime import date, timedelta
+
+    return (date.today() - timedelta(days=7)).isoformat()
+
+
+def _month_ago() -> str:
+    from datetime import date, timedelta
+
+    return (date.today() - timedelta(days=30)).isoformat()
+
+
+def _print_token_summary(data: dict) -> None:
+    """Print dashboard summary."""
+    for period_name in ["today", "this_week", "this_month"]:
+        period = data.get(period_name, {})
+        label = period_name.replace("_", " ").title()
+        typer.echo(f"\n{label}:")
+        typer.echo(f"  Calls: {period.get('calls', 0)}")
+        typer.echo(f"  Tokens: {period.get('tokens', 0):,}")
+        typer.echo(f"  Cost: ${period.get('cost_usd', 0):.2f}")
+
+    top_models = data.get("top_models", [])
+    if top_models:
+        typer.echo("\nTop Models (30 days):")
+        for m in top_models:
+            typer.echo(
+                f"  {m['model']}: {m['calls']} calls, ${m.get('cost_usd', 0):.2f}"
+            )
+
+
+def _print_token_usage_table(data: dict) -> None:
+    """Print aggregated token usage."""
+    typer.echo(f"Total calls: {data.get('total_calls', 0)}")
+    typer.echo(f"Input tokens: {data.get('total_input_tokens', 0):,}")
+    typer.echo(f"Output tokens: {data.get('total_output_tokens', 0):,}")
+    typer.echo(f"Cache read: {data.get('total_cache_read_tokens', 0):,}")
+    typer.echo(f"Cache write: {data.get('total_cache_write_tokens', 0):,}")
+    typer.echo(f"Cost: ${data.get('total_cost_usd', 0):.2f}")
+    typer.echo(f"Duration: {data.get('total_duration_ms', 0):,}ms")
+
+    breakdown = data.get("breakdown", [])
+    if breakdown:
+        typer.echo("\nBreakdown:")
+        for row in breakdown:
+            typer.echo(
+                f"  {row.get('group_key', 'N/A')}: "
+                f"{row.get('call_count', 0)} calls, "
+                f"${row.get('cost_usd', 0):.2f}, "
+                f"avg {row.get('avg_duration_ms', 0)}ms"
+            )
+
+
+def _print_job_token_usage(data: dict) -> None:
+    """Print per-job token usage."""
+    typer.echo(f"Job: {data.get('job_id', 'N/A')}")
+    records = data.get("records", [])
+    for rec in records:
+        typer.echo(
+            f"\n  [{rec.get('call_type', '')}] "
+            f"{rec.get('ai_provider', '')}/{rec.get('ai_model', '')}"
+        )
+        typer.echo(
+            f"    Input: {rec.get('input_tokens', 0):,}  "
+            f"Output: {rec.get('output_tokens', 0):,}"
+        )
+        cost = rec.get("cost_usd")
+        cost_str = f"${cost:.4f}" if cost is not None else "N/A"
+        typer.echo(f"    Cost: {cost_str}  Duration: {rec.get('duration_ms', 0)}ms")
+
+
+def _print_token_usage_csv(rows: list[dict]) -> None:
+    """Print token usage as CSV."""
+    import csv
+    import sys
+
+    if not rows:
+        return
+    writer = csv.DictWriter(sys.stdout, fieldnames=rows[0].keys())
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+@admin_app.command("token-usage")
+def token_usage_cmd(
+    period: str | None = typer.Option(None, help="Period: today, week, month, all"),
+    start_date: str | None = typer.Option(
+        None, "--start-date", help="Start date (YYYY-MM-DD)"
+    ),
+    end_date: str | None = typer.Option(
+        None, "--end-date", help="End date (YYYY-MM-DD)"
+    ),
+    provider: str | None = typer.Option(None, help="Filter by AI provider"),
+    model: str | None = typer.Option(None, help="Filter by AI model"),
+    call_type: str | None = typer.Option(None, help="Filter by call type"),
+    group_by: str | None = typer.Option(
+        None,
+        help="Group by: provider, model, call_type, day, week, month, job",
+    ),
+    job_id: str | None = typer.Option(None, help="Get usage for specific job"),
+    output_format: str = typer.Option(
+        "table", "--format", help="Output format: table, json, csv"
+    ),
+    json_output: bool = _JSON_OPTION,
+):
+    """View AI token usage and costs. Admin only."""
+    _set_json(json_output)
+    # --json flag overrides --format
+    effective_format = "json" if _state.get("json", False) else output_format
+
+    try:
+        client = _get_client()
+
+        if job_id:
+            data = client.get_token_usage_for_job(job_id)
+            if effective_format == "json":
+                print_output(data, columns=[], as_json=True)
+            elif effective_format == "csv":
+                _print_token_usage_csv(data.get("records", []))
+            else:
+                _print_job_token_usage(data)
+            return
+
+        if period == "today":
+            start_date = start_date or _today()
+        elif period == "week":
+            start_date = start_date or _week_ago()
+        elif period == "month":
+            start_date = start_date or _month_ago()
+
+        if (
+            not start_date
+            and not end_date
+            and not provider
+            and not model
+            and not call_type
+            and not group_by
+        ):
+            # Summary mode — no filters specified
+            data = client.get_token_usage_summary()
+            if effective_format == "json":
+                print_output(data, columns=[], as_json=True)
+            else:
+                _print_token_summary(data)
+            return
+
+        data = client.get_token_usage(
+            start_date=start_date,
+            end_date=end_date,
+            ai_provider=provider,
+            ai_model=model,
+            call_type=call_type,
+            group_by=group_by,
+        )
+        if effective_format == "json":
+            print_output(data, columns=[], as_json=True)
+        elif effective_format == "csv":
+            _print_token_usage_csv(data.get("breakdown", []))
+        else:
+            _print_token_usage_table(data)
+    except JJIError as err:
+        _handle_error(err)
+
+
 # -- Metadata -----------------------------------------------------------------
 
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1994,6 +1994,14 @@ def token_usage_cmd(
             data = client.get_token_usage_summary()
             if effective_format == "json":
                 print_output(data, columns=[], as_json=True)
+            elif effective_format == "csv":
+                # Flatten period rows for CSV output
+                rows = []
+                for period_name in ["today", "this_week", "this_month"]:
+                    period = data.get(period_name, {})
+                    if isinstance(period, dict):
+                        rows.append({"period": period_name, **period})
+                _print_token_usage_csv(rows)
             else:
                 _print_token_summary(data)
             return
@@ -2009,7 +2017,13 @@ def token_usage_cmd(
         if effective_format == "json":
             print_output(data, columns=[], as_json=True)
         elif effective_format == "csv":
-            _print_token_usage_csv(data.get("breakdown", []))
+            breakdown = data.get("breakdown", [])
+            if breakdown:
+                _print_token_usage_csv(breakdown)
+            else:
+                # No group_by — output the totals row as CSV
+                totals = {k: v for k, v in data.items() if k != "breakdown"}
+                _print_token_usage_csv([totals] if totals else [])
         else:
             _print_token_usage_table(data)
     except JJIError as err:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1858,14 +1858,16 @@ def _print_token_summary(data: dict) -> None:
         typer.echo(f"\n{label}:")
         typer.echo(f"  Calls: {period.get('calls', 0)}")
         typer.echo(f"  Tokens: {period.get('tokens', 0):,}")
-        typer.echo(f"  Cost: ${period.get('cost_usd', 0):.2f}")
+        _cost = period.get("cost_usd")
+        typer.echo(f"  Cost: {f'${_cost:.2f}' if _cost is not None else 'N/A'}")
 
     top_models = data.get("top_models", [])
     if top_models:
         typer.echo("\nTop Models (30 days):")
         for m in top_models:
+            _mcost = m.get("cost_usd")
             typer.echo(
-                f"  {m.get('model', 'unknown')}: {m.get('calls', 0)} calls, ${m.get('cost_usd', 0):.2f}"
+                f"  {m.get('model', 'unknown')}: {m.get('calls', 0)} calls, {f'${_mcost:.2f}' if _mcost is not None else 'N/A'}"
             )
 
 
@@ -1876,7 +1878,8 @@ def _print_token_usage_table(data: dict) -> None:
     typer.echo(f"Output tokens: {data.get('total_output_tokens', 0):,}")
     typer.echo(f"Cache read: {data.get('total_cache_read_tokens', 0):,}")
     typer.echo(f"Cache write: {data.get('total_cache_write_tokens', 0):,}")
-    typer.echo(f"Cost: ${data.get('total_cost_usd', 0):.2f}")
+    _tcost = data.get("total_cost_usd")
+    typer.echo(f"Cost: {f'${_tcost:.2f}' if _tcost is not None else 'N/A'}")
     typer.echo(f"Duration: {data.get('total_duration_ms', 0):,}ms")
 
     breakdown = data.get("breakdown", [])
@@ -1886,7 +1889,7 @@ def _print_token_usage_table(data: dict) -> None:
             typer.echo(
                 f"  {row.get('group_key', 'N/A')}: "
                 f"{row.get('call_count', 0)} calls, "
-                f"${row.get('cost_usd', 0):.2f}, "
+                f"{f'${row["cost_usd"]:.2f}' if row.get('cost_usd') is not None else 'N/A'}, "
                 f"avg {row.get('avg_duration_ms', 0)}ms"
             )
 
@@ -1954,12 +1957,14 @@ def token_usage_cmd(
     valid_formats = {"table", "json", "csv"}
     if period and period not in valid_periods:
         typer.echo(
-            f"Invalid --period: {period}. Valid: {', '.join(sorted(valid_periods))}"
+            f"Invalid --period: {period}. Valid: {', '.join(sorted(valid_periods))}",
+            err=True,
         )
         raise typer.Exit(1)
     if effective_format not in valid_formats:
         typer.echo(
-            f"Invalid --format: {effective_format}. Valid: {', '.join(sorted(valid_formats))}"
+            f"Invalid --format: {effective_format}. Valid: {', '.join(sorted(valid_formats))}",
+            err=True,
         )
         raise typer.Exit(1)
 

--- a/src/jenkins_job_insight/jira.py
+++ b/src/jenkins_job_insight/jira.py
@@ -22,6 +22,7 @@ from jenkins_job_insight.models import (
     JiraMatch,
     ProductBugReport,
 )
+from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -318,6 +319,7 @@ async def _filter_matches_with_ai(
     ai_provider: str,
     ai_model: str,
     ai_cli_timeout: int | None = None,
+    job_id: str = "",
 ) -> list[JiraMatch]:
     """Use AI to determine which Jira candidates are relevant to the bug.
 
@@ -332,6 +334,7 @@ async def _filter_matches_with_ai(
         ai_provider: AI provider name.
         ai_model: AI model identifier.
         ai_cli_timeout: Timeout in minutes (overrides AI_CLI_TIMEOUT env var).
+        job_id: Job identifier for token usage tracking.
 
     Returns:
         List of JiraMatch objects for relevant candidates only.
@@ -372,21 +375,32 @@ Example: [{{"key": "PROJ-123", "relevant": true, "score": 0.9}}, {{"key": "PROJ-
 
 Respond with ONLY the JSON array, no other text."""
 
-    success, output = await call_ai_cli(
+    result = await call_ai_cli(
         prompt,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
     )
 
-    if not success:
-        logger.warning("AI relevance filtering failed: %s", output)
+    if job_id:
+        await record_ai_usage(
+            job_id=job_id,
+            result=result,
+            call_type="jira_filter",
+            prompt_chars=len(prompt),
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+        )
+
+    if not result.success:
+        logger.warning("AI relevance filtering failed: %s", result.text)
         return []
 
     # Parse AI response
     try:
-        text = output.strip()
+        text = result.text.strip()
         # Strip markdown code block if present
         if "```json" in text:
             start = text.index("```json") + len("```json")
@@ -462,6 +476,7 @@ async def enrich_with_jira_matches(
     settings: Settings,
     ai_provider: str = "",
     ai_model: str = "",
+    job_id: str = "",
 ) -> None:
     """Search Jira for matching issues and attach results in-place.
 
@@ -477,6 +492,7 @@ async def enrich_with_jira_matches(
         settings: Application settings with Jira configuration.
         ai_provider: AI provider for relevance filtering.
         ai_model: AI model for relevance filtering.
+        job_id: Job identifier for token usage tracking.
     """
     if not settings.jira_enabled:
         return
@@ -535,6 +551,7 @@ async def enrich_with_jira_matches(
                         ai_provider=ai_provider,
                         ai_model=ai_model,
                         ai_cli_timeout=settings.ai_cli_timeout,
+                        job_id=job_id,
                     )
                 else:
                     # No AI config — fall back to returning all candidates as matches

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -46,6 +46,7 @@ from jenkins_job_insight.encryption import (
     encrypt_sensitive_fields,
 )
 from jenkins_job_insight.jira import enrich_with_jira_matches
+from jenkins_job_insight.token_tracking import build_token_usage_summary
 from jenkins_job_insight.monitoring import (
     build_health_response,
     dispatch_alert,
@@ -985,6 +986,7 @@ async def _enrich_result_with_jira(
     settings: Settings,
     ai_provider: str = "",
     ai_model: str = "",
+    job_id: str = "",
 ) -> None:
     """Enrich PRODUCT BUG failures with Jira matches.
 
@@ -997,6 +999,7 @@ async def _enrich_result_with_jira(
         settings: Application settings with Jira configuration.
         ai_provider: AI provider for Jira relevance filtering.
         ai_model: AI model for Jira relevance filtering.
+        job_id: Job identifier for token usage tracking.
     """
     if not settings.jira_enabled:
         return
@@ -1013,7 +1016,9 @@ async def _enrich_result_with_jira(
 
     _collect(failures)
 
-    await enrich_with_jira_matches(all_failures, settings, ai_provider, ai_model)
+    await enrich_with_jira_matches(
+        all_failures, settings, ai_provider, ai_model, job_id=job_id
+    )
 
 
 async def _wait_for_jenkins_completion(
@@ -1250,6 +1255,7 @@ async def process_analysis_with_id(
                 settings,
                 ai_provider,
                 ai_model,
+                job_id=job_id,
             )
 
         await _safe_update_progress_phase("saving")
@@ -1258,6 +1264,11 @@ async def process_analysis_with_id(
         )
         result_data = result.model_dump(mode="json")
         await _preserve_request_params(job_id, result_data)
+
+        # Attach token usage summary before persisting
+        token_summary = await build_token_usage_summary(job_id)
+        if token_summary:
+            result_data["token_usage"] = token_summary.model_dump(mode="json")
 
         # Save to storage — do NOT persist base_url / result_url as they are
         # request-derived and re-generated on every GET to avoid host-header
@@ -1651,7 +1662,9 @@ async def analyze_failures(
 
         # Enrich PRODUCT BUG failures with Jira matches
         if _resolve_enable_jira(body, merged):
-            await enrich_with_jira_matches(all_analyses, merged, ai_provider, ai_model)
+            await enrich_with_jira_matches(
+                all_analyses, merged, ai_provider, ai_model, job_id=job_id
+            )
 
         # If raw_xml was provided, produce enriched XML
         enriched_xml = None
@@ -1672,6 +1685,12 @@ async def analyze_failures(
 
         result_data = analysis_result.model_dump(mode="json")
         await _preserve_request_params(job_id, result_data)
+
+        # Attach token usage summary before persisting
+        token_summary = await build_token_usage_summary(job_id)
+        if token_summary:
+            result_data["token_usage"] = token_summary.model_dump(mode="json")
+
         await update_status(job_id, "completed", result_data)
 
         # Populate failure history
@@ -2298,6 +2317,7 @@ async def preview_github_issue(
         ai_model=ai_model,
         jenkins_url=jenkins_url,
         include_links=effective_include_links,
+        job_id=job_id,
     )
 
     # Duplicate detection (best-effort: failures must not break preview)
@@ -2373,6 +2393,7 @@ async def preview_jira_bug(
         ai_model=ai_model,
         jenkins_url=jenkins_url,
         include_links=effective_include_links,
+        job_id=job_id,
     )
 
     # Duplicate detection (best-effort: failures must not break preview)
@@ -3944,6 +3965,47 @@ async def save_user_tokens_endpoint(request: Request) -> JSONResponse:
 
 
 # --- Admin endpoints ---
+
+
+@app.get("/api/admin/token-usage")
+async def get_token_usage(
+    request: Request,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    ai_provider: str | None = None,
+    ai_model: str | None = None,
+    call_type: str | None = None,
+    group_by: str | None = None,
+) -> dict:
+    """Get aggregated token usage with optional filters and grouping. Admin only."""
+    _require_admin(request)
+    return await storage.get_token_usage_summary(
+        start_date=start_date,
+        end_date=end_date,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        call_type=call_type,
+        group_by=group_by,
+    )
+
+
+@app.get("/api/admin/token-usage/summary")
+async def get_token_usage_dashboard(request: Request) -> dict:
+    """Get high-level token usage summary for dashboard. Admin only."""
+    _require_admin(request)
+    return await storage.get_token_usage_dashboard_summary()
+
+
+@app.get("/api/admin/token-usage/{job_id}")
+async def get_token_usage_for_job(request: Request, job_id: str) -> dict:
+    """Get token usage breakdown for a specific job. Admin only."""
+    _require_admin(request)
+    records = await storage.get_token_usage_for_job(job_id)
+    if not records:
+        raise HTTPException(
+            status_code=404, detail="No token usage records found for this job"
+        )
+    return {"job_id": job_id, "records": records}
 
 
 @app.post("/api/admin/users")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1302,6 +1302,15 @@ async def process_analysis_with_id(
             "error": error_detail,
         }
         await _preserve_request_params(job_id, error_data)
+
+        # Attach token usage even on failure — partial AI calls may have been recorded
+        try:
+            token_summary = await build_token_usage_summary(job_id)
+            if token_summary:
+                error_data["token_usage"] = token_summary.model_dump(mode="json")
+        except Exception:
+            pass
+
         await update_status(job_id, "failed", error_data)
 
 
@@ -3979,6 +3988,12 @@ async def get_token_usage(
 ) -> dict:
     """Get aggregated token usage with optional filters and grouping. Admin only."""
     _require_admin(request)
+    _valid_group_by = {"provider", "model", "call_type", "day", "week", "month", "job"}
+    if group_by and group_by not in _valid_group_by:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid group_by value. Valid: {', '.join(sorted(_valid_group_by))}",
+        )
     return await storage.get_token_usage_summary(
         start_date=start_date,
         end_date=end_date,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1734,6 +1734,10 @@ async def analyze_failures(
         )
         fail_data = analysis_result.model_dump(mode="json")
         await _preserve_request_params(job_id, fail_data)
+
+        # Attach token usage even on failure — partial AI calls may have been recorded
+        await _attach_token_usage(job_id, fail_data)
+
         await update_status(job_id, "failed", fail_data)
         return JSONResponse(content=_attach_result_links(fail_data, base_url, job_id))
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -150,7 +150,7 @@ async def _attach_token_usage(job_id: str, result_data: dict) -> None:
         token_summary = await build_token_usage_summary(job_id)
         if token_summary:
             result_data["token_usage"] = token_summary.model_dump(mode="json")
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort token tracking must never fail the job
         logger.debug("Failed to attach token usage for job %s", job_id, exc_info=True)
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -144,6 +144,16 @@ def _install_job_id_filter() -> None:
 _install_job_id_filter()
 
 
+async def _attach_token_usage(job_id: str, result_data: dict) -> None:
+    """Attach token usage summary to result data. Best-effort \u2014 never raises."""
+    try:
+        token_summary = await build_token_usage_summary(job_id)
+        if token_summary:
+            result_data["token_usage"] = token_summary.model_dump(mode="json")
+    except Exception:
+        logger.debug("Failed to attach token usage for job %s", job_id, exc_info=True)
+
+
 async def _bind_job_id(job_id: str) -> None:
     """FastAPI dependency that binds job_id to the logging context."""
     job_id_var.set(job_id)
@@ -154,6 +164,10 @@ IN_PROGRESS_STATUSES = ("pending", "running", "waiting")
 
 AI_PROVIDER = os.getenv("AI_PROVIDER", "").lower()
 AI_MODEL = os.getenv("AI_MODEL", "")
+
+_VALID_GROUP_BY = frozenset(
+    {"provider", "model", "call_type", "day", "week", "month", "job"}
+)
 
 
 def _read_app_port() -> int:
@@ -1266,9 +1280,7 @@ async def process_analysis_with_id(
         await _preserve_request_params(job_id, result_data)
 
         # Attach token usage summary before persisting
-        token_summary = await build_token_usage_summary(job_id)
-        if token_summary:
-            result_data["token_usage"] = token_summary.model_dump(mode="json")
+        await _attach_token_usage(job_id, result_data)
 
         # Save to storage — do NOT persist base_url / result_url as they are
         # request-derived and re-generated on every GET to avoid host-header
@@ -1304,12 +1316,7 @@ async def process_analysis_with_id(
         await _preserve_request_params(job_id, error_data)
 
         # Attach token usage even on failure — partial AI calls may have been recorded
-        try:
-            token_summary = await build_token_usage_summary(job_id)
-            if token_summary:
-                error_data["token_usage"] = token_summary.model_dump(mode="json")
-        except Exception:
-            pass
+        await _attach_token_usage(job_id, error_data)
 
         await update_status(job_id, "failed", error_data)
 
@@ -1696,9 +1703,7 @@ async def analyze_failures(
         await _preserve_request_params(job_id, result_data)
 
         # Attach token usage summary before persisting
-        token_summary = await build_token_usage_summary(job_id)
-        if token_summary:
-            result_data["token_usage"] = token_summary.model_dump(mode="json")
+        await _attach_token_usage(job_id, result_data)
 
         await update_status(job_id, "completed", result_data)
 
@@ -3988,11 +3993,10 @@ async def get_token_usage(
 ) -> dict:
     """Get aggregated token usage with optional filters and grouping. Admin only."""
     _require_admin(request)
-    _valid_group_by = {"provider", "model", "call_type", "day", "week", "month", "job"}
-    if group_by and group_by not in _valid_group_by:
+    if group_by and group_by not in _VALID_GROUP_BY:
         raise HTTPException(
             status_code=422,
-            detail=f"Invalid group_by value. Valid: {', '.join(sorted(_valid_group_by))}",
+            detail=f"Invalid group_by value. Valid: {', '.join(sorted(_VALID_GROUP_BY))}",
         )
     return await storage.get_token_usage_summary(
         start_date=start_date,

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -502,6 +502,9 @@ class FailureAnalysisResult(BaseModel):
         default=None,
         description="Enriched JUnit XML with analysis results (only when raw_xml was provided in request)",
     )
+    token_usage: TokenUsageSummary | None = Field(
+        default=None, description="Token usage summary for this analysis"
+    )
 
 
 class _ChildJobFieldsValidator(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -399,6 +399,35 @@ class ChildJobAnalysis(BaseModel):
     )
 
 
+class TokenUsageEntry(BaseModel):
+    """Token usage for a single AI CLI call."""
+
+    provider: str = ""
+    model: str = ""
+    call_type: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+
+
+class TokenUsageSummary(BaseModel):
+    """Aggregated token usage for an entire analysis job."""
+
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_cache_write_tokens: int = 0
+    total_tokens: int = 0
+    total_cost_usd: float | None = None
+    total_duration_ms: int = 0
+    total_calls: int = 0
+    calls: list[TokenUsageEntry] = Field(default_factory=list)
+
+
 class AnalysisResult(BaseModel):
     """Complete analysis result for a Jenkins job."""
 
@@ -421,6 +450,10 @@ class AnalysisResult(BaseModel):
     child_job_analyses: list[ChildJobAnalysis] = Field(
         default_factory=list,
         description="Analyses of failed child jobs in pipeline",
+    )
+    token_usage: TokenUsageSummary | None = Field(
+        default=None,
+        description="Aggregated token usage across all AI calls in this analysis",
     )
 
 

--- a/src/jenkins_job_insight/peer_analysis.py
+++ b/src/jenkins_job_insight/peer_analysis.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path
 from typing import Any, Coroutine, TypedDict
 
-from ai_cli_runner import run_parallel_with_limit
+from ai_cli_runner import AIResult, run_parallel_with_limit
 from simple_logger.logger import get_logger
 
 from jenkins_job_insight.analyzer import (
@@ -29,6 +29,7 @@ from jenkins_job_insight.models import (
     TestFailure,
 )
 from jenkins_job_insight.storage import update_progress_phase
+from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -468,9 +469,9 @@ async def analyze_failure_group_with_peers(
         async def _call_peer(
             idx: int,
             config: AiConfigEntry,
-        ) -> tuple[AiConfigEntry, bool, str]:
+        ) -> tuple[AiConfigEntry, AIResult]:
             prompt = peer_prompts[idx]
-            ok, output = await _call_ai_cli_with_retry(
+            ai_result = await _call_ai_cli_with_retry(
                 prompt,
                 cwd=repo_path,
                 ai_provider=config.ai_provider,
@@ -478,7 +479,15 @@ async def analyze_failure_group_with_peers(
                 ai_cli_timeout=ai_cli_timeout,
                 cli_flags=PROVIDER_CLI_FLAGS.get(config.ai_provider, []),
             )
-            return config, ok, output
+            await record_ai_usage(
+                job_id=job_id,
+                result=ai_result,
+                call_type="peer",
+                prompt_chars=len(prompt),
+                ai_provider=config.ai_provider,
+                ai_model=config.ai_model,
+            )
+            return config, ai_result
 
         peer_tasks: list[Coroutine[Any, Any, Any]] = [
             _call_peer(idx, cfg) for idx, cfg in enumerate(peer_ai_configs)
@@ -506,11 +515,11 @@ async def analyze_failure_group_with_peers(
                 round_peer_entries.append(entry)
                 all_rounds.append(entry)
                 continue
-            config, ok, output = result
-            if not ok:
+            config, ai_result = result
+            if not ai_result.success:
                 logger.warning(
                     f"Peer {config.ai_provider}/{config.ai_model} CLI failed: "
-                    f"{output if output else 'no output'}"
+                    f"{ai_result.text if ai_result.text else 'no output'}"
                 )
                 entry = PeerRound(
                     round=round_num,
@@ -518,11 +527,11 @@ async def analyze_failure_group_with_peers(
                     ai_model=config.ai_model,
                     role="peer",
                     classification="",
-                    details=output,
+                    details=ai_result.text,
                     agrees_with_orchestrator=None,
                 )
             else:
-                peer_data = _parse_peer_response(output)
+                peer_data = _parse_peer_response(ai_result.text)
                 if peer_data.get("_failed"):
                     logger.warning(
                         f"Peer {config.ai_provider}/{config.ai_model} returned "
@@ -534,7 +543,7 @@ async def analyze_failure_group_with_peers(
                         ai_model=config.ai_model,
                         role="peer",
                         classification="",
-                        details=output,
+                        details=ai_result.text,
                         agrees_with_orchestrator=None,
                     )
                 else:
@@ -631,13 +640,21 @@ async def analyze_failure_group_with_peers(
 
             previous_analysis = parsed_analysis
             try:
-                rev_success, rev_output = await _call_ai_cli_with_retry(
+                rev_result = await _call_ai_cli_with_retry(
                     revision_prompt,
                     cwd=repo_path,
                     ai_provider=main_ai_provider,
                     ai_model=main_ai_model,
                     ai_cli_timeout=ai_cli_timeout,
                     cli_flags=PROVIDER_CLI_FLAGS.get(main_ai_provider, []),
+                )
+                await record_ai_usage(
+                    job_id=job_id,
+                    result=rev_result,
+                    call_type="revision",
+                    prompt_chars=len(revision_prompt),
+                    ai_provider=main_ai_provider,
+                    ai_model=main_ai_model,
                 )
             except Exception as exc:
                 logger.warning(
@@ -646,8 +663,8 @@ async def analyze_failure_group_with_peers(
                 parsed_analysis = previous_analysis
                 continue
 
-            if rev_success:
-                revised = _parse_json_response(rev_output)
+            if rev_result.success:
+                revised = _parse_json_response(rev_result.text)
                 normalized_revised = _coerce_supported_classification(
                     revised.classification
                 )

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections.abc import Callable
@@ -382,6 +383,36 @@ async def init_db() -> None:
         )
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_jm_tier ON job_metadata (tier)"
+        )
+
+        # AI token usage tracking table
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS ai_token_usage (
+                id TEXT PRIMARY KEY,
+                job_id TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                ai_provider TEXT NOT NULL DEFAULT '',
+                ai_model TEXT NOT NULL DEFAULT '',
+                call_type TEXT NOT NULL DEFAULT '',
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                cost_usd REAL,
+                duration_ms INTEGER,
+                prompt_chars INTEGER NOT NULL DEFAULT 0,
+                response_chars INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_usage_job_id ON ai_token_usage (job_id)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_usage_created_at ON ai_token_usage (created_at)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_usage_provider ON ai_token_usage (ai_provider)"
         )
 
         await db.commit()
@@ -2894,3 +2925,190 @@ async def bulk_set_metadata(items: list[dict]) -> dict:
             await _upsert_job_metadata_row(db, item)
         await db.commit()
     return {"updated": len(items)}
+
+
+async def record_token_usage(
+    job_id: str,
+    ai_provider: str,
+    ai_model: str,
+    call_type: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cost_usd: float | None = None,
+    duration_ms: int | None = None,
+    prompt_chars: int = 0,
+    response_chars: int = 0,
+) -> str:
+    """Record a single AI CLI call's token usage. Returns the record ID."""
+    record_id = str(uuid.uuid4())
+    total_tokens = input_tokens + output_tokens
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO ai_token_usage "
+            "(id, job_id, ai_provider, ai_model, call_type, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_write_tokens, total_tokens, cost_usd, duration_ms, "
+            "prompt_chars, response_chars) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                record_id,
+                job_id,
+                ai_provider,
+                ai_model,
+                call_type,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_write_tokens,
+                total_tokens,
+                cost_usd,
+                duration_ms,
+                prompt_chars,
+                response_chars,
+            ),
+        )
+        await db.commit()
+    return record_id
+
+
+async def get_token_usage_for_job(job_id: str) -> list[dict]:
+    """Get all token usage records for a specific job."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM ai_token_usage WHERE job_id = ? ORDER BY created_at ASC",
+            (job_id,),
+        )
+        return [dict(row) for row in await cursor.fetchall()]
+
+
+async def get_token_usage_summary(
+    start_date: str | None = None,
+    end_date: str | None = None,
+    ai_provider: str | None = None,
+    ai_model: str | None = None,
+    call_type: str | None = None,
+    group_by: str | None = None,
+) -> dict:
+    """Get aggregated token usage with optional filters and grouping.
+
+    group_by can be: provider, model, call_type, day, week, month, job
+    """
+    conditions: list[str] = []
+    params: list = []
+
+    if start_date:
+        conditions.append("created_at >= ?")
+        params.append(start_date)
+    if end_date:
+        conditions.append("created_at <= ?")
+        params.append(end_date)
+    if ai_provider:
+        conditions.append("ai_provider = ?")
+        params.append(ai_provider)
+    if ai_model:
+        conditions.append("ai_model = ?")
+        params.append(ai_model)
+    if call_type:
+        conditions.append("call_type = ?")
+        params.append(call_type)
+
+    where_clause = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        # Totals
+        totals_query = (
+            "SELECT "
+            "COALESCE(SUM(input_tokens), 0) as total_input_tokens, "
+            "COALESCE(SUM(output_tokens), 0) as total_output_tokens, "
+            "COALESCE(SUM(cache_read_tokens), 0) as total_cache_read_tokens, "
+            "COALESCE(SUM(cache_write_tokens), 0) as total_cache_write_tokens, "
+            "COALESCE(SUM(cost_usd), 0) as total_cost_usd, "
+            "COUNT(*) as total_calls, "
+            "COALESCE(SUM(duration_ms), 0) as total_duration_ms "
+            f"FROM ai_token_usage{where_clause}"
+        )
+        cursor = await db.execute(totals_query, params)
+        totals = dict(await cursor.fetchone())
+
+        # Breakdown by group
+        breakdown: list[dict] = []
+        if group_by:
+            group_column = {
+                "provider": "ai_provider",
+                "model": "ai_provider || ' / ' || ai_model",
+                "call_type": "call_type",
+                "day": "date(created_at)",
+                "week": "strftime('%Y-W%W', created_at)",
+                "month": "strftime('%Y-%m', created_at)",
+                "job": "job_id",
+            }.get(group_by)
+
+            if group_column:
+                breakdown_query = (
+                    f"SELECT {group_column} as group_key, "
+                    "COALESCE(SUM(input_tokens), 0) as input_tokens, "
+                    "COALESCE(SUM(output_tokens), 0) as output_tokens, "
+                    "COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens, "
+                    "COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens, "
+                    "COALESCE(SUM(cost_usd), 0) as cost_usd, "
+                    "COUNT(*) as call_count, "
+                    "CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(duration_ms), 0) / COUNT(*) ELSE 0 END as avg_duration_ms "
+                    f"FROM ai_token_usage{where_clause} "
+                    f"GROUP BY {group_column} "
+                    "ORDER BY COALESCE(SUM(cost_usd), 0) DESC"
+                )
+                cursor = await db.execute(breakdown_query, params)
+                breakdown = [dict(row) for row in await cursor.fetchall()]
+
+        return {
+            **totals,
+            "breakdown": breakdown,
+        }
+
+
+async def get_token_usage_dashboard_summary() -> dict:
+    """Get high-level summary for dashboard cards (today, this week, this month, top models, top jobs)."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        periods = {
+            "today": "date(created_at) = date('now')",
+            "this_week": "created_at >= datetime('now', '-7 days')",
+            "this_month": "created_at >= datetime('now', '-30 days')",
+        }
+
+        result: dict = {}
+        for period_name, condition in periods.items():
+            cursor = await db.execute(
+                f"SELECT COUNT(*) as calls, "
+                f"COALESCE(SUM(total_tokens), 0) as tokens, "
+                f"COALESCE(SUM(cost_usd), 0) as cost_usd "
+                f"FROM ai_token_usage WHERE {condition}"
+            )
+            result[period_name] = dict(await cursor.fetchone())
+
+        # Top models by cost
+        cursor = await db.execute(
+            "SELECT ai_model as model, COUNT(*) as calls, "
+            "COALESCE(SUM(cost_usd), 0) as cost_usd "
+            "FROM ai_token_usage "
+            "WHERE created_at >= datetime('now', '-30 days') "
+            "GROUP BY ai_model ORDER BY cost_usd DESC LIMIT 5"
+        )
+        result["top_models"] = [dict(row) for row in await cursor.fetchall()]
+
+        # Top jobs by cost
+        cursor = await db.execute(
+            "SELECT job_id, COUNT(*) as calls, "
+            "COALESCE(SUM(cost_usd), 0) as cost_usd "
+            "FROM ai_token_usage "
+            "WHERE created_at >= datetime('now', '-30 days') "
+            "GROUP BY job_id ORDER BY cost_usd DESC LIMIT 5"
+        )
+        result["top_jobs"] = [dict(row) for row in await cursor.fetchall()]
+
+        return result

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3066,7 +3066,7 @@ async def get_token_usage_summary(
                     "COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens, "
                     "COALESCE(SUM(cost_usd), 0) as cost_usd, "
                     "COUNT(*) as call_count, "
-                    "CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(duration_ms), 0) / COUNT(*) ELSE 0 END as avg_duration_ms "
+                    "CASE WHEN COUNT(duration_ms) > 0 THEN COALESCE(SUM(duration_ms), 0) / COUNT(duration_ms) ELSE 0 END as avg_duration_ms "
                     f"FROM ai_token_usage{where_clause} "  # noqa: S608
                     f"GROUP BY {group_column} "
                     "ORDER BY COALESCE(SUM(cost_usd), 0) DESC"

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3039,7 +3039,7 @@ async def get_token_usage_summary(
             "COALESCE(SUM(cost_usd), 0) as total_cost_usd, "
             "COUNT(*) as total_calls, "
             "COALESCE(SUM(duration_ms), 0) as total_duration_ms "
-            f"FROM ai_token_usage{where_clause}"
+            f"FROM ai_token_usage{where_clause}"  # noqa: S608
         )
         cursor = await db.execute(totals_query, params)
         totals = dict(await cursor.fetchone())
@@ -3067,7 +3067,7 @@ async def get_token_usage_summary(
                     "COALESCE(SUM(cost_usd), 0) as cost_usd, "
                     "COUNT(*) as call_count, "
                     "CASE WHEN COUNT(*) > 0 THEN COALESCE(SUM(duration_ms), 0) / COUNT(*) ELSE 0 END as avg_duration_ms "
-                    f"FROM ai_token_usage{where_clause} "
+                    f"FROM ai_token_usage{where_clause} "  # noqa: S608
                     f"GROUP BY {group_column} "
                     "ORDER BY COALESCE(SUM(cost_usd), 0) DESC"
                 )
@@ -3100,7 +3100,7 @@ async def get_token_usage_dashboard_summary() -> dict:
         result: dict = {}
         for period_name, condition in periods.items():
             cursor = await db.execute(
-                f"SELECT COUNT(*) as calls, "
+                f"SELECT COUNT(*) as calls, "  # noqa: S608
                 f"COALESCE(SUM(total_tokens), 0) as tokens, "
                 f"COALESCE(SUM(cost_usd), 0) as cost_usd "
                 f"FROM ai_token_usage WHERE {condition}"
@@ -3109,11 +3109,11 @@ async def get_token_usage_dashboard_summary() -> dict:
 
         # Top models by cost
         cursor = await db.execute(
-            "SELECT ai_model as model, COUNT(*) as calls, "
+            "SELECT ai_provider || ' / ' || ai_model as model, COUNT(*) as calls, "
             "COALESCE(SUM(cost_usd), 0) as cost_usd "
             "FROM ai_token_usage "
             "WHERE created_at >= datetime('now', '-30 days') "
-            "GROUP BY ai_model ORDER BY cost_usd DESC LIMIT 5"
+            "GROUP BY ai_provider, ai_model ORDER BY cost_usd DESC LIMIT 5"
         )
         result["top_models"] = [dict(row) for row in await cursor.fetchall()]
 

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -414,6 +414,12 @@ async def init_db() -> None:
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_token_usage_provider ON ai_token_usage (ai_provider)"
         )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_usage_model ON ai_token_usage (ai_model)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_usage_call_type ON ai_token_usage (call_type)"
+        )
 
         await db.commit()
 
@@ -3002,6 +3008,9 @@ async def get_token_usage_summary(
         conditions.append("created_at >= ?")
         params.append(start_date)
     if end_date:
+        # Normalize date-only to end of day so records from that day are included
+        if len(end_date) == 10:  # YYYY-MM-DD
+            end_date = f"{end_date} 23:59:59"
         conditions.append("created_at <= ?")
         params.append(end_date)
     if ai_provider:
@@ -3071,7 +3080,13 @@ async def get_token_usage_summary(
 
 
 async def get_token_usage_dashboard_summary() -> dict:
-    """Get high-level summary for dashboard cards (today, this week, this month, top models, top jobs)."""
+    """Get high-level summary for dashboard cards.
+
+    Period keys use rolling windows:
+    - ``today``: records created today (date match)
+    - ``this_week``: last 7 rolling days (not calendar week)
+    - ``this_month``: last 30 rolling days (not calendar month)
+    """
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
 

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -2004,6 +2004,7 @@ async def _delete_job_rows(db: aiosqlite.Connection, job_id: str) -> bool:
     await db.execute("DELETE FROM failure_reviews WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM failure_history WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM test_classifications WHERE job_id = ?", (job_id,))
+    await db.execute("DELETE FROM ai_token_usage WHERE job_id = ?", (job_id,))
     cursor = await db.execute("DELETE FROM results WHERE job_id = ?", (job_id,))
     return cursor.rowcount > 0
 

--- a/src/jenkins_job_insight/token_tracking.py
+++ b/src/jenkins_job_insight/token_tracking.py
@@ -29,21 +29,21 @@ async def record_ai_usage(
     Uses provider/model from result.usage if available, falls back to parameters.
     """
     try:
-        usage = result.usage
-        if usage is None:
+        if not job_id:
             return
 
+        usage = result.usage
         await storage.record_token_usage(
             job_id=job_id,
-            ai_provider=usage.provider or ai_provider,
-            ai_model=usage.model or ai_model,
+            ai_provider=(usage.provider if usage else "") or ai_provider,
+            ai_model=(usage.model if usage else "") or ai_model,
             call_type=call_type,
-            input_tokens=usage.input_tokens,
-            output_tokens=usage.output_tokens,
-            cache_read_tokens=usage.cache_read_tokens,
-            cache_write_tokens=usage.cache_write_tokens,
-            cost_usd=usage.cost_usd,
-            duration_ms=usage.duration_ms,
+            input_tokens=usage.input_tokens if usage else 0,
+            output_tokens=usage.output_tokens if usage else 0,
+            cache_read_tokens=usage.cache_read_tokens if usage else 0,
+            cache_write_tokens=usage.cache_write_tokens if usage else 0,
+            cost_usd=usage.cost_usd if usage else None,
+            duration_ms=usage.duration_ms if usage else None,
             prompt_chars=prompt_chars,
             response_chars=len(result.text),
         )

--- a/src/jenkins_job_insight/token_tracking.py
+++ b/src/jenkins_job_insight/token_tracking.py
@@ -1,0 +1,114 @@
+"""Token usage tracking utilities.
+
+Provides helpers to record AI CLI token usage to the database
+and build token usage summaries for analysis results.
+"""
+
+import os
+
+from ai_cli_runner import AIResult
+from simple_logger.logger import get_logger
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.models import TokenUsageEntry, TokenUsageSummary
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+async def record_ai_usage(
+    job_id: str,
+    result: AIResult,
+    call_type: str,
+    prompt_chars: int = 0,
+    ai_provider: str = "",
+    ai_model: str = "",
+) -> None:
+    """Record token usage from an AIResult to the database.
+
+    Best-effort — failures are logged but never raised.
+    Uses provider/model from result.usage if available, falls back to parameters.
+    """
+    try:
+        usage = result.usage
+        if usage is None:
+            return
+
+        await storage.record_token_usage(
+            job_id=job_id,
+            ai_provider=usage.provider or ai_provider,
+            ai_model=usage.model or ai_model,
+            call_type=call_type,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+            cost_usd=usage.cost_usd,
+            duration_ms=usage.duration_ms,
+            prompt_chars=prompt_chars,
+            response_chars=len(result.text),
+        )
+    except Exception:
+        logger.debug("Failed to record token usage for job %s", job_id, exc_info=True)
+
+
+async def build_token_usage_summary(job_id: str) -> TokenUsageSummary | None:
+    """Build a TokenUsageSummary from all recorded usage for a job.
+
+    Returns None if no usage records exist.
+    """
+    try:
+        records = await storage.get_token_usage_for_job(job_id)
+        if not records:
+            return None
+
+        calls = []
+        total_input = 0
+        total_output = 0
+        total_cache_read = 0
+        total_cache_write = 0
+        total_cost: float | None = 0.0
+        total_duration = 0
+
+        for rec in records:
+            calls.append(
+                TokenUsageEntry(
+                    provider=rec["ai_provider"],
+                    model=rec["ai_model"],
+                    call_type=rec["call_type"],
+                    input_tokens=rec["input_tokens"],
+                    output_tokens=rec["output_tokens"],
+                    cache_read_tokens=rec["cache_read_tokens"],
+                    cache_write_tokens=rec["cache_write_tokens"],
+                    total_tokens=rec["total_tokens"],
+                    cost_usd=rec["cost_usd"],
+                    duration_ms=rec["duration_ms"],
+                )
+            )
+            total_input += rec["input_tokens"]
+            total_output += rec["output_tokens"]
+            total_cache_read += rec["cache_read_tokens"]
+            total_cache_write += rec["cache_write_tokens"]
+            if rec["cost_usd"] is not None:
+                if total_cost is not None:
+                    total_cost += rec["cost_usd"]
+            else:
+                total_cost = None  # If any call lacks cost, total is None
+            if rec["duration_ms"]:
+                total_duration += rec["duration_ms"]
+
+        return TokenUsageSummary(
+            total_input_tokens=total_input,
+            total_output_tokens=total_output,
+            total_cache_read_tokens=total_cache_read,
+            total_cache_write_tokens=total_cache_write,
+            total_tokens=total_input + total_output,
+            total_cost_usd=total_cost,
+            total_duration_ms=total_duration,
+            total_calls=len(calls),
+            calls=calls,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to build token usage summary for job %s", job_id, exc_info=True
+        )
+        return None

--- a/src/jenkins_job_insight/token_tracking.py
+++ b/src/jenkins_job_insight/token_tracking.py
@@ -93,7 +93,7 @@ async def build_token_usage_summary(job_id: str) -> TokenUsageSummary | None:
                     total_cost += rec["cost_usd"]
             else:
                 total_cost = None  # If any call lacks cost, total is None
-            if rec["duration_ms"]:
+            if rec["duration_ms"] is not None:
                 total_duration += rec["duration_ms"]
 
         return TokenUsageSummary(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import httpx
+from ai_cli_runner import AIResult
 import pytest
 
 from jenkins_job_insight.cli.client import JJIClient
@@ -191,8 +192,8 @@ def mock_jenkins_client() -> MagicMock:
 def mock_ai_cli() -> Generator[MagicMock, None, None]:
     """Mock the call_ai_cli function."""
     with patch("jenkins_job_insight.analyzer.call_ai_cli") as mock:
-        mock.return_value = (
-            True,
-            '{"classification": "CODE ISSUE", "affected_tests": ["test_example"], "details": "The test failed due to a missing configuration.", "code_fix": {"file": "tests/test_example.py", "line": "42", "change": "Add the missing import statement"}}',
+        mock.return_value = AIResult(
+            success=True,
+            text='{"classification": "CODE ISSUE", "affected_tests": ["test_example"], "details": "The test failed due to a missing configuration.", "code_fix": {"file": "tests/test_example.py", "line": "42", "change": "Add the missing import statement"}}',
         )
         yield mock

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jenkins
 import pytest
+from ai_cli_runner import AIResult
 from fastapi import HTTPException
 
 from jenkins_job_insight.analyzer import (
@@ -118,12 +119,10 @@ class TestCallAiCliWithRetry:
         with patch(
             "jenkins_job_insight.analyzer.call_ai_cli", new_callable=AsyncMock
         ) as mock:
-            mock.return_value = (True, "result")
-            success, output = await _call_ai_cli_with_retry(
-                "prompt", ai_provider="test"
-            )
-            assert success is True
-            assert output == "result"
+            mock.return_value = AIResult(success=True, text="result")
+            result = await _call_ai_cli_with_retry("prompt", ai_provider="test")
+            assert result.success is True
+            assert result.text == "result"
             assert mock.call_count == 1
 
     @pytest.mark.asyncio
@@ -136,14 +135,17 @@ class TestCallAiCliWithRetry:
             patch("jenkins_job_insight.analyzer.asyncio.sleep", new_callable=AsyncMock),
         ):
             mock.side_effect = [
-                (False, "ENOENT: no such file or directory, rename config"),
-                (True, "success after retry"),
+                AIResult(
+                    success=False,
+                    text="ENOENT: no such file or directory, rename config",
+                ),
+                AIResult(success=True, text="success after retry"),
             ]
-            success, output = await _call_ai_cli_with_retry(
+            result = await _call_ai_cli_with_retry(
                 "prompt", ai_provider="test", max_retries=1
             )
-            assert success is True
-            assert output == "success after retry"
+            assert result.success is True
+            assert result.text == "success after retry"
             assert mock.call_count == 2
 
     @pytest.mark.asyncio
@@ -152,12 +154,12 @@ class TestCallAiCliWithRetry:
         with patch(
             "jenkins_job_insight.analyzer.call_ai_cli", new_callable=AsyncMock
         ) as mock:
-            mock.return_value = (False, "some other error")
-            success, output = await _call_ai_cli_with_retry(
+            mock.return_value = AIResult(success=False, text="some other error")
+            result = await _call_ai_cli_with_retry(
                 "prompt", ai_provider="test", max_retries=3
             )
-            assert success is False
-            assert "some other error" in output
+            assert result.success is False
+            assert "some other error" in result.text
             assert mock.call_count == 1
 
     @pytest.mark.asyncio
@@ -169,11 +171,13 @@ class TestCallAiCliWithRetry:
             ) as mock,
             patch("jenkins_job_insight.analyzer.asyncio.sleep", new_callable=AsyncMock),
         ):
-            mock.return_value = (False, "ENOENT: no such file or directory")
-            success, _ = await _call_ai_cli_with_retry(
+            mock.return_value = AIResult(
+                success=False, text="ENOENT: no such file or directory"
+            )
+            result = await _call_ai_cli_with_retry(
                 "prompt", ai_provider="test", max_retries=2
             )
-            assert success is False
+            assert result.success is False
             assert mock.call_count == 3  # initial + 2 retries
 
 
@@ -196,7 +200,7 @@ class TestRunSingleAiAnalysis:
                 "details": "broken assertion",
             }
         )
-        mock_cli = AsyncMock(return_value=(True, ai_response))
+        mock_cli = AsyncMock(return_value=AIResult(success=True, text=ai_response))
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry", mock_cli
         )
@@ -228,7 +232,7 @@ class TestRunSingleAiAnalysis:
         from jenkins_job_insight.analyzer import _run_single_ai_analysis
         from jenkins_job_insight.models import TestFailure
 
-        mock_cli = AsyncMock(return_value=(False, "CLI timeout"))
+        mock_cli = AsyncMock(return_value=AIResult(success=False, text="CLI timeout"))
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry", mock_cli
         )
@@ -286,7 +290,7 @@ class TestRunSingleAiAnalysis:
                 "suggested_changes": "",
             }
         )
-        mock_cli = AsyncMock(return_value=(True, peer_response))
+        mock_cli = AsyncMock(return_value=AIResult(success=True, text=peer_response))
         monkeypatch.setattr(
             "jenkins_job_insight.peer_analysis._call_ai_cli_with_retry", mock_cli
         )
@@ -420,9 +424,9 @@ class TestAnalyzeFailureGroupPeerDelegation:
         from jenkins_job_insight.analyzer import TestFailure, analyze_failure_group
 
         mock_cli = AsyncMock(
-            return_value=(
-                True,
-                '{"classification":"CODE ISSUE","affected_tests":["t"],"details":"d"}',
+            return_value=AIResult(
+                success=True,
+                text='{"classification":"CODE ISSUE","affected_tests":["t"],"details":"d"}',
             )
         )
         monkeypatch.setattr(
@@ -599,7 +603,10 @@ class TestConsoleOnlyPeerWarning:
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
 
@@ -643,7 +650,10 @@ class TestConsoleOnlyPeerWarning:
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
 
@@ -702,12 +712,15 @@ class TestConsoleOnlyPeerWarning:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -784,7 +797,7 @@ class TestAnalyzeJobProgressPhases:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
 
         # Mock child job analysis
@@ -885,7 +898,7 @@ class TestAnalyzeJobProgressPhases:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
 
         mock_failure = FailureAnalysis(
@@ -1040,7 +1053,7 @@ class TestAnalyzeJobProgressPhases:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
 
         mock_failure = FailureAnalysis(
@@ -1175,12 +1188,15 @@ class TestForceAnalysisSuccessfulBuild:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
 
@@ -1242,12 +1258,15 @@ class TestForceAnalysisSuccessfulBuild:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
 
@@ -1756,12 +1775,15 @@ class TestAnalyzeJobWorkspacePattern:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -1855,12 +1877,15 @@ class TestAnalyzeJobWorkspacePattern:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -1946,12 +1971,15 @@ class TestAnalyzeJobWorkspacePattern:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -2048,12 +2076,15 @@ class TestAnalyzeJobWorkspacePattern:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -2172,7 +2203,7 @@ class TestAnalyzeJobWorkspacePattern:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.update_progress_phase",
@@ -2402,12 +2433,15 @@ class TestWorkspaceAlwaysCreated:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -2669,12 +2703,15 @@ class TestAnalyzeJobParsesRepoRef:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(
@@ -2766,12 +2803,15 @@ class TestAnalyzeJobParsesRepoRef:
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer.check_ai_cli_available",
-            AsyncMock(return_value=(True, "")),
+            AsyncMock(return_value=AIResult(success=True, text="")),
         )
         monkeypatch.setattr(
             "jenkins_job_insight.analyzer._call_ai_cli_with_retry",
             AsyncMock(
-                return_value=(True, '{"classification": "CODE ISSUE", "details": "d"}')
+                return_value=AIResult(
+                    success=True,
+                    text='{"classification": "CODE ISSUE", "details": "d"}',
+                )
             ),
         )
         monkeypatch.setattr(

--- a/tests/test_api_token_usage.py
+++ b/tests/test_api_token_usage.py
@@ -1,0 +1,179 @@
+"""Tests for admin token usage API endpoints."""
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.config import get_settings
+
+
+@pytest.fixture
+def _init_db(temp_db_path):
+    """Initialize database with test path."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(storage.init_db())
+        yield
+
+
+@pytest.fixture
+def client(_init_db, temp_db_path):
+    """Create a test client with admin key configured."""
+    with patch.dict(
+        os.environ,
+        {
+            "ADMIN_KEY": "test-admin-key-16chars",  # pragma: allowlist secret
+            "JJI_ENCRYPTION_KEY": "test-encryption-key-for-hmac",  # pragma: allowlist secret
+            "SECURE_COOKIES": "false",
+            "DB_PATH": str(temp_db_path),
+        },
+    ):
+        get_settings.cache_clear()
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as c:
+                yield c
+        get_settings.cache_clear()
+
+
+def _admin_login(
+    client,
+    username="admin",
+    api_key="test-admin-key-16chars",  # pragma: allowlist secret
+):
+    """Helper to login as admin and return cookies."""
+    resp = client.post(
+        "/api/auth/login", json={"username": username, "api_key": api_key}
+    )
+    assert resp.status_code == 200
+    return resp.cookies
+
+
+def _insert_test_records(client):
+    """Insert token usage records via storage layer."""
+    import asyncio
+
+    async def _insert():
+        await storage.record_token_usage(
+            job_id="job-1",
+            ai_provider="claude",
+            ai_model="opus-4",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.05,
+            duration_ms=1000,
+        )
+        await storage.record_token_usage(
+            job_id="job-2",
+            ai_provider="gemini",
+            ai_model="2.5-pro",
+            call_type="peer_review",
+            input_tokens=200,
+            output_tokens=80,
+            cost_usd=0.03,
+            duration_ms=800,
+        )
+
+    asyncio.run(_insert())
+
+
+class TestGetTokenUsageEndpoint:
+    def test_returns_data_for_admin(self, client) -> None:
+        """Admin users can access token usage."""
+        cookies = _admin_login(client)
+        _insert_test_records(client)
+        resp = client.get("/api/admin/token-usage", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_calls"] == 2
+        assert data["total_input_tokens"] == 300
+
+    def test_403_for_non_admin(self, client) -> None:
+        """Non-admin users get 403."""
+        # Make a request without admin cookies
+        resp = client.get("/api/admin/token-usage")
+        assert resp.status_code == 403
+
+    def test_filter_by_provider(self, client) -> None:
+        """Provider filter works."""
+        cookies = _admin_login(client)
+        _insert_test_records(client)
+        resp = client.get(
+            "/api/admin/token-usage",
+            params={"ai_provider": "claude"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_calls"] == 1
+
+    def test_group_by_provider(self, client) -> None:
+        """Group by parameter works."""
+        cookies = _admin_login(client)
+        _insert_test_records(client)
+        resp = client.get(
+            "/api/admin/token-usage",
+            params={"group_by": "provider"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["breakdown"]) == 2
+
+    def test_empty_db_returns_zeros(self, client) -> None:
+        """Empty database returns zero totals."""
+        cookies = _admin_login(client)
+        resp = client.get("/api/admin/token-usage", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_calls"] == 0
+
+
+class TestGetTokenUsageSummaryEndpoint:
+    def test_returns_dashboard_data_for_admin(self, client) -> None:
+        """Admin users can access dashboard summary."""
+        cookies = _admin_login(client)
+        _insert_test_records(client)
+        resp = client.get("/api/admin/token-usage/summary", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "today" in data
+        assert "this_week" in data
+        assert "this_month" in data
+        assert "top_models" in data
+        assert "top_jobs" in data
+
+    def test_403_for_non_admin(self, client) -> None:
+        """Non-admin users get 403."""
+        resp = client.get("/api/admin/token-usage/summary")
+        assert resp.status_code == 403
+
+
+class TestGetTokenUsageForJobEndpoint:
+    def test_returns_records_for_job(self, client) -> None:
+        """Returns records for a specific job."""
+        cookies = _admin_login(client)
+        _insert_test_records(client)
+        resp = client.get("/api/admin/token-usage/job-1", cookies=cookies)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["job_id"] == "job-1"
+        assert len(data["records"]) == 1
+        assert data["records"][0]["ai_provider"] == "claude"
+
+    def test_404_for_no_records(self, client) -> None:
+        """Returns 404 when no records exist for job."""
+        cookies = _admin_login(client)
+        resp = client.get("/api/admin/token-usage/nonexistent", cookies=cookies)
+        assert resp.status_code == 404
+        assert "No token usage records" in resp.json()["detail"]
+
+    def test_403_for_non_admin(self, client) -> None:
+        """Non-admin users get 403."""
+        resp = client.get("/api/admin/token-usage/job-1")
+        assert resp.status_code == 403

--- a/tests/test_api_token_usage.py
+++ b/tests/test_api_token_usage.py
@@ -55,7 +55,6 @@ def _admin_login(
 
 def _insert_test_records(client):
     """Insert token usage records via storage layer."""
-    import asyncio
 
     async def _insert():
         await storage.record_token_usage(
@@ -132,6 +131,17 @@ class TestGetTokenUsageEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["total_calls"] == 0
+
+    def test_invalid_group_by_returns_422(self, client) -> None:
+        """Invalid group_by value returns 422."""
+        cookies = _admin_login(client)
+        resp = client.get(
+            "/api/admin/token-usage",
+            params={"group_by": "invalid_field"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 422
+        assert "Invalid group_by" in resp.json()["detail"]
 
 
 class TestGetTokenUsageSummaryEndpoint:

--- a/tests/test_bug_creation.py
+++ b/tests/test_bug_creation.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from ai_cli_runner import AIResult
 
 from jenkins_job_insight.models import (
     AnalysisDetail,
@@ -63,9 +64,9 @@ class TestGenerateGithubIssueContent:
         from jenkins_job_insight.bug_creation import generate_github_issue_content
 
         with patch("jenkins_job_insight.bug_creation.call_ai_cli") as mock_ai:
-            mock_ai.return_value = (
-                True,
-                "Fix: login handler missing ValueError catch\n\n"
+            mock_ai.return_value = AIResult(
+                success=True,
+                text="Fix: login handler missing ValueError catch\n\n"
                 "## Test Failure\n\n"
                 "**Test:** `tests.auth.test_login.TestLogin.test_valid_credentials`\n\n"
                 "## Error\n\n"
@@ -91,7 +92,7 @@ class TestGenerateGithubIssueContent:
         from jenkins_job_insight.bug_creation import generate_github_issue_content
 
         with patch("jenkins_job_insight.bug_creation.call_ai_cli") as mock_ai:
-            mock_ai.return_value = (False, "AI CLI timed out")
+            mock_ai.return_value = AIResult(success=False, text="AI CLI timed out")
 
             result = await generate_github_issue_content(
                 failure=code_issue_failure,
@@ -108,7 +109,7 @@ class TestGenerateGithubIssueContent:
         from jenkins_job_insight.bug_creation import generate_github_issue_content
 
         with patch("jenkins_job_insight.bug_creation.call_ai_cli") as mock_ai:
-            mock_ai.return_value = (False, "AI CLI timed out")
+            mock_ai.return_value = AIResult(success=False, text="AI CLI timed out")
 
             result = await generate_github_issue_content(
                 failure=code_issue_failure,
@@ -125,9 +126,9 @@ class TestGenerateJiraBugContent:
         from jenkins_job_insight.bug_creation import generate_jira_bug_content
 
         with patch("jenkins_job_insight.bug_creation.call_ai_cli") as mock_ai:
-            mock_ai.return_value = (
-                True,
-                "DNS resolution timeout on internal resolver\n\n"
+            mock_ai.return_value = AIResult(
+                success=True,
+                text="DNS resolution timeout on internal resolver\n\n"
                 "h2. Summary\n\n"
                 "DNS resolution is failing intermittently.\n\n"
                 "h2. Evidence\n\n"
@@ -147,7 +148,7 @@ class TestGenerateJiraBugContent:
         from jenkins_job_insight.bug_creation import generate_jira_bug_content
 
         with patch("jenkins_job_insight.bug_creation.call_ai_cli") as mock_ai:
-            mock_ai.return_value = (False, "error")
+            mock_ai.return_value = AIResult(success=False, text="error")
 
             result = await generate_jira_bug_content(
                 failure=product_bug_failure,

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1346,6 +1346,80 @@ class TestJJIClientAdminUsers:
         assert exc_info.value.status_code == 403
 
 
+class TestTokenUsage:
+    def test_get_token_usage_no_params(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/admin/token-usage"
+            return httpx.Response(
+                200,
+                json={"total_calls": 5, "total_cost_usd": 0.12, "breakdown": []},
+            )
+
+        client = _make_client(handler)
+        result = client.get_token_usage()
+        assert result["total_calls"] == 5
+
+    def test_get_token_usage_with_filters(self):
+        def handler(request):
+            assert request.url.params["start_date"] == "2026-01-01"
+            assert request.url.params["ai_provider"] == "claude"
+            assert request.url.params["group_by"] == "model"
+            # Params not provided should be stripped (None-filtering)
+            assert "end_date" not in request.url.params
+            return httpx.Response(
+                200,
+                json={"total_calls": 3, "breakdown": [{"group_key": "claude-sonnet"}]},
+            )
+
+        client = _make_client(handler)
+        result = client.get_token_usage(
+            start_date="2026-01-01", ai_provider="claude", group_by="model"
+        )
+        assert result["total_calls"] == 3
+        assert len(result["breakdown"]) == 1
+
+    def test_get_token_usage_summary(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/admin/token-usage/summary"
+            return httpx.Response(
+                200,
+                json={"today": {"calls": 10}, "this_week": {"calls": 50}},
+            )
+
+        client = _make_client(handler)
+        result = client.get_token_usage_summary()
+        assert result["today"]["calls"] == 10
+
+    def test_get_token_usage_for_job(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert "/api/admin/token-usage/job-123" in str(request.url)
+            return httpx.Response(
+                200,
+                json={
+                    "job_id": "job-123",
+                    "records": [{"call_type": "analysis", "input_tokens": 100}],
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.get_token_usage_for_job("job-123")
+        assert result["job_id"] == "job-123"
+        assert len(result["records"]) == 1
+
+    def test_get_token_usage_forbidden(self):
+        client = _make_client(
+            lambda request: httpx.Response(
+                403, json={"detail": "Admin access required"}
+            )
+        )
+        with pytest.raises(JJIError) as exc_info:
+            client.get_token_usage()
+        assert exc_info.value.status_code == 403
+
+
 class TestJJIClientApiKeyHeader:
     def test_api_key_sent_as_bearer_header(self):
         def check_header(request):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2778,6 +2778,188 @@ class TestAdminUsersChangeRole:
         assert output["role"] == "admin"
 
 
+class TestTokenUsageCommand:
+    def test_token_usage_summary_default(self, mock_client):
+        """No flags → summary mode."""
+        mock_client.get_token_usage_summary.return_value = {
+            "today": {"calls": 10, "tokens": 5000, "cost_usd": 0.05},
+            "this_week": {"calls": 50, "tokens": 25000, "cost_usd": 0.25},
+            "this_month": {"calls": 200, "tokens": 100000, "cost_usd": 1.00},
+            "top_models": [
+                {"model": "claude-sonnet", "calls": 100, "cost_usd": 0.50},
+            ],
+        }
+        result = runner.invoke(app, ["admin", "token-usage"])
+        assert result.exit_code == 0
+        assert "Today" in result.output
+        assert "This Week" in result.output
+        assert "This Month" in result.output
+        assert "claude-sonnet" in result.output
+        mock_client.get_token_usage_summary.assert_called_once()
+
+    def test_token_usage_summary_json(self, mock_client):
+        mock_client.get_token_usage_summary.return_value = {
+            "today": {"calls": 10},
+        }
+        result = runner.invoke(app, ["--json", "admin", "token-usage"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["today"]["calls"] == 10
+
+    def test_token_usage_with_group_by(self, mock_client):
+        """--group-by triggers filtered mode, not summary."""
+        mock_client.get_token_usage.return_value = {
+            "total_calls": 5,
+            "total_input_tokens": 1000,
+            "total_output_tokens": 500,
+            "total_cache_read_tokens": 200,
+            "total_cache_write_tokens": 100,
+            "total_cost_usd": 0.10,
+            "total_duration_ms": 5000,
+            "breakdown": [
+                {
+                    "group_key": "claude",
+                    "call_count": 3,
+                    "cost_usd": 0.06,
+                    "avg_duration_ms": 800,
+                },
+                {
+                    "group_key": "gemini",
+                    "call_count": 2,
+                    "cost_usd": 0.04,
+                    "avg_duration_ms": 600,
+                },
+            ],
+        }
+        result = runner.invoke(app, ["admin", "token-usage", "--group-by", "provider"])
+        assert result.exit_code == 0
+        assert "Total calls: 5" in result.output
+        assert "claude" in result.output
+        assert "gemini" in result.output
+        mock_client.get_token_usage.assert_called_once_with(
+            start_date=None,
+            end_date=None,
+            ai_provider=None,
+            ai_model=None,
+            call_type=None,
+            group_by="provider",
+        )
+
+    def test_token_usage_period_today(self, mock_client):
+        """--period today sets start_date and uses filtered mode."""
+        mock_client.get_token_usage.return_value = {
+            "total_calls": 2,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_cache_read_tokens": 0,
+            "total_cache_write_tokens": 0,
+            "total_cost_usd": 0.0,
+            "total_duration_ms": 0,
+            "breakdown": [],
+        }
+        result = runner.invoke(app, ["admin", "token-usage", "--period", "today"])
+        assert result.exit_code == 0
+        # Should have called get_token_usage (not summary) because period sets start_date
+        mock_client.get_token_usage.assert_called_once()
+        call_kwargs = mock_client.get_token_usage.call_args[1]
+        assert call_kwargs["start_date"] is not None
+
+    def test_token_usage_job_id(self, mock_client):
+        """--job-id fetches per-job usage."""
+        mock_client.get_token_usage_for_job.return_value = {
+            "job_id": "abc-123",
+            "records": [
+                {
+                    "call_type": "analysis",
+                    "ai_provider": "claude",
+                    "ai_model": "sonnet",
+                    "input_tokens": 1000,
+                    "output_tokens": 500,
+                    "cost_usd": 0.01,
+                    "duration_ms": 1200,
+                },
+            ],
+        }
+        result = runner.invoke(app, ["admin", "token-usage", "--job-id", "abc-123"])
+        assert result.exit_code == 0
+        assert "Job: abc-123" in result.output
+        assert "analysis" in result.output
+        assert "claude" in result.output
+        mock_client.get_token_usage_for_job.assert_called_once_with("abc-123")
+
+    def test_token_usage_job_id_json(self, mock_client):
+        mock_client.get_token_usage_for_job.return_value = {
+            "job_id": "abc-123",
+            "records": [],
+        }
+        result = runner.invoke(
+            app, ["--json", "admin", "token-usage", "--job-id", "abc-123"]
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["job_id"] == "abc-123"
+
+    def test_token_usage_csv_format(self, mock_client):
+        mock_client.get_token_usage.return_value = {
+            "total_calls": 1,
+            "breakdown": [
+                {"group_key": "claude", "call_count": 1, "cost_usd": 0.01},
+            ],
+        }
+        result = runner.invoke(
+            app,
+            ["admin", "token-usage", "--group-by", "provider", "--format", "csv"],
+        )
+        assert result.exit_code == 0
+        assert "group_key" in result.output  # CSV header
+        assert "claude" in result.output
+
+    def test_token_usage_error_403(self, mock_client):
+        mock_client.get_token_usage_summary.side_effect = JJIError(
+            status_code=403, detail="Admin access required"
+        )
+        result = runner.invoke(app, ["admin", "token-usage"])
+        assert result.exit_code == 1
+
+    def test_token_usage_with_provider_filter(self, mock_client):
+        """--provider triggers filtered mode."""
+        mock_client.get_token_usage.return_value = {
+            "total_calls": 3,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_cache_read_tokens": 0,
+            "total_cache_write_tokens": 0,
+            "total_cost_usd": 0.0,
+            "total_duration_ms": 0,
+            "breakdown": [],
+        }
+        result = runner.invoke(app, ["admin", "token-usage", "--provider", "claude"])
+        assert result.exit_code == 0
+        mock_client.get_token_usage.assert_called_once()
+        call_kwargs = mock_client.get_token_usage.call_args[1]
+        assert call_kwargs["ai_provider"] == "claude"
+
+    def test_token_usage_job_cost_none(self, mock_client):
+        """cost_usd=None should display as N/A."""
+        mock_client.get_token_usage_for_job.return_value = {
+            "job_id": "x",
+            "records": [
+                {
+                    "call_type": "analysis",
+                    "ai_provider": "claude",
+                    "ai_model": "sonnet",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cost_usd": None,
+                    "duration_ms": 500,
+                },
+            ],
+        }
+        result = runner.invoke(app, ["admin", "token-usage", "--job-id", "x"])
+        assert result.exit_code == 0
+        assert "N/A" in result.output
+
+
 class TestApiKeyOption:
     def test_api_key_passed_to_client(self):
         """--api-key should cause _get_client to create client with api_key."""

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -432,21 +432,20 @@ class TestDispatchAlert:
         from jenkins_job_insight import monitoring
 
         monitoring.alert_throttler.reset()
-        with (
-            patch(
-                "jenkins_job_insight.monitoring.send_slack_alert",
-                new_callable=AsyncMock,
-            ) as mock_slack,
-            patch(
-                "jenkins_job_insight.monitoring.send_email_alert_async",
-                new_callable=AsyncMock,
-            ) as mock_email,
-        ):
-            mock_slack.return_value = True
-            mock_email.return_value = True
-            await dispatch_alert("test_event", "test message")
-        mock_slack.assert_called_once_with("test message")
-        mock_email.assert_called_once()
+        original_slack = monitoring.send_slack_alert
+        original_email = monitoring.send_email_alert_async
+        mock_slack = AsyncMock(return_value=True)
+        mock_email = AsyncMock(return_value=True)
+        monitoring.send_slack_alert = mock_slack
+        monitoring.send_email_alert_async = mock_email
+        try:
+            await dispatch_alert("test_dispatch_event", "test message")
+            mock_slack.assert_called_once_with("test message")
+            mock_email.assert_called_once()
+        finally:
+            monitoring.send_slack_alert = original_slack
+            monitoring.send_email_alert_async = original_email
+            monitoring.alert_throttler.reset()
 
     async def test_dispatch_throttled(self):
         from jenkins_job_insight import monitoring
@@ -454,21 +453,19 @@ class TestDispatchAlert:
         monitoring.alert_throttler.reset()
         original_cooldown = monitoring.alert_throttler.cooldown_seconds
         monitoring.alert_throttler.cooldown_seconds = 9999.0
+        original_slack = monitoring.send_slack_alert
+        original_email = monitoring.send_email_alert_async
+        mock_slack = AsyncMock()
+        monitoring.send_slack_alert = mock_slack
+        monitoring.send_email_alert_async = AsyncMock()
         try:
-            with (
-                patch(
-                    "jenkins_job_insight.monitoring.send_slack_alert",
-                    new_callable=AsyncMock,
-                ) as mock_slack,
-                patch(
-                    "jenkins_job_insight.monitoring.send_email_alert_async",
-                    new_callable=AsyncMock,
-                ),
-            ):
-                await dispatch_alert("test_throttle_event", "first")
-                await dispatch_alert("test_throttle_event", "second")
+            await dispatch_alert("test_throttle_direct", "first")
+            await dispatch_alert("test_throttle_direct", "second")
+            # Only first call should go through
             mock_slack.assert_called_once()
         finally:
+            monitoring.send_slack_alert = original_slack
+            monitoring.send_email_alert_async = original_email
             monitoring.alert_throttler.cooldown_seconds = original_cooldown
             monitoring.alert_throttler.reset()
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -429,9 +429,10 @@ class TestDispatchAlert:
     """Tests for dispatch_alert."""
 
     async def test_dispatch_sends_to_all_channels(self):
-        throttler = AlertThrottler(cooldown_seconds=0.0)
+        from jenkins_job_insight import monitoring
+
+        monitoring.alert_throttler.reset()
         with (
-            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
             patch(
                 "jenkins_job_insight.monitoring.send_slack_alert",
                 new_callable=AsyncMock,
@@ -448,22 +449,28 @@ class TestDispatchAlert:
         mock_email.assert_called_once()
 
     async def test_dispatch_throttled(self):
-        throttler = AlertThrottler(cooldown_seconds=9999.0)
-        with (
-            patch("jenkins_job_insight.monitoring.alert_throttler", throttler),
-            patch(
-                "jenkins_job_insight.monitoring.send_slack_alert",
-                new_callable=AsyncMock,
-            ) as mock_slack,
-            patch(
-                "jenkins_job_insight.monitoring.send_email_alert_async",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await dispatch_alert("test_event", "first")
-            await dispatch_alert("test_event", "second")
-        # Only first call should go through
-        mock_slack.assert_called_once()
+        from jenkins_job_insight import monitoring
+
+        monitoring.alert_throttler.reset()
+        original_cooldown = monitoring.alert_throttler.cooldown_seconds
+        monitoring.alert_throttler.cooldown_seconds = 9999.0
+        try:
+            with (
+                patch(
+                    "jenkins_job_insight.monitoring.send_slack_alert",
+                    new_callable=AsyncMock,
+                ) as mock_slack,
+                patch(
+                    "jenkins_job_insight.monitoring.send_email_alert_async",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                await dispatch_alert("test_throttle_event", "first")
+                await dispatch_alert("test_throttle_event", "second")
+            mock_slack.assert_called_once()
+        finally:
+            monitoring.alert_throttler.cooldown_seconds = original_cooldown
+            monitoring.alert_throttler.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -455,6 +455,10 @@ class TestDispatchAlert:
                 "jenkins_job_insight.monitoring.send_slack_alert",
                 new_callable=AsyncMock,
             ) as mock_slack,
+            patch(
+                "jenkins_job_insight.monitoring.send_email_alert_async",
+                new_callable=AsyncMock,
+            ),
         ):
             await dispatch_alert("test_event", "first")
             await dispatch_alert("test_event", "second")

--- a/tests/test_peer_analysis.py
+++ b/tests/test_peer_analysis.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ai_cli_runner import AIResult
 from jenkins_job_insight.models import AiConfigEntry, TestFailure
 
 
@@ -669,7 +670,7 @@ class TestAnalyzeWithPeers:
             cli_flags=None,
             max_retries=3,
         ):
-            return (True, peer_response)
+            return AIResult(success=True, text=peer_response)
 
         with (
             patch(
@@ -744,12 +745,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-2: round 1 peers (disagree)
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Call 3: main AI revision
             if call_count == 3:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Calls 4-5: round 2 peers (agree)
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -820,12 +821,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-2: round 1 peers disagree
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Call 3: orchestrator revision FAILS
             if call_count == 3:
-                return (False, "CLI error: connection refused")
+                return AIResult(success=False, text="CLI error: connection refused")
             # Calls 4-5: round 2 peers agree (should see CODE ISSUE, preserved)
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -898,12 +899,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-2: round 1 peers disagree
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Call 3: orchestrator revision RAISES an exception
             if call_count == 3:
                 raise RuntimeError("CLI process crashed")
             # Calls 4-5: round 2 peers agree with preserved CODE ISSUE
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -998,12 +999,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-2: round 1 peers disagree
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Call 3: revision returns same classification but drops structured fields
             if call_count == 3:
-                return (True, revision_response)
+                return AIResult(success=True, text=revision_response)
             # Calls 4-5: round 2 peers agree
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -1100,10 +1101,10 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             if call_count == 3:
-                return (True, revision_response)
-            return (True, peer_agree)
+                return AIResult(success=True, text=revision_response)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -1197,10 +1198,10 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             if call_count == 3:
-                return (True, revision_response)
-            return (True, peer_agree)
+                return AIResult(success=True, text=revision_response)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -1269,9 +1270,9 @@ class TestAnalyzeWithPeers:
         ):
             # Revision calls: main AI always returns same classification
             if "revision" in prompt.lower() or "revise" in prompt.lower():
-                return (True, main_response)
+                return AIResult(success=True, text=main_response)
             # Peer calls: always disagree
-            return (True, peer_disagree)
+            return AIResult(success=True, text=peer_disagree)
 
         with (
             patch(
@@ -1309,8 +1310,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (False, "CLI error: connection refused")
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=False, text="CLI error: connection refused")
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -1357,7 +1358,7 @@ class TestAnalyzeWithPeers:
             cli_flags=None,
             max_retries=3,
         ):
-            return (True, peer_response)
+            return AIResult(success=True, text=peer_response)
 
         with (
             patch(
@@ -1422,8 +1423,8 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # First peer fails, second agrees
             if call_count == 1:
-                return (False, "CLI crashed")
-            return (True, peer_agree)
+                return AIResult(success=False, text="CLI crashed")
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -1495,12 +1496,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-2: round 1 peers (disagree)
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Call 3: main AI revision
             if call_count == 3:
-                return (True, main_response)
+                return AIResult(success=True, text=main_response)
             # Calls 4-5: round 2 peers (agree)
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         phases: list[str] = []
 
@@ -1576,10 +1577,10 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             if call_count == 3:
-                return (True, main_response)
-            return (True, peer_agree)
+                return AIResult(success=True, text=main_response)
+            return AIResult(success=True, text=peer_agree)
 
         phases: list[str] = []
 
@@ -1643,7 +1644,7 @@ class TestAnalyzeWithPeers:
             cli_flags=None,
             max_retries=3,
         ):
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         phases: list[str] = []
 
@@ -1711,18 +1712,18 @@ class TestAnalyzeWithPeers:
             call_count += 1
             if call_count == 1:
                 # Invalid classification
-                return (
-                    True,
-                    _make_peer_json_response(
+                return AIResult(
+                    success=True,
+                    text=_make_peer_json_response(
                         agrees=True,
                         classification="UNKNOWN TYPE",
                         reasoning="not a valid classification",
                     ),
                 )
             # Valid and agrees
-            return (
-                True,
-                _make_peer_json_response(
+            return AIResult(
+                success=True,
+                text=_make_peer_json_response(
                     agrees=True,
                     classification="CODE ISSUE",
                 ),
@@ -1778,8 +1779,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (True, null_classification_response)
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=True, text=null_classification_response)
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -1813,8 +1814,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (True, peer_response)
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=True, text=peer_response)
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -1861,7 +1862,7 @@ class TestAnalyzeWithPeers:
             cli_flags=None,
             max_retries=3,
         ):
-            return (True, peer_response)
+            return AIResult(success=True, text=peer_response)
 
         with (
             patch(
@@ -1908,8 +1909,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (True, peer_response)
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=True, text=peer_response)
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -1941,8 +1942,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (True, peer_response)
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=True, text=peer_response)
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -1974,8 +1975,8 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, orchestrator_json)
-            return (True, peer_response)
+                return AIResult(success=True, text=orchestrator_json)
+            return AIResult(success=True, text=peer_response)
 
         results = await _run_peer_analysis(
             monkeypatch,
@@ -2089,16 +2090,16 @@ class TestAnalyzeWithPeers:
             # Calls 1-2: round 1 peers
             if call_count == 1:
                 captured_prompts.append((ai_provider, prompt))
-                return (True, peer1_r1)
+                return AIResult(success=True, text=peer1_r1)
             if call_count == 2:
                 captured_prompts.append((ai_provider, prompt))
-                return (True, peer2_r1)
+                return AIResult(success=True, text=peer2_r1)
             # Call 3: revision
             if call_count == 3:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Calls 4-5: round 2 peers
             captured_prompts.append((ai_provider, prompt))
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -2179,14 +2180,14 @@ class TestAnalyzeWithPeers:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return (True, peer1_r1)
+                return AIResult(success=True, text=peer1_r1)
             if call_count == 2:
-                return (True, peer2_r1)
+                return AIResult(success=True, text=peer2_r1)
             if call_count == 3:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Round 2 peers
             captured_round2.append((ai_provider, ai_model, prompt))
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -2273,15 +2274,15 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Round 1: peer1 succeeds, peer2 CLI fails
             if call_count == 1:
-                return (True, peer1_r1)
+                return AIResult(success=True, text=peer1_r1)
             if call_count == 2:
-                return (False, cli_error_output)
+                return AIResult(success=False, text=cli_error_output)
             # Revision call
             if call_count == 3:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Round 2 peers
             captured_round2.append((ai_provider, ai_model, prompt))
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -2367,12 +2368,12 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Round 1 peer calls (2 peers)
             if call_count <= 2:
-                return (True, peer_disagree)
+                return AIResult(success=True, text=peer_disagree)
             # Revision call after round 1
             if call_count == 3:
-                return (True, revision_response)
+                return AIResult(success=True, text=revision_response)
             # Round 2 peer calls
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -2431,7 +2432,7 @@ class TestAnalyzeWithPeers:
         ):
             nonlocal peer_call_count
             peer_call_count += 1
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         # 3 identical peer configs -- all should be called
         duplicate_peers = [
@@ -2535,17 +2536,17 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Round 1: peer0 succeeds, peer1 fails, peer2 succeeds
             if call_count == 1:
-                return (True, peer0_r1)
+                return AIResult(success=True, text=peer0_r1)
             if call_count == 2:
-                return (False, "CLI_FAILURE_OUTPUT")
+                return AIResult(success=False, text="CLI_FAILURE_OUTPUT")
             if call_count == 3:
-                return (True, peer2_r1)
+                return AIResult(success=True, text=peer2_r1)
             # Call 4: revision
             if call_count == 4:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Calls 5-7: round 2 peers
             captured_round2.append((ai_provider, ai_model, prompt))
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         with (
             patch(
@@ -2649,13 +2650,13 @@ class TestAnalyzeWithPeers:
             call_count += 1
             # Calls 1-3: round 1 peers
             if call_count <= 3:
-                return (True, peer_r1_responses[call_count - 1])
+                return AIResult(success=True, text=peer_r1_responses[call_count - 1])
             # Call 4: revision
             if call_count == 4:
-                return (True, main_response_r2)
+                return AIResult(success=True, text=main_response_r2)
             # Calls 5-7: round 2 peers
             captured_round2.append((call_count - 5, prompt))
-            return (True, peer_agree)
+            return AIResult(success=True, text=peer_agree)
 
         duplicate_peers = [
             AiConfigEntry(ai_provider="gemini", ai_model="gemini-2.5-pro"),

--- a/tests/test_storage_token_usage.py
+++ b/tests/test_storage_token_usage.py
@@ -1,0 +1,308 @@
+"""Tests for storage token usage functions."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from jenkins_job_insight import storage
+
+
+@pytest.fixture
+def _init_db(temp_db_path):
+    """Initialize database with test path for token usage tests."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        asyncio.run(storage.init_db())
+        yield
+
+
+@pytest.fixture
+def _storage(temp_db_path, _init_db):
+    """Patch DB_PATH for all storage calls in the test."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        yield
+
+
+class TestRecordTokenUsage:
+    @pytest.mark.asyncio
+    async def test_inserts_record_and_returns_uuid(self, _storage) -> None:
+        """record_token_usage inserts a record and returns a UUID."""
+        record_id = await storage.record_token_usage(
+            job_id="job-1",
+            ai_provider="claude",
+            ai_model="opus-4",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            cost_usd=0.05,
+            duration_ms=1200,
+            prompt_chars=500,
+            response_chars=200,
+        )
+        assert isinstance(record_id, str)
+        assert len(record_id) == 36  # UUID format
+
+    @pytest.mark.asyncio
+    async def test_stored_fields_are_correct(self, _storage) -> None:
+        """All fields are stored correctly."""
+        await storage.record_token_usage(
+            job_id="job-2",
+            ai_provider="gemini",
+            ai_model="2.5-pro",
+            call_type="peer_review",
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=15,
+            cache_write_tokens=3,
+            cost_usd=0.03,
+            duration_ms=800,
+            prompt_chars=1000,
+            response_chars=400,
+        )
+        records = await storage.get_token_usage_for_job("job-2")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["job_id"] == "job-2"
+        assert rec["ai_provider"] == "gemini"
+        assert rec["ai_model"] == "2.5-pro"
+        assert rec["call_type"] == "peer_review"
+        assert rec["input_tokens"] == 200
+        assert rec["output_tokens"] == 80
+        assert rec["cache_read_tokens"] == 15
+        assert rec["cache_write_tokens"] == 3
+        assert rec["total_tokens"] == 280
+        assert rec["cost_usd"] == pytest.approx(0.03)
+        assert rec["duration_ms"] == 800
+        assert rec["prompt_chars"] == 1000
+        assert rec["response_chars"] == 400
+
+    @pytest.mark.asyncio
+    async def test_total_tokens_computed(self, _storage) -> None:
+        """total_tokens = input_tokens + output_tokens."""
+        await storage.record_token_usage(
+            job_id="job-3",
+            ai_provider="claude",
+            ai_model="opus",
+            call_type="analysis",
+            input_tokens=300,
+            output_tokens=150,
+        )
+        records = await storage.get_token_usage_for_job("job-3")
+        assert records[0]["total_tokens"] == 450
+
+
+class TestGetTokenUsageForJob:
+    @pytest.mark.asyncio
+    async def test_returns_records_for_job(self, _storage) -> None:
+        """Returns all records for a specific job."""
+        await storage.record_token_usage(
+            job_id="job-a",
+            ai_provider="claude",
+            ai_model="opus",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        await storage.record_token_usage(
+            job_id="job-a",
+            ai_provider="gemini",
+            ai_model="2.5-pro",
+            call_type="peer_review",
+            input_tokens=200,
+            output_tokens=80,
+        )
+        records = await storage.get_token_usage_for_job("job-a")
+        assert len(records) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_nonexistent_job(self, _storage) -> None:
+        """Returns empty list for non-existent job."""
+        records = await storage.get_token_usage_for_job("nonexistent-job")
+        assert records == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_return_other_jobs(self, _storage) -> None:
+        """Records from other jobs are not included."""
+        await storage.record_token_usage(
+            job_id="job-x",
+            ai_provider="claude",
+            ai_model="opus",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        await storage.record_token_usage(
+            job_id="job-y",
+            ai_provider="claude",
+            ai_model="opus",
+            call_type="analysis",
+            input_tokens=200,
+            output_tokens=80,
+        )
+        records = await storage.get_token_usage_for_job("job-x")
+        assert len(records) == 1
+        assert records[0]["job_id"] == "job-x"
+
+
+class TestGetTokenUsageSummary:
+    @pytest.mark.asyncio
+    async def _insert_test_records(self) -> None:
+        """Helper to insert test records for summary tests."""
+        await storage.record_token_usage(
+            job_id="job-1",
+            ai_provider="claude",
+            ai_model="opus-4",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.05,
+            duration_ms=1000,
+        )
+        await storage.record_token_usage(
+            job_id="job-2",
+            ai_provider="gemini",
+            ai_model="2.5-pro",
+            call_type="peer_review",
+            input_tokens=200,
+            output_tokens=80,
+            cost_usd=0.03,
+            duration_ms=800,
+        )
+        await storage.record_token_usage(
+            job_id="job-1",
+            ai_provider="claude",
+            ai_model="opus-4",
+            call_type="jira_filter",
+            input_tokens=50,
+            output_tokens=20,
+            cost_usd=0.01,
+            duration_ms=300,
+        )
+
+    @pytest.mark.asyncio
+    async def test_totals_correct(self, _storage) -> None:
+        """Totals are correctly aggregated."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary()
+        assert summary["total_calls"] == 3
+        assert summary["total_input_tokens"] == 350
+        assert summary["total_output_tokens"] == 150
+        assert summary["total_cost_usd"] == pytest.approx(0.09)
+
+    @pytest.mark.asyncio
+    async def test_empty_db_returns_zeros(self, _storage) -> None:
+        """Empty database returns zero totals."""
+        summary = await storage.get_token_usage_summary()
+        assert summary["total_calls"] == 0
+        assert summary["total_input_tokens"] == 0
+        assert summary["total_cost_usd"] == 0
+
+    @pytest.mark.asyncio
+    async def test_filter_by_provider(self, _storage) -> None:
+        """Filter by ai_provider works."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(ai_provider="claude")
+        assert summary["total_calls"] == 2
+        assert summary["total_input_tokens"] == 150
+
+    @pytest.mark.asyncio
+    async def test_filter_by_call_type(self, _storage) -> None:
+        """Filter by call_type works."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(call_type="analysis")
+        assert summary["total_calls"] == 1
+        assert summary["total_input_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_filter_by_model(self, _storage) -> None:
+        """Filter by ai_model works."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(ai_model="2.5-pro")
+        assert summary["total_calls"] == 1
+        assert summary["total_input_tokens"] == 200
+
+    @pytest.mark.asyncio
+    async def test_group_by_provider(self, _storage) -> None:
+        """group_by=provider produces breakdown by provider."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(group_by="provider")
+        breakdown = summary["breakdown"]
+        assert len(breakdown) == 2
+        keys = {row["group_key"] for row in breakdown}
+        assert "claude" in keys
+        assert "gemini" in keys
+
+    @pytest.mark.asyncio
+    async def test_group_by_call_type(self, _storage) -> None:
+        """group_by=call_type produces breakdown by call_type."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(group_by="call_type")
+        breakdown = summary["breakdown"]
+        assert len(breakdown) == 3
+        keys = {row["group_key"] for row in breakdown}
+        assert "analysis" in keys
+        assert "peer_review" in keys
+        assert "jira_filter" in keys
+
+    @pytest.mark.asyncio
+    async def test_group_by_job(self, _storage) -> None:
+        """group_by=job produces breakdown by job_id."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary(group_by="job")
+        breakdown = summary["breakdown"]
+        assert len(breakdown) == 2
+        keys = {row["group_key"] for row in breakdown}
+        assert "job-1" in keys
+        assert "job-2" in keys
+
+    @pytest.mark.asyncio
+    async def test_no_breakdown_without_group_by(self, _storage) -> None:
+        """No breakdown returned when group_by is not specified."""
+        await self._insert_test_records()
+        summary = await storage.get_token_usage_summary()
+        assert summary["breakdown"] == []
+
+
+class TestGetTokenUsageDashboardSummary:
+    @pytest.mark.asyncio
+    async def test_returns_expected_keys(self, _storage) -> None:
+        """Dashboard summary returns today, this_week, this_month, top_models, top_jobs."""
+        result = await storage.get_token_usage_dashboard_summary()
+        assert "today" in result
+        assert "this_week" in result
+        assert "this_month" in result
+        assert "top_models" in result
+        assert "top_jobs" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_db_returns_zeros(self, _storage) -> None:
+        """Empty database returns zero values."""
+        result = await storage.get_token_usage_dashboard_summary()
+        assert result["today"]["calls"] == 0
+        assert result["this_week"]["calls"] == 0
+        assert result["this_month"]["calls"] == 0
+        assert result["top_models"] == []
+        assert result["top_jobs"] == []
+
+    @pytest.mark.asyncio
+    async def test_recent_records_appear_in_periods(self, _storage) -> None:
+        """Records inserted now appear in today, this_week, and this_month."""
+        await storage.record_token_usage(
+            job_id="job-dash",
+            ai_provider="claude",
+            ai_model="opus-4",
+            call_type="analysis",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.05,
+        )
+        result = await storage.get_token_usage_dashboard_summary()
+        assert result["today"]["calls"] == 1
+        assert result["this_week"]["calls"] == 1
+        assert result["this_month"]["calls"] == 1
+        assert len(result["top_models"]) == 1
+        assert result["top_models"][0]["model"] == "opus-4"
+        assert len(result["top_jobs"]) == 1
+        assert result["top_jobs"][0]["job_id"] == "job-dash"

--- a/tests/test_storage_token_usage.py
+++ b/tests/test_storage_token_usage.py
@@ -303,6 +303,6 @@ class TestGetTokenUsageDashboardSummary:
         assert result["this_week"]["calls"] == 1
         assert result["this_month"]["calls"] == 1
         assert len(result["top_models"]) == 1
-        assert result["top_models"][0]["model"] == "opus-4"
+        assert result["top_models"][0]["model"] == "claude / opus-4"
         assert len(result["top_jobs"]) == 1
         assert result["top_jobs"][0]["job_id"] == "job-dash"

--- a/tests/test_token_tracking.py
+++ b/tests/test_token_tracking.py
@@ -55,8 +55,8 @@ class TestRecordAiUsage:
             )
 
     @pytest.mark.asyncio
-    async def test_does_nothing_when_usage_is_none(self) -> None:
-        """Does nothing when usage is None (no crash)."""
+    async def test_records_zeros_when_usage_is_none(self) -> None:
+        """Records with zero token fields when usage is None."""
         result = AIResult(success=True, text="output")
         assert result.usage is None
 
@@ -64,7 +64,41 @@ class TestRecordAiUsage:
             "jenkins_job_insight.token_tracking.storage.record_token_usage",
             new_callable=AsyncMock,
         ) as mock_record:
-            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+            await record_ai_usage(
+                job_id="job-123",
+                result=result,
+                call_type="analysis",
+                ai_provider="claude",
+                ai_model="opus-4",
+            )
+            mock_record.assert_called_once_with(
+                job_id="job-123",
+                ai_provider="claude",
+                ai_model="opus-4",
+                call_type="analysis",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=None,
+                duration_ms=None,
+                prompt_chars=0,
+                response_chars=len("output"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_job_id_empty(self) -> None:
+        """Does nothing when job_id is empty."""
+        usage = AITokenUsage(
+            input_tokens=100, output_tokens=50, provider="claude", model="opus"
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            await record_ai_usage(job_id="", result=result, call_type="analysis")
             mock_record.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_token_tracking.py
+++ b/tests/test_token_tracking.py
@@ -1,0 +1,265 @@
+"""Tests for token_tracking module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from ai_cli_runner import AIResult, AITokenUsage
+
+from jenkins_job_insight.token_tracking import (
+    build_token_usage_summary,
+    record_ai_usage,
+)
+
+
+class TestRecordAiUsage:
+    """Tests for record_ai_usage."""
+
+    @pytest.mark.asyncio
+    async def test_records_usage_when_present(self) -> None:
+        """Records token usage when AIResult has usage data."""
+        usage = AITokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            cost_usd=0.05,
+            duration_ms=1200,
+            provider="claude",
+            model="opus-4",
+        )
+        result = AIResult(success=True, text="analysis output", usage=usage)
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            await record_ai_usage(
+                job_id="job-123",
+                result=result,
+                call_type="analysis",
+                prompt_chars=500,
+            )
+            mock_record.assert_called_once_with(
+                job_id="job-123",
+                ai_provider="claude",
+                ai_model="opus-4",
+                call_type="analysis",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=10,
+                cache_write_tokens=5,
+                cost_usd=0.05,
+                duration_ms=1200,
+                prompt_chars=500,
+                response_chars=len("analysis output"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_does_nothing_when_usage_is_none(self) -> None:
+        """Does nothing when usage is None (no crash)."""
+        result = AIResult(success=True, text="output")
+        assert result.usage is None
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+            mock_record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_best_effort_errors_dont_propagate(self) -> None:
+        """Errors in storage do not propagate."""
+        usage = AITokenUsage(
+            input_tokens=100, output_tokens=50, provider="claude", model="opus"
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB unavailable"),
+        ):
+            # Should not raise
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_parameter_provider_model(self) -> None:
+        """Uses parameter provider/model when usage lacks them."""
+        usage = AITokenUsage(input_tokens=100, output_tokens=50, provider="", model="")
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            await record_ai_usage(
+                job_id="job-123",
+                result=result,
+                call_type="peer_review",
+                ai_provider="gemini",
+                ai_model="2.5-pro",
+            )
+            call_kwargs = mock_record.call_args.kwargs
+            assert call_kwargs["ai_provider"] == "gemini"
+            assert call_kwargs["ai_model"] == "2.5-pro"
+            assert call_kwargs["call_type"] == "peer_review"
+
+    @pytest.mark.asyncio
+    async def test_records_correct_response_chars(self) -> None:
+        """response_chars is derived from len(result.text)."""
+        long_text = "x" * 12345
+        usage = AITokenUsage(
+            input_tokens=10, output_tokens=20, provider="claude", model="m"
+        )
+        result = AIResult(success=True, text=long_text, usage=usage)
+
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.record_token_usage",
+            new_callable=AsyncMock,
+        ) as mock_record:
+            await record_ai_usage(job_id="job-1", result=result, call_type="analysis")
+            assert mock_record.call_args.kwargs["response_chars"] == 12345
+
+
+class TestBuildTokenUsageSummary:
+    """Tests for build_token_usage_summary."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_records(self) -> None:
+        """Returns None when no records exist."""
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.get_token_usage_for_job",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await build_token_usage_summary("job-123")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_builds_correct_summary(self) -> None:
+        """Builds correct summary from multiple records."""
+        records = [
+            {
+                "ai_provider": "claude",
+                "ai_model": "opus-4",
+                "call_type": "analysis",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 10,
+                "cache_write_tokens": 5,
+                "total_tokens": 150,
+                "cost_usd": 0.05,
+                "duration_ms": 1200,
+            },
+            {
+                "ai_provider": "gemini",
+                "ai_model": "2.5-pro",
+                "call_type": "peer_review",
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 280,
+                "cost_usd": 0.03,
+                "duration_ms": 800,
+            },
+        ]
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.get_token_usage_for_job",
+            new_callable=AsyncMock,
+            return_value=records,
+        ):
+            summary = await build_token_usage_summary("job-123")
+
+        assert summary is not None
+        assert summary.total_calls == 2
+        assert summary.total_input_tokens == 300
+        assert summary.total_output_tokens == 130
+        assert summary.total_cache_read_tokens == 10
+        assert summary.total_cache_write_tokens == 5
+        assert summary.total_tokens == 430
+        assert summary.total_cost_usd == pytest.approx(0.08)
+        assert summary.total_duration_ms == 2000
+        assert len(summary.calls) == 2
+        assert summary.calls[0].provider == "claude"
+        assert summary.calls[1].call_type == "peer_review"
+
+    @pytest.mark.asyncio
+    async def test_handles_none_cost_usd(self) -> None:
+        """Sets total cost to None if any call lacks cost."""
+        records = [
+            {
+                "ai_provider": "claude",
+                "ai_model": "opus-4",
+                "call_type": "analysis",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 150,
+                "cost_usd": 0.05,
+                "duration_ms": 1000,
+            },
+            {
+                "ai_provider": "gemini",
+                "ai_model": "2.5-pro",
+                "call_type": "analysis",
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 280,
+                "cost_usd": None,
+                "duration_ms": 500,
+            },
+        ]
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.get_token_usage_for_job",
+            new_callable=AsyncMock,
+            return_value=records,
+        ):
+            summary = await build_token_usage_summary("job-123")
+
+        assert summary is not None
+        assert summary.total_cost_usd is None
+        # Other totals should still be correct
+        assert summary.total_input_tokens == 300
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_storage_error(self) -> None:
+        """Returns None when storage raises an exception."""
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.get_token_usage_for_job",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB error"),
+        ):
+            result = await build_token_usage_summary("job-123")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handles_none_duration_ms(self) -> None:
+        """None duration_ms values are treated as 0 in totals."""
+        records = [
+            {
+                "ai_provider": "claude",
+                "ai_model": "opus-4",
+                "call_type": "analysis",
+                "input_tokens": 50,
+                "output_tokens": 20,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 70,
+                "cost_usd": 0.01,
+                "duration_ms": None,
+            },
+        ]
+        with patch(
+            "jenkins_job_insight.token_tracking.storage.get_token_usage_for_job",
+            new_callable=AsyncMock,
+            return_value=records,
+        ):
+            summary = await build_token_usage_summary("job-123")
+
+        assert summary is not None
+        assert summary.total_duration_ms == 0


### PR DESCRIPTION
Closes #142

## Summary

Track all AI CLI token usage per call, store in the database, and expose via API, CLI, and frontend dashboard. Uses `ai-cli-runner` 0.2.0's `output_format="json"` to get token metadata from Claude, Cursor, and Gemini CLIs.

## Changes

### Backend
- **All 8 AI CLI call sites** now pass `output_format="json"` and use `AIResult` directly (no more tuple unpacking)
- **`_call_ai_cli_with_retry()`** returns `AIResult` instead of `tuple[bool, str]` — propagates token usage
- **`token_tracking.py`** — `record_ai_usage()` (best-effort per-call recording) + `build_token_usage_summary()` (per-job aggregation)
- **`ai_token_usage` DB table** — stores per-call records with provider, model, call_type, tokens, cost, duration
- **Call types tracked**: primary, peer, revision, jira_filter, github_preview, jira_preview, child_console, main_console
- **`token_usage` field** added to `AnalysisResult` — attached before result storage

### API (admin only)
- `GET /api/admin/token-usage` — aggregated usage with filters (date range, provider, model, call_type) and grouping (by provider, model, call_type, day, week, month, job)
- `GET /api/admin/token-usage/summary` — dashboard cards: today/this_week/this_month stats + top models/jobs
- `GET /api/admin/token-usage/{job_id}` — per-job breakdown of every AI call

### CLI
- `jji admin token-usage` with `--period`, `--group-by`, `--provider`, `--model`, `--call-type`, `--job-id`, `--format` (table/json/csv)

### Frontend
- **Token Usage dashboard** (`/admin/token-usage`) — summary cards, breakdown table with sorting, date/group filters
- **TokenUsageBadge** on report page header — compact `⚡ 15K in / 3K out · $0.45` format
- **NavBar** — "Token Usage" link for admin users

### Documentation
- README.md: feature description, CLI commands, API endpoints
- AGENTS.md: `token_tracking` in key components, `TokenUsagePage` in frontend directory

## Security
- All 3 endpoints require admin authentication (`_require_admin`)
- SQL queries use parameterized placeholders — `group_by` uses hardcoded dict allowlist
- Frontend route wrapped in `<ProtectedRoute adminOnly>`

## Tests
- 1,529 tests pass (1,431 backend + 98 frontend)
- New test files: `test_token_tracking.py`, `test_storage_token_usage.py`, `test_api_token_usage.py`
- Updated: `test_cli_main.py`, `test_cli_client.py` for new CLI commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Token Usage: dashboard (Today/7d/30d), filters/grouping, per‑job breakdown, CSV/JSON export, admin nav/route, and token‑usage badge on reports; analysis results now include persisted token‑usage summaries.
  * New formatting helpers for compact numbers and USD cost display.

* **Documentation**
  * README and docs updated with CLI/API usage and AI failure‑classification notes.

* **Tests**
  * Extensive new/updated tests for API, storage, CLI, token tracking, analyzer, peer flows, UI, and formatting helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->