### PR TITLE
fix: add PyYAML to project dependencies (#175)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pydantic-settings",
   "python-jenkins",
   "python-multipart",
+  "pyyaml",
   "pywebpush",
   "python-simple-logger",
   "reportportal-client>=5.7.4",

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -2251,16 +2251,10 @@ def metadata_import(
     items: list[dict] = []
 
     if path.suffix.lower() in (".yaml", ".yml"):
-        try:
-            import yaml
+        import yaml
 
+        try:
             items = yaml.safe_load(content)
-        except ImportError:
-            typer.echo(
-                "Error: PyYAML is required for YAML files. Install with: pip install pyyaml",
-                err=True,
-            )
-            raise typer.Exit(code=1) from None
         except yaml.YAMLError as exc:
             typer.echo(f"Error: invalid YAML: {exc}", err=True)
             raise typer.Exit(code=1) from None


### PR DESCRIPTION
Closes #175

## Fix

- Added `pyyaml` to `pyproject.toml` dependencies
- Removed the try/except ImportError fallback in CLI since PyYAML is now always available

## Testing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added YAML parsing support as a required project dependency, ensuring all users have necessary YAML functionality available by default without additional installation steps.

* **Changes**
  * Updated CLI error handling for YAML operations to reflect the now-mandatory dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->