### PR TITLE
fix: clear all metadata filters including team, tier, version (#176)

### DIFF
--- a/frontend/src/components/shared/MetadataFilterBar.tsx
+++ b/frontend/src/components/shared/MetadataFilterBar.tsx
@@ -22,6 +22,7 @@ interface MetadataFilterBarProps {
   onTierChange: (value: string) => void
   onVersionChange: (value: string) => void
   onLabelsChange: (value: string[]) => void
+  onClearAll?: () => void
 }
 
 export function MetadataFilterBar({
@@ -33,6 +34,7 @@ export function MetadataFilterBar({
   onTierChange,
   onVersionChange,
   onLabelsChange,
+  onClearAll,
 }: MetadataFilterBarProps) {
   const [options, setOptions] = useState<{
     teams: string[]
@@ -68,11 +70,15 @@ export function MetadataFilterBar({
   const hasFilters = team || tier || version || labels.length > 0
 
   const clearAll = useCallback(() => {
-    onTeamChange('')
-    onTierChange('')
-    onVersionChange('')
-    onLabelsChange([])
-  }, [onTeamChange, onTierChange, onVersionChange, onLabelsChange])
+    if (onClearAll) {
+      onClearAll()
+    } else {
+      onTeamChange('')
+      onTierChange('')
+      onVersionChange('')
+      onLabelsChange([])
+    }
+  }, [onClearAll, onTeamChange, onTierChange, onVersionChange, onLabelsChange])
 
   const toggleLabel = useCallback((label: string) => {
     if (labels.includes(label)) {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -140,6 +140,16 @@ export function DashboardPage() {
       return next
     }, { replace: true })
   }, [setSearchParams])
+  const clearMetadataFilters = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.delete('team')
+      next.delete('tier')
+      next.delete('version')
+      next.delete('label')
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
   const hasMetadataFilters = !!(metaTeam || metaTier || metaVersion || metaLabels.length > 0)
   const setDateFrom = useCallback((value: string) => {
     setSearchParams((prev) => {
@@ -438,6 +448,7 @@ export function DashboardPage() {
           onTierChange={(v) => setMetaParam('tier', v)}
           onVersionChange={(v) => setMetaParam('version', v)}
           onLabelsChange={setMetaLabels}
+          onClearAll={clearMetadataFilters}
         />
 
         {/* Bulk result message */}

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -15,7 +15,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
   TableHeader,
   TableRow,
 } from '@/components/ui/table'


### PR DESCRIPTION
Closes #176

## Bug

The 'Clear filters' button on the dashboard only cleared labels but did not reset team, tier, or version dropdowns.

## Fix

Updated the clear handler to reset all filter state variables and clear all URL query params.

## Testing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the metadata filter bar's "Clear All" functionality to properly reset all applied filters (team, tier, version, and labels) while maintaining synchronization with the application's URL-based state, ensuring a consistent user experience when clearing multiple filter selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->