### PR TITLE
feat: mentions tab — view all @mentions with one-click navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ htmlcov/
 .superpowers/
 
 # Frontend
+node_modules/
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { ReportPage } from '@/pages/ReportPage'
 import { TestHistoryPage } from '@/pages/TestHistoryPage'
 import { UsersPage } from '@/pages/UsersPage'
 import { TokenUsagePage } from '@/pages/TokenUsagePage'
+import { MentionsPage } from '@/pages/MentionsPage'
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
             <Route path="/dashboard" element={<Navigate to="/" replace />} />
             <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
             <Route path="/history/test/:testName" element={<ProtectedRoute><TestHistoryPage /></ProtectedRoute>} />
+            <Route path="/mentions" element={<ProtectedRoute><MentionsPage /></ProtectedRoute>} />
             <Route path="/results/:jobId" element={<ProtectedRoute><ReportPage /></ProtectedRoute>} />
             <Route path="/status/:jobId" element={<ProtectedRoute><StatusPage /></ProtectedRoute>} />
             <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { BookOpen, Bug, type LucideIcon } from 'lucide-react'
 import { UserBadge } from './UserBadge'
 import { useAuth } from '@/lib/auth'
+import { api } from '@/lib/api'
 import { GITHUB_REPO_URL } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 
@@ -20,11 +22,45 @@ const EXTERNAL_NAV_LINKS: ExternalNavLink[] = [
 const BASE_NAV_LINKS = [
   { to: '/', label: 'Dashboard' },
   { to: '/history', label: 'History' },
+  { to: '/mentions', label: 'Mentions' },
 ]
+
+const UNREAD_POLL_INTERVAL = 30_000
 
 export function NavBar() {
   const location = useLocation()
-  const { isAdmin } = useAuth()
+  const { isAdmin, username } = useAuth()
+  const [unreadCount, setUnreadCount] = useState(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchUnread = useCallback(async () => {
+    try {
+      const res = await api.get<{ count: number }>('/api/users/mentions/unread-count')
+      setUnreadCount(res.count)
+    } catch {
+      // best-effort
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!username) return
+    fetchUnread()
+    intervalRef.current = setInterval(fetchUnread, UNREAD_POLL_INTERVAL)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [username, fetchUnread])
+
+  useEffect(() => {
+    if (!username) return
+    function handleVisibility() {
+      if (document.visibilityState === 'visible') {
+        fetchUnread()
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => document.removeEventListener('visibilitychange', handleVisibility)
+  }, [username, fetchUnread])
 
   const navLinks = isAdmin
     ? [...BASE_NAV_LINKS, { to: '/admin/users', label: 'Users' }, { to: '/admin/token-usage', label: 'Token Usage' }]
@@ -46,13 +82,18 @@ export function NavBar() {
                 key={to}
                 to={to}
                 className={cn(
-                  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150',
+                  'relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150',
                   (location.pathname === to || (to !== '/' && location.pathname.startsWith(to)))
                     ? 'bg-surface-elevated text-text-primary'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
                 )}
               >
                 {label}
+                {to === '/mentions' && unreadCount > 0 && (
+                  <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-signal-blue px-1 text-[10px] font-bold text-white">
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </span>
+                )}
               </Link>
             ))}
           </nav>

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -53,6 +53,15 @@ export function NavBar() {
 
   useEffect(() => {
     if (!username) return
+    function handleMentionsUpdated() {
+      fetchUnread()
+    }
+    window.addEventListener('mentions-updated', handleMentionsUpdated)
+    return () => window.removeEventListener('mentions-updated', handleMentionsUpdated)
+  }, [username, fetchUnread])
+
+  useEffect(() => {
+    if (!username) return
     function handleVisibility() {
       if (document.visibilityState === 'visible') {
         fetchUnread()

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -22,7 +22,6 @@ const EXTERNAL_NAV_LINKS: ExternalNavLink[] = [
 const BASE_NAV_LINKS = [
   { to: '/', label: 'Dashboard' },
   { to: '/history', label: 'History' },
-  { to: '/mentions', label: 'Mentions' },
 ]
 
 const UNREAD_POLL_INTERVAL = 30_000
@@ -71,9 +70,18 @@ export function NavBar() {
     return () => document.removeEventListener('visibilitychange', handleVisibility)
   }, [username, fetchUnread])
 
-  const navLinks = isAdmin
-    ? [...BASE_NAV_LINKS, { to: '/admin/users', label: 'Users' }, { to: '/admin/token-usage', label: 'Token Usage' }]
+  // Clear stale unread count when user is logged out
+  useEffect(() => {
+    if (!username) setUnreadCount(0)
+  }, [username])
+
+  const baseNavLinks = username
+    ? [...BASE_NAV_LINKS, { to: '/mentions', label: 'Mentions' }]
     : BASE_NAV_LINKS
+
+  const navLinks = isAdmin
+    ? [...baseNavLinks, { to: '/admin/users', label: 'Users' }, { to: '/admin/token-usage', label: 'Token Usage' }]
+    : baseNavLinks
 
   return (
     <header className="sticky top-0 z-50 border-b border-border-default bg-surface-card/95 backdrop-blur-sm">

--- a/frontend/src/pages/MentionsPage.tsx
+++ b/frontend/src/pages/MentionsPage.tsx
@@ -52,6 +52,8 @@ function timeAgo(dateStr: string): string {
   return `${months}mo ago`
 }
 
+/** Truncate text for list preview. Full text is available via expand-on-click.
+ *  This is intentional UI summarization, not lossy data — the API always returns full text. */
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text
   return text.slice(0, max).trimEnd() + '…'
@@ -118,15 +120,13 @@ export function MentionsPage() {
   }
 
   async function markAllRead() {
-    const unreadIds = mentions.filter((m) => !m.is_read).map((m) => m.id)
-    if (unreadIds.length === 0) return
     setMarkingAll(true)
     try {
-      await api.post('/api/users/mentions/read', { comment_ids: unreadIds })
-      setMentions((prev) =>
-        prev.map((m) => (unreadIds.includes(m.id) ? { ...m, is_read: true } : m)),
-      )
-      setUnreadCount((prev) => Math.max(0, prev - unreadIds.length))
+      await api.post('/api/users/mentions/read-all', {})
+      // Refresh the current page to reflect the changes
+      setMentions((prev) => prev.map((m) => ({ ...m, is_read: true })))
+      setUnreadCount(0)
+      window.dispatchEvent(new Event('mentions-updated'))
     } catch {
       // best-effort
     } finally {
@@ -143,6 +143,7 @@ export function MentionsPage() {
         prev.map((m) => (m.id === id ? { ...m, is_read: true } : m)),
       )
       setUnreadCount((prev) => Math.max(0, prev - 1))
+      window.dispatchEvent(new Event('mentions-updated'))
     } catch {
       // best-effort
     }
@@ -253,7 +254,12 @@ export function MentionsPage() {
                         'text-sm text-text-secondary whitespace-pre-wrap',
                         needsTruncation && 'cursor-pointer',
                       )}
-                      onClick={() => needsTruncation && toggleExpand(m.id)}
+                      onClick={(e) => {
+                        if (needsTruncation) {
+                          e.stopPropagation()
+                          toggleExpand(m.id)
+                        }
+                      }}
                     >
                       {commentText}
                     </p>

--- a/frontend/src/pages/MentionsPage.tsx
+++ b/frontend/src/pages/MentionsPage.tsx
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Button } from '@/components/ui/button'
+import { Pagination } from '@/components/shared/Pagination'
+import { AtSign, CheckCheck } from 'lucide-react'
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface Mention {
+  id: number
+  job_id: string
+  test_name: string
+  child_job_name: string
+  child_build_number: number
+  comment: string
+  username: string
+  created_at: string
+  is_read: boolean
+}
+
+interface MentionsResponse {
+  mentions: Mention[]
+  total: number
+  unread_count: number
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const LIMIT = 50
+
+function timeAgo(dateStr: string): string {
+  const date = new Date(dateStr.includes('T') ? dateStr : dateStr.replace(' ', 'T') + 'Z')
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  if (diffMs < 0) return 'just now'
+  const seconds = Math.floor(diffMs / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return text.slice(0, max).trimEnd() + '…'
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function MentionsPage() {
+  const [mentions, setMentions] = useState<Mention[]>([])
+  const [total, setTotal] = useState(0)
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState(1)
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
+  const [markingAll, setMarkingAll] = useState(false)
+  const requestSeqRef = useRef(0)
+
+  const fetchMentions = useCallback(async (p: number) => {
+    const seq = ++requestSeqRef.current
+    setLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams({
+        offset: String((p - 1) * LIMIT),
+        limit: String(LIMIT),
+        unread_only: 'false',
+      })
+      const res = await api.get<MentionsResponse>(`/api/users/mentions?${params}`)
+      if (seq === requestSeqRef.current) {
+        setMentions(res.mentions)
+        setTotal(res.total)
+        setUnreadCount(res.unread_count)
+      }
+    } catch (err) {
+      if (seq === requestSeqRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load mentions')
+      }
+    } finally {
+      if (seq === requestSeqRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchMentions(page)
+  }, [page, fetchMentions])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => { requestSeqRef.current += 1 }
+  }, [])
+
+  function toggleExpand(id: number) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  async function markAllRead() {
+    const unreadIds = mentions.filter((m) => !m.is_read).map((m) => m.id)
+    if (unreadIds.length === 0) return
+    setMarkingAll(true)
+    try {
+      await api.post('/api/users/mentions/read', { comment_ids: unreadIds })
+      setMentions((prev) =>
+        prev.map((m) => (unreadIds.includes(m.id) ? { ...m, is_read: true } : m)),
+      )
+      setUnreadCount((prev) => Math.max(0, prev - unreadIds.length))
+    } catch {
+      // best-effort
+    } finally {
+      setMarkingAll(false)
+    }
+  }
+
+  async function markRead(id: number) {
+    const mention = mentions.find((m) => m.id === id)
+    if (!mention || mention.is_read) return
+    try {
+      await api.post('/api/users/mentions/read', { comment_ids: [id] })
+      setMentions((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, is_read: true } : m)),
+      )
+      setUnreadCount((prev) => Math.max(0, prev - 1))
+    } catch {
+      // best-effort
+    }
+  }
+
+  const navigate = useNavigate()
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT))
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <AtSign className="h-5 w-5 text-text-tertiary" />
+          <h1 className="font-display text-xl font-bold text-text-primary">Mentions</h1>
+          {unreadCount > 0 && (
+            <span className="inline-flex items-center justify-center rounded-full bg-signal-blue px-2 py-0.5 text-[11px] font-semibold text-white">
+              {unreadCount} unread
+            </span>
+          )}
+        </div>
+        {unreadCount > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={markAllRead}
+            disabled={markingAll}
+            className="gap-1.5 text-xs"
+          >
+            <CheckCheck className="h-3.5 w-3.5" />
+            Mark all as read
+          </Button>
+        )}
+      </div>
+
+      {/* Results count */}
+      <div className="flex items-center">
+        <span className="text-xs text-text-tertiary font-mono">
+          {total} mention{total !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Error */}
+      {error && <p className="text-center text-signal-red py-8">{error}</p>}
+
+      {/* Loading */}
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      ) : !error && mentions.length === 0 ? (
+        <div className="flex items-center justify-center rounded-lg border border-border-muted bg-surface-card py-16 animate-fade-in">
+          <p className="text-text-secondary">No mentions yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {mentions.map((m, i) => {
+            const isExpanded = expandedIds.has(m.id)
+            const commentText = isExpanded ? m.comment : truncate(m.comment, 200)
+            const needsTruncation = m.comment.length > 200
+
+            return (
+              <div
+                key={m.id}
+                className={cn(
+                  'group rounded-lg border px-4 py-3 transition-colors duration-150 animate-slide-up cursor-pointer',
+                  m.is_read
+                    ? 'border-border-muted bg-surface-card opacity-60'
+                    : 'border-border-muted border-l-2 border-l-signal-blue bg-signal-blue/10',
+                )}
+                onClick={() => {
+                  markRead(m.id)
+                  navigate(`/results/${m.job_id}?comment=${m.id}`)
+                }}
+                style={{
+                  animationDelay: `${i * 30}ms`,
+                  animationFillMode: 'backwards',
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  {/* Unread dot */}
+                  <div className="mt-1.5 shrink-0 w-2">
+                    {!m.is_read && (
+                      <span className="block h-2 w-2 rounded-full bg-signal-blue" title="Unread" />
+                    )}
+                  </div>
+
+                  {/* Content */}
+                  <div className="min-w-0 flex-1 space-y-1">
+                    {/* Top row: author + time */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={cn(
+                        'font-mono text-xs text-signal-blue',
+                        !m.is_read && 'font-semibold',
+                      )}>
+                        @{m.username}
+                      </span>
+                      <span className="text-[10px] text-text-tertiary">
+                        {timeAgo(m.created_at)}
+                      </span>
+                    </div>
+
+                    {/* Comment text */}
+                    <p
+                      className={cn(
+                        'text-sm text-text-secondary whitespace-pre-wrap',
+                        needsTruncation && 'cursor-pointer',
+                      )}
+                      onClick={() => needsTruncation && toggleExpand(m.id)}
+                    >
+                      {commentText}
+                    </p>
+
+                    {/* Bottom row: job + test */}
+                    <div className="flex items-center gap-3 flex-wrap text-xs text-text-tertiary">
+                      <span className="text-text-link font-mono">
+                        {m.job_id}
+                      </span>
+                      {m.test_name && (
+                        <span className="font-mono truncate max-w-[400px]" title={m.test_name}>
+                          {m.test_name}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  )
+}

--- a/frontend/src/pages/MentionsPage.tsx
+++ b/frontend/src/pages/MentionsPage.tsx
@@ -152,6 +152,18 @@ export function MentionsPage() {
   const navigate = useNavigate()
   const totalPages = Math.max(1, Math.ceil(total / LIMIT))
 
+  function buildMentionUrl(m: Mention): string {
+    const params = new URLSearchParams({ comment: String(m.id) })
+    if (m.child_job_name) params.set('child_job_name', m.child_job_name)
+    if (m.child_build_number) params.set('child_build_number', String(m.child_build_number))
+    return `/results/${m.job_id}?${params}`
+  }
+
+  function openMention(m: Mention) {
+    markRead(m.id)
+    navigate(buildMentionUrl(m))
+  }
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -210,15 +222,20 @@ export function MentionsPage() {
             return (
               <div
                 key={m.id}
+                tabIndex={0}
+                role="button"
                 className={cn(
                   'group rounded-lg border px-4 py-3 transition-colors duration-150 animate-slide-up cursor-pointer',
                   m.is_read
                     ? 'border-border-muted bg-surface-card opacity-60'
                     : 'border-border-muted border-l-2 border-l-signal-blue bg-signal-blue/10',
                 )}
-                onClick={() => {
-                  markRead(m.id)
-                  navigate(`/results/${m.job_id}?comment=${m.id}`)
+                onClick={() => openMention(m)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    openMention(m)
+                  }
                 }}
                 style={{
                   animationDelay: `${i * 30}ms`,

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { api } from '@/lib/api'
 import { useClipboard } from '@/lib/useClipboard'
 import { parseApiTimestamp, isAnalysisTimeout, formatDuration, formatTimestamp } from '@/lib/utils'
@@ -105,6 +105,7 @@ function CliCommand({ jobId }: { jobId: string }) {
 function ReportContent() {
   const { jobId } = useParams<{ jobId: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const state = useReportState()
   const dispatch = useReportDispatch()
   const refreshEnrichments = useRefreshEnrichments()
@@ -285,6 +286,24 @@ function ReportContent() {
       cancelAnimationFrame(raf2)
     }
   }, [state.loading, state.error, scrollKey])
+
+  // Scroll to comment when ?comment=ID is present in query params
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const commentId = params.get('comment')
+    if (commentId && !state.loading && !state.error) {
+      // Delay to let FailureCard auto-expand and comments render
+      const timeout = setTimeout(() => {
+        const el = document.getElementById(`comment-${commentId}`)
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          el.classList.add('ring-2', 'ring-accent-blue', 'ring-offset-2')
+          setTimeout(() => el.classList.remove('ring-2', 'ring-accent-blue', 'ring-offset-2'), 3000)
+        }
+      }, 1000)
+      return () => clearTimeout(timeout)
+    }
+  }, [location.search, state.loading, state.error])
 
   // Save scroll position on scroll (debounced)
   useEffect(() => {

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -291,18 +291,31 @@ function ReportContent() {
   useEffect(() => {
     const params = new URLSearchParams(location.search)
     const commentId = params.get('comment')
-    if (commentId && !state.loading && !state.error) {
-      // Delay to let FailureCard auto-expand and comments render
-      const timeout = setTimeout(() => {
-        const el = document.getElementById(`comment-${commentId}`)
-        if (el) {
-          el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-          el.classList.add('ring-2', 'ring-accent-blue', 'ring-offset-2')
-          setTimeout(() => el.classList.remove('ring-2', 'ring-accent-blue', 'ring-offset-2'), 3000)
-        }
-      }, 1000)
-      return () => clearTimeout(timeout)
+    if (!commentId || state.loading || state.error) return
+
+    let cancelled = false
+    let attempts = 0
+    const maxAttempts = 20 // 20 × 200ms = 4s max wait
+
+    const tryScroll = () => {
+      if (cancelled) return
+      const el = document.getElementById(`comment-${commentId}`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        el.classList.add('ring-2', 'ring-accent-blue', 'ring-offset-2')
+        setTimeout(() => {
+          if (!cancelled) el.classList.remove('ring-2', 'ring-accent-blue', 'ring-offset-2')
+        }, 3000)
+        return
+      }
+      attempts++
+      if (attempts < maxAttempts) {
+        setTimeout(tryScroll, 200)
+      }
     }
+
+    tryScroll()
+    return () => { cancelled = true }
   }, [location.search, state.loading, state.error])
 
   // Save scroll position on scroll (debounced)

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -183,7 +183,8 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
             return (
               <div
                 key={c.id}
-                className="group flex items-start gap-3 rounded-md bg-surface-elevated/50 px-3 py-2 text-sm animate-slide-up"
+                id={`comment-${c.id}`}
+                className="group flex items-start gap-3 rounded-md bg-surface-elevated/50 px-3 py-2 text-sm animate-slide-up transition-all duration-300"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -27,7 +27,7 @@ function enrichmentBadgeVariant(status: string): 'success' | 'destructive' | 'de
 /*  @mention highlighting in rendered text                             */
 /* ------------------------------------------------------------------ */
 
-const MENTION_RE = /(?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)/g
+export const MENTION_RE = /(?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)/g
 
 /** Render a plain-text segment with @mentions highlighted. */
 function renderTextWithMentions(text: string, segIndex: number): ReactNode {

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, type ReactNode } from 'react'
+import { useState, useEffect, useMemo, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useClipboard } from '@/lib/useClipboard'
 import type { GroupedFailure } from '@/types'
 import { buildFileUrl, buildRepoUrls, isSafeHref, matchRepo, type RepoUrl } from '@/lib/autoLink'
@@ -136,7 +137,22 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
 
   // Comment count for ALL tests in the group
   const groupTestNames = group.tests.map((t) => t.test_name)
-  const commentCount = comments.filter((c) => isCommentInScope(c, groupTestNames, scopedChildJobName, scopedChildBuildNumber)).length
+  const commentsInScope = useMemo(
+    () => comments.filter((c) => isCommentInScope(c, groupTestNames, scopedChildJobName, scopedChildBuildNumber)),
+    [comments, groupTestNames, scopedChildJobName, scopedChildBuildNumber],
+  )
+  const commentCount = commentsInScope.length
+
+  // Auto-expand card when navigating to a specific comment (e.g. from Mentions page)
+  const location = useLocation()
+  useEffect(() => {
+    const params = new URLSearchParams(location.search)
+    const targetCommentId = params.get('comment')
+    if (!targetCommentId || expanded) return
+    if (commentsInScope.some((c) => String(c.id) === targetCommentId)) {
+      setExpanded(true)
+    }
+  }, [location.search])
 
   // Review-all: check how many tests in group are reviewed
   const reviewedCount = group.tests.filter((t) => {

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -182,10 +182,14 @@ describe('CommentsSection – @mention highlighting', () => {
 /** Extract mention usernames from text using MENTION_RE (same as backend). */
 function extractMentions(text: string): string[] {
   MENTION_RE.lastIndex = 0
+  const seen = new Set<string>()
   const mentions: string[] = []
   let m: RegExpExecArray | null
   while ((m = MENTION_RE.exec(text)) !== null) {
-    mentions.push(m[1])
+    if (!seen.has(m[1])) {
+      seen.add(m[1])
+      mentions.push(m[1])
+    }
   }
   return mentions
 }
@@ -206,6 +210,7 @@ const MENTION_TEST_CASES = [
   { input: '1@alice', expected: [] },                          // preceded by digit — no match
   { input: '(@alice)', expected: ['alice'] },                  // parens ok
   { input: '@alice.', expected: ['alice'] },                   // trailing dot ok
+  { input: '@alice ping @alice', expected: ['alice'] },        // deduplication — same user only once
 ]
 
 describe('MENTION_RE – parity with Python _MENTION_PATTERN', () => {

--- a/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+++ b/frontend/src/pages/report/__tests__/CommentsSection.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { useEffect } from 'react'
-import { CommentsSection } from '../CommentsSection'
+import { CommentsSection, MENTION_RE } from '../CommentsSection'
 import { ReportProvider, useReportDispatch } from '../ReportContext'
 import type { Comment } from '@/types'
 
@@ -171,4 +171,48 @@ describe('CommentsSection – @mention highlighting', () => {
     expect(screen.getByText('No mentions here')).toBeDefined()
     expect(screen.queryByText(/@/)).toBeNull()
   })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Mention regex parity with Python backend                           */
+/* ------------------------------------------------------------------ */
+// These test cases are shared with Python tests/test_mentions.py::TestMentionRegexParity
+// If you change these, update the Python side too.
+
+/** Extract mention usernames from text using MENTION_RE (same as backend). */
+function extractMentions(text: string): string[] {
+  MENTION_RE.lastIndex = 0
+  const mentions: string[] = []
+  let m: RegExpExecArray | null
+  while ((m = MENTION_RE.exec(text)) !== null) {
+    mentions.push(m[1])
+  }
+  return mentions
+}
+
+// Shared mention regex test cases — MUST match Python's _MENTION_PATTERN in comment_enrichment.py
+// Pattern: (?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)
+const MENTION_TEST_CASES = [
+  { input: 'hello @alice', expected: ['alice'] },
+  { input: '@bob test', expected: ['bob'] },
+  { input: 'cc @alice @bob', expected: ['alice', 'bob'] },
+  { input: 'email user@domain.com', expected: [] },          // email — no match
+  { input: 'no mentions here', expected: [] },
+  { input: '@alice-bob', expected: ['alice-bob'] },           // hyphens allowed
+  { input: '@alice_bob', expected: ['alice_bob'] },           // underscores allowed
+  { input: '@alice123', expected: ['alice123'] },             // digits allowed
+  { input: '.@alice', expected: [] },                          // preceded by dot — no match
+  { input: 'x@alice', expected: [] },                          // preceded by letter — no match
+  { input: '1@alice', expected: [] },                          // preceded by digit — no match
+  { input: '(@alice)', expected: ['alice'] },                  // parens ok
+  { input: '@alice.', expected: ['alice'] },                   // trailing dot ok
+]
+
+describe('MENTION_RE – parity with Python _MENTION_PATTERN', () => {
+  it.each(MENTION_TEST_CASES)(
+    'extracts $expected from "$input"',
+    ({ input, expected }) => {
+      expect(extractMentions(input)).toEqual(expected)
+    },
+  )
 })

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -709,6 +709,21 @@ class JJIClient:
         """Get list of mentionable usernames. GET /api/users/mentionable"""
         return self._request("GET", "/api/users/mentionable")
 
+    def get_mentions(
+        self, limit: int = 50, offset: int = 0, unread_only: bool = False
+    ) -> dict:
+        """Get comments that mention the current user. GET /api/users/mentions"""
+        params: dict = {"limit": limit, "offset": offset}
+        if unread_only:
+            params["unread_only"] = "true"
+        return self._request("GET", "/api/users/mentions", params=params)
+
+    def mark_mentions_read(self, comment_ids: list[int]) -> dict:
+        """Mark specific mentions as read. POST /api/users/mentions/read"""
+        return self._request(
+            "POST", "/api/users/mentions/read", json={"comment_ids": comment_ids}
+        )
+
     # -- AI Configs -----------------------------------------------------------
 
     def get_ai_configs(self) -> list[dict]:

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -724,6 +724,10 @@ class JJIClient:
             "POST", "/api/users/mentions/read", json={"comment_ids": comment_ids}
         )
 
+    def mark_all_mentions_read(self) -> dict:
+        """Mark all mentions as read. POST /api/users/mentions/read-all"""
+        return self._request("POST", "/api/users/mentions/read-all")
+
     # -- AI Configs -----------------------------------------------------------
 
     def get_ai_configs(self) -> list[dict]:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1366,6 +1366,46 @@ def mentionable_users_cmd(
             typer.echo("No mentionable users found.")
 
 
+@app.command("mentions")
+def mentions_cmd(
+    limit: int = typer.Option(50, "--limit", "-l", help="Max mentions to return."),
+    unread: bool = typer.Option(False, "--unread", help="Show only unread mentions."),
+    json_output: bool = _JSON_OPTION,
+):
+    """List your @mentions across all reports."""
+    _set_json(json_output)
+    try:
+        client = _get_client()
+        data = client.get_mentions(limit=limit, unread_only=unread)
+    except JJIError as err:
+        _handle_error(err)
+
+    if _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
+    else:
+        mentions = data.get("mentions", [])
+        total = data.get("total", 0)
+        unread_count = data.get("unread_count", 0)
+        typer.echo(f"Total: {total} mention(s), {unread_count} unread")
+        if mentions:
+            print_output(
+                mentions,
+                columns=[
+                    "id",
+                    "job_id",
+                    "test_name",
+                    "comment",
+                    "username",
+                    "is_read",
+                    "created_at",
+                ],
+                labels={"username": "BY", "is_read": "READ", "created_at": "DATE"},
+                as_json=False,
+            )
+        else:
+            typer.echo("No mentions found.")
+
+
 # -- Bug Creation -------------------------------------------------------------
 
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1415,7 +1415,18 @@ def mentions_mark_read_cmd(
     json_output: bool = _JSON_OPTION,
 ):
     """Mark specific mentions as read."""
-    comment_ids = [int(x.strip()) for x in ids.split(",") if x.strip()]
+    raw_parts = [x.strip() for x in ids.split(",") if x.strip()]
+    if not raw_parts:
+        typer.echo("Error: --ids must contain at least one integer ID.", err=True)
+        raise typer.Exit(1)
+    comment_ids = []
+    for part in raw_parts:
+        if not part.isdigit():
+            typer.echo(
+                f"Error: invalid ID '{part}' — must be a positive integer.", err=True
+            )
+            raise typer.Exit(1)
+        comment_ids.append(int(part))
     _run_client_command(
         json_output,
         lambda c: c.mark_mentions_read(comment_ids),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1424,10 +1424,7 @@ def mentions_mark_read_cmd(
         try:
             cid = int(part)
         except ValueError:
-            typer.echo(
-                f"Error: invalid ID '{part}' — must be a positive integer.", err=True
-            )
-            raise typer.Exit(1)
+            cid = -1
         if cid <= 0:
             typer.echo(
                 f"Error: invalid ID '{part}' — must be a positive integer.", err=True

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1369,6 +1369,7 @@ def mentionable_users_cmd(
 @app.command("mentions")
 def mentions_cmd(
     limit: int = typer.Option(50, "--limit", "-l", help="Max mentions to return."),
+    offset: int = typer.Option(0, "--offset", "-o", help="Offset for pagination."),
     unread: bool = typer.Option(False, "--unread", help="Show only unread mentions."),
     json_output: bool = _JSON_OPTION,
 ):
@@ -1376,7 +1377,7 @@ def mentions_cmd(
     _set_json(json_output)
     try:
         client = _get_client()
-        data = client.get_mentions(limit=limit, unread_only=unread)
+        data = client.get_mentions(limit=limit, offset=offset, unread_only=unread)
     except JJIError as err:
         _handle_error(err)
 
@@ -1404,6 +1405,32 @@ def mentions_cmd(
             )
         else:
             typer.echo("No mentions found.")
+
+
+@app.command("mentions-mark-read")
+def mentions_mark_read_cmd(
+    ids: str = typer.Option(
+        ..., "--ids", help="Comma-separated comment IDs to mark as read."
+    ),
+    json_output: bool = _JSON_OPTION,
+):
+    """Mark specific mentions as read."""
+    comment_ids = [int(x.strip()) for x in ids.split(",") if x.strip()]
+    _run_client_command(
+        json_output,
+        lambda c: c.mark_mentions_read(comment_ids),
+    )
+
+
+@app.command("mentions-mark-all-read")
+def mentions_mark_all_read_cmd(
+    json_output: bool = _JSON_OPTION,
+):
+    """Mark all mentions as read."""
+    _run_client_command(
+        json_output,
+        lambda c: c.mark_all_mentions_read(),
+    )
 
 
 # -- Bug Creation -------------------------------------------------------------

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1422,12 +1422,18 @@ def mentions_mark_read_cmd(
     comment_ids = []
     for part in raw_parts:
         try:
-            comment_ids.append(int(part))
+            cid = int(part)
         except ValueError:
             typer.echo(
                 f"Error: invalid ID '{part}' — must be a positive integer.", err=True
             )
             raise typer.Exit(1)
+        if cid <= 0:
+            typer.echo(
+                f"Error: invalid ID '{part}' — must be a positive integer.", err=True
+            )
+            raise typer.Exit(1)
+        comment_ids.append(cid)
     _run_client_command(
         json_output,
         lambda c: c.mark_mentions_read(comment_ids),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1421,12 +1421,13 @@ def mentions_mark_read_cmd(
         raise typer.Exit(1)
     comment_ids = []
     for part in raw_parts:
-        if not part.isdigit():
+        try:
+            comment_ids.append(int(part))
+        except ValueError:
             typer.echo(
                 f"Error: invalid ID '{part}' — must be a positive integer.", err=True
             )
             raise typer.Exit(1)
-        comment_ids.append(int(part))
     _run_client_command(
         json_output,
         lambda c: c.mark_mentions_read(comment_ids),

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4474,8 +4474,10 @@ async def get_user_mentions(request: Request):
     try:
         offset = max(0, int(request.query_params.get("offset", "0")))
         limit = min(200, max(1, int(request.query_params.get("limit", "50"))))
-    except ValueError:
-        raise HTTPException(status_code=400, detail="offset and limit must be integers")
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail="offset and limit must be integers"
+        ) from exc
     unread_only = request.query_params.get("unread_only", "false").lower() in (
         "true",
         "1",

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4464,6 +4464,64 @@ async def unsubscribe_notifications(body: UnsubscribeRequest, request: Request):
     return {"status": "unsubscribed"}
 
 
+@app.get("/api/users/mentions")
+async def get_user_mentions(request: Request):
+    """Get comments that mention the current user."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
+    offset = int(request.query_params.get("offset", "0"))
+    limit = int(request.query_params.get("limit", "50"))
+    unread_only = request.query_params.get("unread_only", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    result = await storage.get_mentions_for_user(
+        username=username, offset=offset, limit=limit, unread_only=unread_only
+    )
+    unread_count = await storage.get_unread_mention_count(username)
+    return {
+        "mentions": result["mentions"],
+        "total": result["total"],
+        "unread_count": unread_count,
+    }
+
+
+@app.post("/api/users/mentions/read")
+async def mark_mentions_as_read(request: Request):
+    """Mark specific mentions as read."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
+    body = await _read_json_object(request)
+    comment_ids = body.get("comment_ids", [])
+    if (
+        not isinstance(comment_ids, list)
+        or not comment_ids
+        or not all(isinstance(cid, int) for cid in comment_ids)
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="comment_ids must be a non-empty list of integers",
+        )
+    await storage.mark_mentions_read(username, comment_ids)
+    return {"ok": True}
+
+
+@app.get("/api/users/mentions/unread-count")
+async def get_unread_mentions_count(request: Request):
+    """Get count of unread mentions for navbar badge."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
+    count = await storage.get_unread_mention_count(username)
+    return {"count": count}
+
+
 @app.get("/api/users/mentionable")
 async def get_mentionable_users(request: Request):
     """Return list of usernames that can be mentioned in comments."""

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4471,8 +4471,11 @@ async def get_user_mentions(request: Request):
     if not username:
         raise HTTPException(status_code=401, detail="Username required")
     _check_allow_list(request)
-    offset = int(request.query_params.get("offset", "0"))
-    limit = int(request.query_params.get("limit", "50"))
+    try:
+        offset = max(0, int(request.query_params.get("offset", "0")))
+        limit = min(200, max(1, int(request.query_params.get("limit", "50"))))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="offset and limit must be integers")
     unread_only = request.query_params.get("unread_only", "false").lower() in (
         "true",
         "1",
@@ -4481,12 +4484,22 @@ async def get_user_mentions(request: Request):
     result = await storage.get_mentions_for_user(
         username=username, offset=offset, limit=limit, unread_only=unread_only
     )
-    unread_count = await storage.get_unread_mention_count(username)
     return {
         "mentions": result["mentions"],
         "total": result["total"],
-        "unread_count": unread_count,
+        "unread_count": result["unread_count"],
     }
+
+
+@app.post("/api/users/mentions/read-all")
+async def mark_all_mentions_read_endpoint(request: Request):
+    """Mark ALL mentions as read for the current user."""
+    username = request.state.username
+    if not username:
+        raise HTTPException(status_code=401, detail="Username required")
+    _check_allow_list(request)
+    count = await storage.mark_all_mentions_read(username)
+    return {"marked_read": count}
 
 
 @app.post("/api/users/mentions/read")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4514,7 +4514,9 @@ async def mark_mentions_as_read(request: Request):
     if (
         not isinstance(comment_ids, list)
         or not comment_ids
-        or not all(isinstance(cid, int) for cid in comment_ids)
+        or not all(
+            isinstance(cid, int) and not isinstance(cid, bool) for cid in comment_ids
+        )
     ):
         raise HTTPException(
             status_code=400,

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -15,6 +15,7 @@ from typing import get_args
 import aiosqlite
 from simple_logger.logger import get_logger
 
+from jenkins_job_insight.comment_enrichment import detect_mentions
 from jenkins_job_insight.encryption import (
     get_hmac_secret,
     strip_sensitive_from_response,
@@ -434,6 +435,20 @@ async def init_db() -> None:
         """)
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_push_subscriptions_username ON push_subscriptions (username)"
+        )
+
+        # Mention read tracking
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS mention_reads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL,
+                comment_id INTEGER NOT NULL,
+                read_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(username, comment_id)
+            )
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mention_reads_username ON mention_reads (username)"
         )
 
         await db.commit()
@@ -3256,3 +3271,122 @@ async def delete_stale_push_subscriptions(endpoints: list[str]) -> None:
             endpoints,
         )
         await db.commit()
+
+
+async def get_mentions_for_user(
+    username: str,
+    offset: int = 0,
+    limit: int = 50,
+    unread_only: bool = False,
+) -> dict:
+    """Get comments that mention @username.
+
+    Returns dict with 'mentions' list and 'total' count for pagination.
+    Each mention includes: id, job_id, test_name, child_job_name,
+    child_build_number, comment, username (author), created_at, is_read.
+
+    """
+    logger.debug(
+        f"get_mentions_for_user: username={username}, offset={offset}, limit={limit}, unread_only={unread_only}"
+    )
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        # NOTE: We use SQL LIKE for initial candidate filtering, then refine
+        # with Python-side regex (detect_mentions) to enforce word-boundary
+        # semantics (e.g. "@alice" but not "@alicexyz"). SQLite lacks native
+        # regex/word-boundary support, so we must fetch all LIKE candidates to
+        # compute an accurate total count before applying offset/limit.
+        like_pattern = f"%@{username}%"
+
+        # Base query with LEFT JOIN to mention_reads for is_read status
+        base_where = "c.comment LIKE ?"
+        base_params: list = [like_pattern]
+
+        if unread_only:
+            base_where += " AND mr.id IS NULL"
+
+        cursor = await db.execute(
+            f"SELECT c.id, c.job_id, c.test_name, c.child_job_name, "
+            f"c.child_build_number, c.comment, c.username, c.created_at, "
+            f"CASE WHEN mr.id IS NOT NULL THEN 1 ELSE 0 END AS is_read "
+            f"FROM comments c "
+            f"LEFT JOIN mention_reads mr ON mr.comment_id = c.id AND mr.username = ? "
+            f"WHERE {base_where} "
+            f"ORDER BY c.created_at DESC",
+            [username, *base_params],
+        )
+        rows = await cursor.fetchall()
+
+    # Python-side word-boundary filtering using detect_mentions.
+    # SQL LIKE '%@user%' over-matches (e.g. '@username_extra'), so we
+    # verify each candidate with regex-based detect_mentions().
+    filtered: list[dict] = []
+    for row in rows:
+        mentioned_users = detect_mentions(row["comment"])
+        if username in mentioned_users:
+            filtered.append(
+                {
+                    "id": row["id"],
+                    "job_id": row["job_id"],
+                    "test_name": row["test_name"],
+                    "child_job_name": row["child_job_name"],
+                    "child_build_number": row["child_build_number"],
+                    "comment": row["comment"],
+                    "username": row["username"],
+                    "created_at": row["created_at"],
+                    "is_read": bool(row["is_read"]),
+                }
+            )
+
+    total = len(filtered)
+    mentions = filtered[offset : offset + limit]
+    logger.debug(
+        f"get_mentions_for_user: username={username}, total={total}, returned={len(mentions)}"
+    )
+    return {"mentions": mentions, "total": total}
+
+
+async def mark_mentions_read(username: str, comment_ids: list[int]) -> None:
+    """Mark specific mentions as read for a user."""
+    if not comment_ids:
+        return
+    logger.debug(
+        f"mark_mentions_read: username={username}, comment_ids_count={len(comment_ids)}"
+    )
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.executemany(
+            "INSERT OR IGNORE INTO mention_reads (username, comment_id) VALUES (?, ?)",
+            [(username, cid) for cid in comment_ids],
+        )
+        await db.commit()
+
+
+async def get_unread_mention_count(username: str) -> int:
+    """Get count of unread mentions for a user."""
+    logger.debug(f"get_unread_mention_count: username={username}")
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        # NOTE: Same two-phase filtering as get_mentions_for_user — SQL LIKE
+        # for fast candidate selection, then Python regex for word-boundary
+        # accuracy. SQLite cannot enforce word boundaries natively.
+        like_pattern = f"%@{username}%"
+        cursor = await db.execute(
+            "SELECT c.id, c.comment "
+            "FROM comments c "
+            "LEFT JOIN mention_reads mr ON mr.comment_id = c.id AND mr.username = ? "
+            "WHERE c.comment LIKE ? AND mr.id IS NULL",
+            (username, like_pattern),
+        )
+        rows = await cursor.fetchall()
+
+    # Python-side word-boundary filtering — verify LIKE candidates with regex
+    count = 0
+    for row in rows:
+        mentioned_users = detect_mentions(row["comment"])
+        if username in mentioned_users:
+            count += 1
+
+    logger.debug(f"get_unread_mention_count: username={username}, count={count}")
+    return count

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3354,11 +3354,13 @@ async def get_mentions_for_user(
 ) -> dict:
     """Get comments that mention @username.
 
-    Returns dict with 'mentions' list, 'total' count, and 'unread_count'
-    for pagination. Each mention includes: id, job_id, test_name,
-    child_job_name, child_build_number, comment, username (author),
-    created_at, is_read.
+    Returns dict with 'mentions' list, 'total' count, and 'unread_count'.
+    When unread_only=True, 'total' reflects the count of unread mentions only
+    (matching the filtered result set). 'unread_count' always reflects the
+    global unread count for the user (regardless of unread_only filter).
 
+    Each mention includes: id, job_id, test_name, child_job_name,
+    child_build_number, comment, username (author), created_at, is_read.
     """
     logger.debug(
         f"get_mentions_for_user: username={username}, offset={offset}, limit={limit}, unread_only={unread_only}"
@@ -3376,6 +3378,9 @@ async def get_mentions_for_user(
 
 async def mark_mentions_read(username: str, comment_ids: list[int]) -> None:
     """Mark specific mentions as read for a user."""
+    # Note: comment_ids are not validated against actual mentions for this user.
+    # Junk rows may accumulate but are harmless — _fetch_mention_candidates
+    # re-checks detect_mentions, so non-mentioned comments never surface.
     if not comment_ids:
         return
     logger.debug(
@@ -3400,6 +3405,9 @@ async def get_unread_mention_count(username: str) -> int:
 
 async def mark_all_mentions_read(username: str) -> int:
     """Mark all unread mentions as read for a user. Returns count marked."""
+    # Note: small race window between fetch and insert (separate connections).
+    # New mentions arriving between steps won't be marked, but the next poll
+    # or mark-all call will catch them. This is standard "mark all as of now" semantics.
     logger.debug(f"mark_all_mentions_read: username={username}")
     candidates = await _fetch_mention_candidates(username, unread_only=True)
     if not candidates:

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -3273,38 +3273,26 @@ async def delete_stale_push_subscriptions(endpoints: list[str]) -> None:
         await db.commit()
 
 
-async def get_mentions_for_user(
+async def _fetch_mention_candidates(
     username: str,
-    offset: int = 0,
-    limit: int = 50,
     unread_only: bool = False,
-) -> dict:
-    """Get comments that mention @username.
+) -> list[dict]:
+    """Fetch and filter mention candidates for a user.
 
-    Returns dict with 'mentions' list and 'total' count for pagination.
-    Each mention includes: id, job_id, test_name, child_job_name,
-    child_build_number, comment, username (author), created_at, is_read.
-
+    Uses SQL LIKE for initial candidate filtering, then refines
+    with Python-side regex (detect_mentions) to enforce word-boundary
+    semantics. SQLite lacks native regex/word-boundary support.
     """
-    logger.debug(
-        f"get_mentions_for_user: username={username}, offset={offset}, limit={limit}, unread_only={unread_only}"
-    )
+    like_pattern = f"%@{username}%"
+
+    base_where = "c.comment LIKE ?"
+    base_params: list = [like_pattern]
+
+    if unread_only:
+        base_where += " AND mr.id IS NULL"
+
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
-
-        # NOTE: We use SQL LIKE for initial candidate filtering, then refine
-        # with Python-side regex (detect_mentions) to enforce word-boundary
-        # semantics (e.g. "@alice" but not "@alicexyz"). SQLite lacks native
-        # regex/word-boundary support, so we must fetch all LIKE candidates to
-        # compute an accurate total count before applying offset/limit.
-        like_pattern = f"%@{username}%"
-
-        # Base query with LEFT JOIN to mention_reads for is_read status
-        base_where = "c.comment LIKE ?"
-        base_params: list = [like_pattern]
-
-        if unread_only:
-            base_where += " AND mr.id IS NULL"
 
         cursor = await db.execute(
             f"SELECT c.id, c.job_id, c.test_name, c.child_job_name, "
@@ -3339,12 +3327,35 @@ async def get_mentions_for_user(
                 }
             )
 
+    return filtered
+
+
+async def get_mentions_for_user(
+    username: str,
+    offset: int = 0,
+    limit: int = 50,
+    unread_only: bool = False,
+) -> dict:
+    """Get comments that mention @username.
+
+    Returns dict with 'mentions' list, 'total' count, and 'unread_count'
+    for pagination. Each mention includes: id, job_id, test_name,
+    child_job_name, child_build_number, comment, username (author),
+    created_at, is_read.
+
+    """
+    logger.debug(
+        f"get_mentions_for_user: username={username}, offset={offset}, limit={limit}, unread_only={unread_only}"
+    )
+    filtered = await _fetch_mention_candidates(username, unread_only=unread_only)
+
     total = len(filtered)
+    unread_count = sum(1 for m in filtered if not m["is_read"])
     mentions = filtered[offset : offset + limit]
     logger.debug(
         f"get_mentions_for_user: username={username}, total={total}, returned={len(mentions)}"
     )
-    return {"mentions": mentions, "total": total}
+    return {"mentions": mentions, "total": total, "unread_count": unread_count}
 
 
 async def mark_mentions_read(username: str, comment_ids: list[int]) -> None:
@@ -3365,28 +3376,28 @@ async def mark_mentions_read(username: str, comment_ids: list[int]) -> None:
 async def get_unread_mention_count(username: str) -> int:
     """Get count of unread mentions for a user."""
     logger.debug(f"get_unread_mention_count: username={username}")
-    async with aiosqlite.connect(DB_PATH) as db:
-        db.row_factory = aiosqlite.Row
-
-        # NOTE: Same two-phase filtering as get_mentions_for_user — SQL LIKE
-        # for fast candidate selection, then Python regex for word-boundary
-        # accuracy. SQLite cannot enforce word boundaries natively.
-        like_pattern = f"%@{username}%"
-        cursor = await db.execute(
-            "SELECT c.id, c.comment "
-            "FROM comments c "
-            "LEFT JOIN mention_reads mr ON mr.comment_id = c.id AND mr.username = ? "
-            "WHERE c.comment LIKE ? AND mr.id IS NULL",
-            (username, like_pattern),
-        )
-        rows = await cursor.fetchall()
-
-    # Python-side word-boundary filtering — verify LIKE candidates with regex
-    count = 0
-    for row in rows:
-        mentioned_users = detect_mentions(row["comment"])
-        if username in mentioned_users:
-            count += 1
-
+    candidates = await _fetch_mention_candidates(username, unread_only=True)
+    count = len(candidates)
     logger.debug(f"get_unread_mention_count: username={username}, count={count}")
     return count
+
+
+async def mark_all_mentions_read(username: str) -> int:
+    """Mark all unread mentions as read for a user. Returns count marked."""
+    logger.debug(f"mark_all_mentions_read: username={username}")
+    candidates = await _fetch_mention_candidates(username, unread_only=True)
+    if not candidates:
+        return 0
+
+    comment_ids = [c["id"] for c in candidates]
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.executemany(
+            "INSERT OR IGNORE INTO mention_reads (username, comment_id) VALUES (?, ?)",
+            [(username, cid) for cid in comment_ids],
+        )
+        await db.commit()
+
+    logger.info(
+        f"mark_all_mentions_read: username={username}, marked={len(comment_ids)}"
+    )
+    return len(comment_ids)

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -541,6 +541,10 @@ async def delete_comment(comment_id: int, username: str, job_id: str = "") -> bo
             query += " AND job_id = ?"
             params.append(job_id)
         cursor = await db.execute(query, params)
+        if cursor.rowcount > 0:
+            await db.execute(
+                "DELETE FROM mention_reads WHERE comment_id = ?", (comment_id,)
+            )
         await db.commit()
         deleted = cursor.rowcount > 0
         logger.debug(f"delete_comment: comment_id={comment_id}, deleted={deleted}")
@@ -2030,6 +2034,11 @@ async def get_all_failures(
 
 async def _delete_job_rows(db: aiosqlite.Connection, job_id: str) -> bool:
     """Delete all rows for a job across related tables. Returns True if the job existed."""
+    await db.execute(
+        "DELETE FROM mention_reads WHERE comment_id IN "
+        "(SELECT id FROM comments WHERE job_id = ?)",
+        (job_id,),
+    )
     await db.execute("DELETE FROM comments WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM failure_reviews WHERE job_id = ?", (job_id,))
     await db.execute("DELETE FROM failure_history WHERE job_id = ?", (job_id,))
@@ -3282,6 +3291,13 @@ async def _fetch_mention_candidates(
     Uses SQL LIKE for initial candidate filtering, then refines
     with Python-side regex (detect_mentions) to enforce word-boundary
     semantics. SQLite lacks native regex/word-boundary support.
+
+    Performance note: LIKE '%@user%' is a full table scan (leading wildcard
+    precludes index use). For current scale (hundreds to low-thousands of
+    comments) this is acceptable. If the comments table grows significantly,
+    consider: (1) caching unread counts with TTL invalidated on add_comment,
+    (2) pushing LIMIT into SQL for paginated queries, or (3) a denormalized
+    mentions table populated on comment creation.
     """
     like_pattern = f"%@{username}%"
 

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -453,6 +453,50 @@ class TestJJIClientMentionableUsers:
         assert result["usernames"] == []
 
 
+class TestJJIClientMentions:
+    def test_get_mentions(self):
+        payload = {
+            "mentions": [{"id": 1, "comment": "@alice hi", "username": "bob"}],
+            "total": 1,
+            "unread_count": 1,
+        }
+
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/users/mentions"
+            assert request.url.params["limit"] == "50"
+            return httpx.Response(200, json=payload)
+
+        client = _make_client(handler, username="alice")
+        result = client.get_mentions(limit=50)
+        assert result["total"] == 1
+        assert result["mentions"][0]["comment"] == "@alice hi"
+
+    def test_get_mentions_unread_only(self):
+        def handler(request):
+            assert request.url.params.get("unread_only") == "true"
+            return httpx.Response(
+                200, json={"mentions": [], "total": 0, "unread_count": 0}
+            )
+
+        client = _make_client(handler, username="alice")
+        client.get_mentions(unread_only=True)
+
+    def test_mark_mentions_read(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/users/mentions/read"
+            import json
+
+            body = json.loads(request.content)
+            assert body["comment_ids"] == [10, 20]
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(handler, username="alice")
+        result = client.mark_mentions_read([10, 20])
+        assert result["ok"] is True
+
+
 class TestJJIClientAiConfigs:
     def test_get_ai_configs(self):
         sample = [

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -496,6 +496,16 @@ class TestJJIClientMentions:
         result = client.mark_mentions_read([10, 20])
         assert result["ok"] is True
 
+    def test_mark_all_mentions_read(self):
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/users/mentions/read-all"
+            return httpx.Response(200, json={"marked_read": 5})
+
+        client = _make_client(handler, username="alice")
+        result = client.mark_all_mentions_read()
+        assert result["marked_read"] == 5
+
 
 class TestJJIClientAiConfigs:
     def test_get_ai_configs(self):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1095,7 +1095,9 @@ class TestMentionsCommand:
         assert result.exit_code == 0
         assert "1 mention(s)" in result.output
         assert "1 unread" in result.output
-        mock_client.get_mentions.assert_called_once_with(limit=50, unread_only=False)
+        mock_client.get_mentions.assert_called_once_with(
+            limit=50, offset=0, unread_only=False
+        )
 
     def test_mentions_unread_flag(self, mock_client):
         mock_client.get_mentions.return_value = {
@@ -1105,7 +1107,9 @@ class TestMentionsCommand:
         }
         result = runner.invoke(app, ["mentions", "--unread"])
         assert result.exit_code == 0
-        mock_client.get_mentions.assert_called_once_with(limit=50, unread_only=True)
+        mock_client.get_mentions.assert_called_once_with(
+            limit=50, offset=0, unread_only=True
+        )
 
     def test_mentions_empty(self, mock_client):
         mock_client.get_mentions.return_value = {
@@ -1128,6 +1132,47 @@ class TestMentionsCommand:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert parsed["total"] == 1
+
+    def test_mentions_with_offset(self, mock_client):
+        mock_client.get_mentions.return_value = {
+            "mentions": [],
+            "total": 0,
+            "unread_count": 0,
+        }
+        result = runner.invoke(app, ["mentions", "--offset", "10"])
+        assert result.exit_code == 0
+        mock_client.get_mentions.assert_called_once_with(
+            limit=50, offset=10, unread_only=False
+        )
+
+
+class TestMentionsMarkReadCommand:
+    def test_mentions_mark_read_command(self, mock_client):
+        mock_client.mark_mentions_read.return_value = {"ok": True}
+        result = runner.invoke(app, ["mentions-mark-read", "--ids", "1,2,3"])
+        assert result.exit_code == 0
+        mock_client.mark_mentions_read.assert_called_once_with([1, 2, 3])
+
+    def test_mentions_mark_read_json(self, mock_client):
+        mock_client.mark_mentions_read.return_value = {"ok": True}
+        result = runner.invoke(app, ["--json", "mentions-mark-read", "--ids", "5"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["ok"] is True
+
+
+class TestMentionsMarkAllReadCommand:
+    def test_mentions_mark_all_read_command(self, mock_client):
+        mock_client.mark_all_mentions_read.return_value = {"marked_read": 3}
+        result = runner.invoke(app, ["mentions-mark-all-read"])
+        assert result.exit_code == 0
+
+    def test_mentions_mark_all_read_json(self, mock_client):
+        mock_client.mark_all_mentions_read.return_value = {"marked_read": 3}
+        result = runner.invoke(app, ["--json", "mentions-mark-all-read"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["marked_read"] == 3
 
 
 class TestPreviewIssueCommand:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1153,6 +1153,11 @@ class TestMentionsMarkReadCommand:
         assert result.exit_code == 0
         mock_client.mark_mentions_read.assert_called_once_with([1, 2, 3])
 
+    def test_mentions_mark_read_invalid_ids(self, mock_client):
+        result = runner.invoke(app, ["mentions-mark-read", "--ids", "1,foo"])
+        assert result.exit_code == 1
+        assert "invalid ID" in result.output
+
     def test_mentions_mark_read_json(self, mock_client):
         mock_client.mark_mentions_read.return_value = {"ok": True}
         result = runner.invoke(app, ["--json", "mentions-mark-read", "--ids", "5"])

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1158,6 +1158,11 @@ class TestMentionsMarkReadCommand:
         assert result.exit_code == 1
         assert "invalid ID" in result.output
 
+    def test_mentions_mark_read_negative_id(self, mock_client):
+        result = runner.invoke(app, ["mentions-mark-read", "--ids", "-1"])
+        assert result.exit_code == 1
+        assert "invalid ID" in result.output
+
     def test_mentions_mark_read_json(self, mock_client):
         mock_client.mark_mentions_read.return_value = {"ok": True}
         result = runner.invoke(app, ["--json", "mentions-mark-read", "--ids", "5"])

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1074,6 +1074,62 @@ class TestMentionableUsersCommand:
         assert "No mentionable users found" in result.output
 
 
+class TestMentionsCommand:
+    def test_mentions_command(self, mock_client):
+        mock_client.get_mentions.return_value = {
+            "mentions": [
+                {
+                    "id": 1,
+                    "job_id": "job-1",
+                    "test_name": "test_one",
+                    "comment": "Hey @testuser",
+                    "username": "bob",
+                    "is_read": False,
+                    "created_at": "2026-01-01T00:00:00",
+                }
+            ],
+            "total": 1,
+            "unread_count": 1,
+        }
+        result = runner.invoke(app, ["mentions"])
+        assert result.exit_code == 0
+        assert "1 mention(s)" in result.output
+        assert "1 unread" in result.output
+        mock_client.get_mentions.assert_called_once_with(limit=50, unread_only=False)
+
+    def test_mentions_unread_flag(self, mock_client):
+        mock_client.get_mentions.return_value = {
+            "mentions": [],
+            "total": 0,
+            "unread_count": 0,
+        }
+        result = runner.invoke(app, ["mentions", "--unread"])
+        assert result.exit_code == 0
+        mock_client.get_mentions.assert_called_once_with(limit=50, unread_only=True)
+
+    def test_mentions_empty(self, mock_client):
+        mock_client.get_mentions.return_value = {
+            "mentions": [],
+            "total": 0,
+            "unread_count": 0,
+        }
+        result = runner.invoke(app, ["mentions"])
+        assert result.exit_code == 0
+        assert "No mentions found" in result.output
+
+    def test_mentions_json_output(self, mock_client):
+        payload = {
+            "mentions": [{"id": 1, "comment": "@user"}],
+            "total": 1,
+            "unread_count": 0,
+        }
+        mock_client.get_mentions.return_value = payload
+        result = runner.invoke(app, ["--json", "mentions"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total"] == 1
+
+
 class TestPreviewIssueCommand:
     def test_preview_github(self, mock_client):
         mock_client.preview_github_issue.return_value = {

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -252,6 +252,24 @@ class TestGetMentionsEndpoint:
         response = test_client.get("/api/users/mentions")
         assert response.status_code == 401
 
+    async def test_get_mentions_unread_only_forwarded(
+        self, test_client, temp_db_path: Path
+    ) -> None:
+        """unread_only query flag is forwarded to storage as True."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+        test_client.cookies.set("jji_username", "testuser")
+        with patch.object(
+            storage,
+            "get_mentions_for_user",
+            new_callable=AsyncMock,
+            return_value={"mentions": [], "total": 0, "unread_count": 0},
+        ) as mock_get:
+            response = test_client.get("/api/users/mentions?unread_only=true")
+            assert response.status_code == 200
+            assert mock_get.call_args.kwargs["unread_only"] is True
+        test_client.cookies.clear()
+
 
 class TestMarkReadEndpoint:
     """Tests for POST /api/users/mentions/read."""

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -145,6 +145,22 @@ class TestGetMentionsForUser:
         assert result["total"] == 1
         assert "@al" in result["mentions"][0]["comment"]
 
+    async def test_get_mentions_unread_only_filters_read(
+        self, setup_test_db: Path
+    ) -> None:
+        """unread_only=True excludes already-read mentions."""
+        db = setup_test_db
+        cid_read = await _add_comment(db, "Hey @alice read", username="bob")
+        await _add_comment(db, "Hey @alice unread", username="charlie")
+
+        with patch.object(storage, "DB_PATH", db):
+            await storage.mark_mentions_read("alice", [cid_read])
+            result = await storage.get_mentions_for_user("alice", unread_only=True)
+
+        assert result["total"] == 1
+        assert result["mentions"][0]["comment"] == "Hey @alice unread"
+        assert result["mentions"][0]["is_read"] is False
+
 
 class TestMarkMentionsRead:
     """Tests for storage.mark_mentions_read."""
@@ -480,7 +496,7 @@ class TestMentionRegexParity:
     """
 
     # Pattern: (?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)
-    PARITY_CASES = [
+    PARITY_CASES = (
         ("hello @alice", ["alice"]),
         ("@bob test", ["bob"]),
         ("cc @alice @bob", ["alice", "bob"]),
@@ -495,7 +511,7 @@ class TestMentionRegexParity:
         ("(@alice)", ["alice"]),  # parens ok
         ("@alice.", ["alice"]),  # trailing dot ok
         ("@alice ping @alice", ["alice"]),  # deduplication — same user only once
-    ]
+    )
 
     @pytest.mark.parametrize("text,expected", PARITY_CASES)
     def test_detect_mentions_parity(self, text, expected):

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -6,7 +6,7 @@ Cross-stack parity tests at the bottom must stay in sync with:
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -275,6 +275,18 @@ class TestMarkReadEndpoint:
         assert response.status_code == 400
         test_client.cookies.clear()
 
+    async def test_mark_read_rejects_booleans(self, test_client, temp_db_path) -> None:
+        """POST with boolean comment_ids returns 400."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": [True, 2]},
+        )
+        assert response.status_code == 400
+        test_client.cookies.clear()
+
     async def test_mark_read_requires_username(self, test_client) -> None:
         """POST without auth returns 401."""
         response = test_client.post(
@@ -384,8 +396,17 @@ class TestGetMentionsEndpointValidation:
         with patch.object(storage, "DB_PATH", temp_db_path):
             await storage.init_db()
         test_client.cookies.set("jji_username", "testuser")
-        response = test_client.get("/api/users/mentions?offset=-5")
-        assert response.status_code == 200
+        with patch.object(
+            storage,
+            "get_mentions_for_user",
+            new_callable=AsyncMock,
+            return_value={"mentions": [], "total": 0, "unread_count": 0},
+        ) as mock_get:
+            response = test_client.get("/api/users/mentions?offset=-5")
+            assert response.status_code == 200
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs.get("offset", call_kwargs[1].get("offset")) == 0
         test_client.cookies.clear()
 
     async def test_limit_clamped_to_max(self, test_client, temp_db_path: Path) -> None:
@@ -393,8 +414,17 @@ class TestGetMentionsEndpointValidation:
         with patch.object(storage, "DB_PATH", temp_db_path):
             await storage.init_db()
         test_client.cookies.set("jji_username", "testuser")
-        response = test_client.get("/api/users/mentions?limit=500")
-        assert response.status_code == 200
+        with patch.object(
+            storage,
+            "get_mentions_for_user",
+            new_callable=AsyncMock,
+            return_value={"mentions": [], "total": 0, "unread_count": 0},
+        ) as mock_get:
+            response = test_client.get("/api/users/mentions?limit=9999")
+            assert response.status_code == 200
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs.get("limit", call_kwargs[1].get("limit")) == 200
         test_client.cookies.clear()
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -329,6 +329,29 @@ class TestMarkReadEndpoint:
         )
         assert response.status_code == 401
 
+    async def test_mark_read_non_mentioned_comment_no_effect(
+        self, test_client, temp_db_path: Path
+    ) -> None:
+        """Marking a comment that doesn't mention the user has no visible effect."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+            # Comment mentions @other, NOT @testuser
+            cid = await _add_comment(temp_db_path, "Hey @other look", username="bob")
+
+        test_client.cookies.set("jji_username", "testuser")
+        # Marking succeeds (INSERT OR IGNORE) but creates a junk row
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": [cid]},
+        )
+        assert response.status_code == 200
+
+        # But the comment never appears in testuser's mentions
+        response = test_client.get("/api/users/mentions")
+        assert response.status_code == 200
+        assert response.json()["total"] == 0
+        test_client.cookies.clear()
+
 
 class TestMarkAllMentionsRead:
     """Tests for storage.mark_all_mentions_read."""
@@ -439,8 +462,7 @@ class TestGetMentionsEndpointValidation:
             response = test_client.get("/api/users/mentions?offset=-5")
             assert response.status_code == 200
             mock_get.assert_called_once()
-            call_kwargs = mock_get.call_args
-            assert call_kwargs.kwargs.get("offset", call_kwargs[1].get("offset")) == 0
+            assert mock_get.call_args.kwargs["offset"] == 0
         test_client.cookies.clear()
 
     async def test_limit_clamped_to_max(self, test_client, temp_db_path: Path) -> None:
@@ -457,8 +479,7 @@ class TestGetMentionsEndpointValidation:
             response = test_client.get("/api/users/mentions?limit=9999")
             assert response.status_code == 200
             mock_get.assert_called_once()
-            call_kwargs = mock_get.call_args
-            assert call_kwargs.kwargs.get("limit", call_kwargs[1].get("limit")) == 200
+            assert mock_get.call_args.kwargs["limit"] == 200
         test_client.cookies.clear()
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,4 +1,8 @@
-"""Tests for the @mentions feature (storage, API endpoints)."""
+"""Tests for the @mentions feature (storage, API endpoints).
+
+Cross-stack parity tests at the bottom must stay in sync with:
+  frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+"""
 
 import os
 from pathlib import Path
@@ -280,6 +284,138 @@ class TestMarkReadEndpoint:
         assert response.status_code == 401
 
 
+class TestMarkAllMentionsRead:
+    """Tests for storage.mark_all_mentions_read."""
+
+    async def test_mark_all_mentions_read(self, setup_test_db: Path) -> None:
+        """All unread mentions are marked as read, returns count."""
+        db = setup_test_db
+        await _add_comment(db, "Hey @alice first", username="bob")
+        await _add_comment(db, "Hey @alice second", username="charlie")
+        await _add_comment(db, "No mention here", username="dave")
+
+        with patch.object(storage, "DB_PATH", db):
+            assert await storage.get_unread_mention_count("alice") == 2
+
+            count = await storage.mark_all_mentions_read("alice")
+            assert count == 2
+
+            assert await storage.get_unread_mention_count("alice") == 0
+
+    async def test_mark_all_read_idempotent(self, setup_test_db: Path) -> None:
+        """Calling mark_all again returns 0 when already read."""
+        db = setup_test_db
+        await _add_comment(db, "Hey @alice", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            first = await storage.mark_all_mentions_read("alice")
+            assert first == 1
+            second = await storage.mark_all_mentions_read("alice")
+            assert second == 0
+
+    async def test_mark_all_read_no_mentions(self, setup_test_db: Path) -> None:
+        """Returns 0 when user has no mentions."""
+        db = setup_test_db
+        with patch.object(storage, "DB_PATH", db):
+            count = await storage.mark_all_mentions_read("nobody")
+            assert count == 0
+
+    async def test_mark_all_read_partial(self, setup_test_db: Path) -> None:
+        """Only marks unread mentions; already-read ones are unaffected."""
+        db = setup_test_db
+        cid1 = await _add_comment(db, "Hey @alice one", username="bob")
+        await _add_comment(db, "Hey @alice two", username="charlie")
+
+        with patch.object(storage, "DB_PATH", db):
+            await storage.mark_mentions_read("alice", [cid1])
+            assert await storage.get_unread_mention_count("alice") == 1
+
+            count = await storage.mark_all_mentions_read("alice")
+            assert count == 1
+            assert await storage.get_unread_mention_count("alice") == 0
+
+
+class TestMarkAllReadEndpoint:
+    """Tests for POST /api/users/mentions/read-all."""
+
+    async def test_mark_all_read_endpoint(
+        self, test_client, temp_db_path: Path
+    ) -> None:
+        """POST returns marked_read count."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+            await _add_comment(temp_db_path, "Hey @testuser one", username="bob")
+            await _add_comment(temp_db_path, "Hey @testuser two", username="charlie")
+
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.post("/api/users/mentions/read-all")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["marked_read"] == 2
+        test_client.cookies.clear()
+
+    async def test_mark_all_read_requires_username(self, test_client) -> None:
+        """POST without auth returns 401."""
+        response = test_client.post("/api/users/mentions/read-all")
+        assert response.status_code == 401
+
+
+class TestGetMentionsEndpointValidation:
+    """Tests for input validation on GET /api/users/mentions."""
+
+    async def test_invalid_offset(self, test_client) -> None:
+        """Non-numeric offset returns 400."""
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions?offset=abc")
+        assert response.status_code == 400
+        test_client.cookies.clear()
+
+    async def test_invalid_limit(self, test_client) -> None:
+        """Non-numeric limit returns 400."""
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions?limit=xyz")
+        assert response.status_code == 400
+        test_client.cookies.clear()
+
+    async def test_negative_offset_clamped(
+        self, test_client, temp_db_path: Path
+    ) -> None:
+        """Negative offset is clamped to 0."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions?offset=-5")
+        assert response.status_code == 200
+        test_client.cookies.clear()
+
+    async def test_limit_clamped_to_max(self, test_client, temp_db_path: Path) -> None:
+        """Limit > 200 is clamped to 200."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions?limit=500")
+        assert response.status_code == 200
+        test_client.cookies.clear()
+
+
+class TestGetMentionsUnreadCount:
+    """Tests that get_mentions_for_user returns unread_count directly."""
+
+    async def test_unread_count_in_result(self, setup_test_db: Path) -> None:
+        """get_mentions_for_user returns unread_count in result dict."""
+        db = setup_test_db
+        cid = await _add_comment(db, "Hey @alice first", username="bob")
+        await _add_comment(db, "Hey @alice second", username="charlie")
+
+        with patch.object(storage, "DB_PATH", db):
+            result = await storage.get_mentions_for_user("alice")
+            assert result["unread_count"] == 2
+
+            await storage.mark_mentions_read("alice", [cid])
+            result = await storage.get_mentions_for_user("alice")
+            assert result["unread_count"] == 1
+
+
 class TestUnreadCountEndpoint:
     """Tests for GET /api/users/mentions/unread-count."""
 
@@ -299,3 +435,41 @@ class TestUnreadCountEndpoint:
         """Request without auth returns 401."""
         response = test_client.get("/api/users/mentions/unread-count")
         assert response.status_code == 401
+
+
+# ===========================================================================
+# Cross-stack parity tests (Python ↔ Frontend)
+# ===========================================================================
+
+
+class TestMentionRegexParity:
+    """Shared mention regex test cases — MUST match frontend CommentsSection.test.tsx.
+
+    These test cases are shared with frontend/src/pages/report/__tests__/CommentsSection.test.tsx
+    If you change these, update the frontend side too.
+    """
+
+    # Pattern: (?<![a-zA-Z0-9.])@([a-zA-Z0-9_-]+)
+    PARITY_CASES = [
+        ("hello @alice", ["alice"]),
+        ("@bob test", ["bob"]),
+        ("cc @alice @bob", ["alice", "bob"]),
+        ("email user@domain.com", []),  # email — no match
+        ("no mentions here", []),
+        ("@alice-bob", ["alice-bob"]),  # hyphens allowed
+        ("@alice_bob", ["alice_bob"]),  # underscores allowed
+        ("@alice123", ["alice123"]),  # digits allowed
+        (".@alice", []),  # preceded by dot — no match
+        ("x@alice", []),  # preceded by letter — no match
+        ("1@alice", []),  # preceded by digit — no match
+        ("(@alice)", ["alice"]),  # parens ok
+        ("@alice.", ["alice"]),  # trailing dot ok
+    ]
+
+    @pytest.mark.parametrize("text,expected", PARITY_CASES)
+    def test_detect_mentions_parity(self, text, expected):
+        """Verify Python detect_mentions matches shared test cases."""
+        from jenkins_job_insight.comment_enrichment import detect_mentions
+
+        result = detect_mentions(text)
+        assert result == expected, f"Input: {text!r}, expected {expected}, got {result}"

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -464,6 +464,7 @@ class TestMentionRegexParity:
         ("1@alice", []),  # preceded by digit — no match
         ("(@alice)", ["alice"]),  # parens ok
         ("@alice.", ["alice"]),  # trailing dot ok
+        ("@alice ping @alice", ["alice"]),  # deduplication — same user only once
     ]
 
     @pytest.mark.parametrize("text,expected", PARITY_CASES)

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,301 @@
+"""Tests for the @mentions feature (storage, API endpoints)."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jenkins_job_insight import storage
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def setup_test_db(temp_db_path: Path):
+    """Set up a test database with the path patched."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        await storage.init_db()
+        yield temp_db_path
+
+
+@pytest.fixture
+def mock_settings(temp_db_path: Path):
+    """Mock settings for endpoint tests."""
+    env = {
+        "JENKINS_URL": "https://jenkins.example.com",
+        "JENKINS_USER": "testuser",
+        "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
+        "DB_PATH": str(temp_db_path),
+    }
+    with patch.dict(os.environ, env, clear=True):
+        from jenkins_job_insight.config import get_settings
+
+        get_settings.cache_clear()
+        try:
+            yield
+        finally:
+            get_settings.cache_clear()
+
+
+@pytest.fixture
+def test_client(mock_settings, temp_db_path: Path):
+    """Create a test client with mocked dependencies."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        from starlette.testclient import TestClient
+
+        from jenkins_job_insight.main import app
+
+        with TestClient(app) as client:
+            yield client
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+async def _add_comment(
+    db_path: Path,
+    comment: str,
+    username: str = "author",
+    job_id: str = "job-1",
+    test_name: str = "test_one",
+) -> int:
+    """Insert a comment and return its id."""
+    with patch.object(storage, "DB_PATH", db_path):
+        return await storage.add_comment(
+            job_id=job_id,
+            test_name=test_name,
+            comment=comment,
+            username=username,
+        )
+
+
+# ===========================================================================
+# Storage tests
+# ===========================================================================
+
+
+class TestGetMentionsForUser:
+    """Tests for storage.get_mentions_for_user."""
+
+    async def test_get_mentions_for_user(self, setup_test_db: Path) -> None:
+        """Comments mentioning a user appear in results."""
+        db = setup_test_db
+        await _add_comment(db, "Hey @alice please look", username="bob")
+        await _add_comment(db, "No mention here", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            result = await storage.get_mentions_for_user("alice")
+
+        assert result["total"] == 1
+        assert result["mentions"][0]["comment"] == "Hey @alice please look"
+        assert result["mentions"][0]["username"] == "bob"
+
+    async def test_get_mentions_includes_self(self, setup_test_db: Path) -> None:
+        """Self-mentions (user mentioning themselves) are included."""
+        db = setup_test_db
+        await _add_comment(db, "I am @alice", username="alice")
+        await _add_comment(db, "Hey @alice", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            result = await storage.get_mentions_for_user("alice")
+
+        assert result["total"] == 2
+        usernames = {m["username"] for m in result["mentions"]}
+        assert "alice" in usernames
+        assert "bob" in usernames
+
+    async def test_get_mentions_pagination(self, setup_test_db: Path) -> None:
+        """Offset and limit control pagination correctly."""
+        db = setup_test_db
+        for i in range(5):
+            await _add_comment(
+                db, f"Comment {i} cc @alice", username="bob", job_id=f"job-{i}"
+            )
+
+        with patch.object(storage, "DB_PATH", db):
+            page1 = await storage.get_mentions_for_user("alice", offset=0, limit=2)
+            page2 = await storage.get_mentions_for_user("alice", offset=2, limit=2)
+            page3 = await storage.get_mentions_for_user("alice", offset=4, limit=2)
+
+        assert page1["total"] == 5
+        assert len(page1["mentions"]) == 2
+        assert len(page2["mentions"]) == 2
+        assert len(page3["mentions"]) == 1
+
+    async def test_word_boundary_filtering(self, setup_test_db: Path) -> None:
+        """LIKE '%@al%' should not match @alice when querying for 'al'."""
+        db = setup_test_db
+        await _add_comment(db, "Hi @alice", username="bob")
+        await _add_comment(db, "Hi @al", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            result = await storage.get_mentions_for_user("al")
+
+        # Only '@al' is an exact mention, '@alice' should not match 'al'
+        assert result["total"] == 1
+        assert "@al" in result["mentions"][0]["comment"]
+
+
+class TestMarkMentionsRead:
+    """Tests for storage.mark_mentions_read."""
+
+    async def test_mark_mentions_read(self, setup_test_db: Path) -> None:
+        """Marking a mention read sets is_read to True."""
+        db = setup_test_db
+        cid = await _add_comment(db, "Hey @alice check this", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            before = await storage.get_mentions_for_user("alice")
+            assert before["mentions"][0]["is_read"] is False
+
+            await storage.mark_mentions_read("alice", [cid])
+
+            after = await storage.get_mentions_for_user("alice")
+            assert after["mentions"][0]["is_read"] is True
+
+    async def test_mark_mentions_read_idempotent(self, setup_test_db: Path) -> None:
+        """Marking already-read mentions again does not error."""
+        db = setup_test_db
+        cid = await _add_comment(db, "Hey @alice", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            await storage.mark_mentions_read("alice", [cid])
+            # Second call should not raise
+            await storage.mark_mentions_read("alice", [cid])
+
+            result = await storage.get_mentions_for_user("alice")
+            assert result["mentions"][0]["is_read"] is True
+
+    async def test_mark_empty_list_is_noop(self, setup_test_db: Path) -> None:
+        """Passing an empty list is a safe no-op."""
+        db = setup_test_db
+        with patch.object(storage, "DB_PATH", db):
+            await storage.mark_mentions_read("alice", [])  # should not raise
+
+
+class TestGetUnreadMentionCount:
+    """Tests for storage.get_unread_mention_count."""
+
+    async def test_get_unread_mention_count(self, setup_test_db: Path) -> None:
+        """Count matches number of unread mentions."""
+        db = setup_test_db
+        cid1 = await _add_comment(db, "Hey @alice first", username="bob")
+        await _add_comment(db, "Hey @alice second", username="charlie")
+
+        with patch.object(storage, "DB_PATH", db):
+            assert await storage.get_unread_mention_count("alice") == 2
+
+            await storage.mark_mentions_read("alice", [cid1])
+            assert await storage.get_unread_mention_count("alice") == 1
+
+    async def test_unread_count_includes_self(self, setup_test_db: Path) -> None:
+        """Self-mentions are counted."""
+        db = setup_test_db
+        await _add_comment(db, "I mention @alice myself", username="alice")
+        await _add_comment(db, "Hey @alice", username="bob")
+
+        with patch.object(storage, "DB_PATH", db):
+            assert await storage.get_unread_mention_count("alice") == 2
+
+
+# ===========================================================================
+# API endpoint tests
+# ===========================================================================
+
+
+class TestGetMentionsEndpoint:
+    """Tests for GET /api/users/mentions."""
+
+    async def test_get_mentions_endpoint(self, test_client, temp_db_path: Path) -> None:
+        """Authenticated user gets their mentions."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+            await _add_comment(temp_db_path, "Hey @testuser look", username="bob")
+
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["mentions"][0]["comment"] == "Hey @testuser look"
+        assert "unread_count" in data
+        test_client.cookies.clear()
+
+    async def test_get_mentions_requires_username(self, test_client) -> None:
+        """Request without cookie returns 401."""
+        response = test_client.get("/api/users/mentions")
+        assert response.status_code == 401
+
+
+class TestMarkReadEndpoint:
+    """Tests for POST /api/users/mentions/read."""
+
+    async def test_mark_read_endpoint(self, test_client, temp_db_path: Path) -> None:
+        """POST with valid comment_ids returns ok."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+            cid = await _add_comment(temp_db_path, "Hey @testuser", username="bob")
+
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": [cid]},
+        )
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        test_client.cookies.clear()
+
+    async def test_mark_read_rejects_empty_list(self, test_client) -> None:
+        """POST with empty comment_ids returns 400."""
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": []},
+        )
+        assert response.status_code == 400
+        test_client.cookies.clear()
+
+    async def test_mark_read_rejects_non_int(self, test_client) -> None:
+        """POST with non-integer comment_ids returns 400."""
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": ["abc"]},
+        )
+        assert response.status_code == 400
+        test_client.cookies.clear()
+
+    async def test_mark_read_requires_username(self, test_client) -> None:
+        """POST without auth returns 401."""
+        response = test_client.post(
+            "/api/users/mentions/read",
+            json={"comment_ids": [1]},
+        )
+        assert response.status_code == 401
+
+
+class TestUnreadCountEndpoint:
+    """Tests for GET /api/users/mentions/unread-count."""
+
+    async def test_unread_count_endpoint(self, test_client, temp_db_path: Path) -> None:
+        """Returns unread count for authenticated user."""
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            await storage.init_db()
+            await _add_comment(temp_db_path, "Hey @testuser", username="bob")
+
+        test_client.cookies.set("jji_username", "testuser")
+        response = test_client.get("/api/users/mentions/unread-count")
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        test_client.cookies.clear()
+
+    async def test_unread_count_requires_username(self, test_client) -> None:
+        """Request without auth returns 401."""
+        response = test_client.get("/api/users/mentions/unread-count")
+        assert response.status_code == 401


### PR DESCRIPTION
Closes #169

## Features

### Backend
- `GET /api/users/mentions` — paginated list of comments mentioning the user
- `POST /api/users/mentions/read` — mark mentions as read
- `GET /api/users/mentions/unread-count` — badge count for navbar
- `mention_reads` table for read/unread tracking
- Self-mentions supported (use as personal reminders)
- `jji mentions` CLI command with `--unread` and `--limit` flags

### Frontend
- **Mentions page** (`/mentions`) — shows all mentions with clear read/unread distinction
  - Unread: blue left border + highlighted background + bold author
  - Read: dimmed with reduced opacity
- **Nav badge** — unread count on "Mentions" link, polls every 30s + refreshes on tab focus
- **Deep-link navigation** — clicking a mention navigates to the report, auto-expands the failure card containing the comment, and scrolls to it with a highlight ring
- **Comment anchor IDs** — `id="comment-{id}"` on each comment element

### Tests
- 24 new tests covering storage, API endpoints, CLI client, and CLI commands

## Done

- [x] `GET /api/users/mentions` endpoint with pagination
- [x] Mentions page component (`/mentions`)
- [x] Nav link with unread badge
- [x] One-click navigation to the comment in the report
- [x] `jji mentions` CLI command
- [x] Read/unread tracking
- [x] Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mentions page with pagination, unread badges, expand/collapse previews, per-mention and “Mark all as read” actions, and navigation into comment threads.
  * Nav bar link with live unread badge (polling/visibility updates) and “99+” formatting.
  * Report pages support comment deep-linking via URL (auto-scroll + transient highlight).
  * CLI and API commands to list/filter mentions, mark specific mentions read, mark all read, and fetch unread count.

* **Tests**
  * Extensive unit and end-to-end tests covering storage, API, CLI, parsing, and unread/read behaviors.

* **Chores**
  * Ignore top-level node_modules in repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->