### PR TITLE
fix: allow admin login with reserved 'admin' username when API key is provided

### DIFF
--- a/frontend/src/components/shared/ProfileForm.tsx
+++ b/frontend/src/components/shared/ProfileForm.tsx
@@ -249,7 +249,7 @@ export function ProfileForm({ onSaved, onAdminLogin }: ProfileFormProps) {
     const trimmed = username.trim()
     if (!trimmed) return
 
-    if (trimmed.toLowerCase() === 'admin') {
+    if (trimmed.toLowerCase() === 'admin' && !apiKey.trim()) {
       setUsernameError("The username 'admin' is reserved")
       return
     }


### PR DESCRIPTION
## Bug

PR #165 introduced a frontend guard that blocks username `admin` from being submitted. This was intended to prevent regular users from registering with the reserved `admin` username, but it also blocks the bootstrap admin from logging in with their admin API key.

## Fix

Only block `admin` username when no API key is provided. When an API key is present, let the login proceed — the server validates the admin key correctly.

```diff
-    if (trimmed.toLowerCase() === 'admin') {
+    if (trimmed.toLowerCase() === 'admin' && !apiKey.trim()) {
```

## Testing

- All 1,630 tests pass (1,506 backend + 124 frontend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with admin user authentication where the system incorrectly rejected admin login attempts. Admin users can now authenticate successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->