### PR TITLE
feat: add What's New popup on dashboard for feature updates (#172)

### DIFF
--- a/frontend/src/changelog.json
+++ b/frontend/src/changelog.json
@@ -1,0 +1,13 @@
+[
+  {
+    "version": "3.2.0",
+    "date": "2026-04-26",
+    "entries": [
+      { "title": "@Mentions & Notifications", "description": "Get notified when someone mentions you in a comment. View all your mentions in the new Mentions tab." },
+      { "title": "Filter jobs by metadata", "description": "Filter dashboard jobs by team, tier, version, and custom labels." },
+      { "title": "Force analysis on successful builds", "description": "Re-analyze passing builds to catch flaky tests." },
+      { "title": "Monitoring & alerting", "description": "Prometheus metrics, Slack and email alerts for server error spikes." },
+      { "title": "AI token usage dashboard", "description": "Admin dashboard showing AI token consumption per job and provider." }
+    ]
+  }
+]

--- a/frontend/src/components/shared/WhatsNewDialog.tsx
+++ b/frontend/src/components/shared/WhatsNewDialog.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Sparkles } from 'lucide-react'
+import changelog from '@/changelog.json'
+
+const LS_KEY = 'last_seen_changelog_version'
+
+function getLatestVersion(): string | null {
+  return changelog.length > 0 ? changelog[0].version : null
+}
+
+function shouldShow(): boolean {
+  const latest = getLatestVersion()
+  if (!latest) return false
+  const seen = localStorage.getItem(LS_KEY)
+  return seen !== latest
+}
+
+export function WhatsNewDialog() {
+  const [open, setOpen] = useState(false)
+  const [dontShowAgain, setDontShowAgain] = useState(false)
+
+  useEffect(() => {
+    if (shouldShow()) {
+      setOpen(true)
+    }
+  }, [])
+
+  function handleDismiss() {
+    if (dontShowAgain) {
+      const latest = getLatestVersion()
+      if (latest) {
+        localStorage.setItem(LS_KEY, latest)
+      }
+    }
+    setOpen(false)
+  }
+
+  if (changelog.length === 0) return null
+
+  const latest = changelog[0]
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-signal-blue" />
+            What&apos;s New
+          </DialogTitle>
+          <DialogDescription>
+            Version {latest.version} &mdash; {latest.date}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-3 py-2" role="list">
+          {latest.entries.map((entry) => (
+            <li key={entry.title} className="flex gap-3">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-signal-blue" />
+              <div>
+                <p className="text-sm font-medium text-text-primary">{entry.title}</p>
+                <p className="text-xs text-text-secondary">{entry.description}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter className="flex items-center justify-between sm:justify-between">
+          <label className="flex items-center gap-2 text-xs text-text-tertiary cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border-default accent-signal-blue"
+            />
+            Don&apos;t show again
+          </label>
+          <Button size="sm" onClick={handleDismiss}>
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/shared/WhatsNewDialog.tsx
+++ b/frontend/src/components/shared/WhatsNewDialog.tsx
@@ -64,7 +64,7 @@ export function WhatsNewDialog() {
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-signal-blue" />
+            <Sparkles aria-hidden="true" className="h-5 w-5 text-signal-blue" />
             What&apos;s New
           </DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/shared/WhatsNewDialog.tsx
+++ b/frontend/src/components/shared/WhatsNewDialog.tsx
@@ -13,8 +13,11 @@ import changelog from '@/changelog.json'
 
 const LS_KEY = 'jji_last_seen_changelog_version'
 
+/** Changelog sorted by date descending — robust to ordering in changelog.json */
+const sortedChangelog = [...changelog].sort((a, b) => b.date.localeCompare(a.date))
+
 function getLatestVersion(): string | null {
-  return changelog.length > 0 ? changelog[0].version : null
+  return sortedChangelog.length > 0 ? sortedChangelog[0].version : null
 }
 
 function shouldShow(): boolean {
@@ -52,9 +55,9 @@ export function WhatsNewDialog() {
     setOpen(false)
   }
 
-  if (changelog.length === 0) return null
+  if (sortedChangelog.length === 0) return null
 
-  const latest = changelog[0]
+  const latest = sortedChangelog[0]
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) handleDismiss() }}>

--- a/frontend/src/components/shared/WhatsNewDialog.tsx
+++ b/frontend/src/components/shared/WhatsNewDialog.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Sparkles } from 'lucide-react'
 import changelog from '@/changelog.json'
 
-const LS_KEY = 'last_seen_changelog_version'
+const LS_KEY = 'jji_last_seen_changelog_version'
 
 function getLatestVersion(): string | null {
   return changelog.length > 0 ? changelog[0].version : null
@@ -20,8 +20,12 @@ function getLatestVersion(): string | null {
 function shouldShow(): boolean {
   const latest = getLatestVersion()
   if (!latest) return false
-  const seen = localStorage.getItem(LS_KEY)
-  return seen !== latest
+  try {
+    const seen = localStorage.getItem(LS_KEY)
+    return seen !== latest
+  } catch {
+    return false
+  }
 }
 
 export function WhatsNewDialog() {
@@ -38,7 +42,11 @@ export function WhatsNewDialog() {
     if (dontShowAgain) {
       const latest = getLatestVersion()
       if (latest) {
-        localStorage.setItem(LS_KEY, latest)
+        try {
+          localStorage.setItem(LS_KEY, latest)
+        } catch {
+          // localStorage may be unavailable in private browsing
+        }
       }
     }
     setOpen(false)
@@ -62,8 +70,8 @@ export function WhatsNewDialog() {
         </DialogHeader>
 
         <ul className="space-y-3 py-2" role="list">
-          {latest.entries.map((entry) => (
-            <li key={entry.title} className="flex gap-3">
+          {latest.entries.map((entry, idx) => (
+            <li key={`${latest.version}-${idx}`} className="flex gap-3">
               <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-signal-blue" />
               <div>
                 <p className="text-sm font-medium text-text-primary">{entry.title}</p>

--- a/frontend/src/components/shared/__tests__/WhatsNewDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/WhatsNewDialog.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { WhatsNewDialog } from '../WhatsNewDialog'
 import changelog from '@/changelog.json'
 
-const LS_KEY = 'last_seen_changelog_version'
+const LS_KEY = 'jji_last_seen_changelog_version'
 
 describe('WhatsNewDialog', () => {
   beforeEach(() => {

--- a/frontend/src/components/shared/__tests__/WhatsNewDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/WhatsNewDialog.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WhatsNewDialog } from '../WhatsNewDialog'
+import changelog from '@/changelog.json'
+
+const LS_KEY = 'last_seen_changelog_version'
+
+describe('WhatsNewDialog', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows the dialog when no version has been seen', () => {
+    render(<WhatsNewDialog />)
+    expect(screen.getByText("What's New")).toBeInTheDocument()
+  })
+
+  it('lists all entries from the latest changelog version', () => {
+    render(<WhatsNewDialog />)
+    for (const entry of changelog[0].entries) {
+      expect(screen.getByText(entry.title)).toBeInTheDocument()
+    }
+  })
+
+  it('does not show the dialog when the latest version has already been seen', () => {
+    localStorage.setItem(LS_KEY, changelog[0].version)
+    render(<WhatsNewDialog />)
+    expect(screen.queryByText("What's New")).not.toBeInTheDocument()
+  })
+
+  it('shows again for a new version even if a previous version was dismissed', () => {
+    localStorage.setItem(LS_KEY, '0.0.1')
+    render(<WhatsNewDialog />)
+    expect(screen.getByText("What's New")).toBeInTheDocument()
+  })
+
+  it('dismisses without saving version when "Got it" is clicked without checkbox', async () => {
+    const user = userEvent.setup()
+    render(<WhatsNewDialog />)
+    await user.click(screen.getByRole('button', { name: /got it/i }))
+    expect(screen.queryByText("What's New")).not.toBeInTheDocument()
+    expect(localStorage.getItem(LS_KEY)).toBeNull()
+  })
+
+  it('saves the version to localStorage when "Don\'t show again" is checked before dismissing', async () => {
+    const user = userEvent.setup()
+    render(<WhatsNewDialog />)
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: /got it/i }))
+    expect(localStorage.getItem(LS_KEY)).toBe(changelog[0].version)
+  })
+})

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -40,6 +40,7 @@ import { useAuth } from '@/lib/auth'
 import { MetadataFilterBar } from '@/components/shared/MetadataFilterBar'
 import { MetadataBadges } from '@/components/shared/MetadataBadges'
 import { NotificationPrompt } from '@/components/shared/NotificationPrompt'
+import { WhatsNewDialog } from '@/components/shared/WhatsNewDialog'
 
 const STATUS_FILTER_ALL = 'ALL'
 const STATUS_FILTER_OPTIONS = [STATUS_FILTER_ALL, 'completed', 'running', 'waiting', 'pending', 'failed', 'timeout'] as const
@@ -713,6 +714,8 @@ export function DashboardPage() {
         />
 
         <NotificationPrompt />
+
+        <WhatsNewDialog />
       </div>
     </TooltipProvider>
   )

--- a/frontend/src/pages/report/ChildJobSection.tsx
+++ b/frontend/src/pages/report/ChildJobSection.tsx
@@ -26,7 +26,7 @@ export function ChildJobSection({ child, jobId, depth = 0, activeHash, parentHas
   const hashId = childJobHashId(child.job_name, child.build_number, parentHashId)
   const expandKey = `jji-expand-${jobId}-${hashId}`
   const sectionRef = useRef<HTMLDivElement>(null)
-  const [expanded, setExpanded] = useSessionState(expandKey, false)
+  const [expanded, setExpanded] = useSessionState<boolean>(expandKey, false)
 
   // Auto-expand and scroll when the URL hash targets this child job or any descendant
   useEffect(() => {

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -94,7 +94,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const { githubIssuesEnabled, jiraIssuesEnabled, serverJiraProjectKey, comments, reviews, aiConfigs, result, classifications } = useReportState()
   const dispatch = useReportDispatch()
   const expandKey = `jji-expand-${jobId}-${scopedChildJobName}-${scopedChildBuildNumber}-${group.id}`
-  const [expanded, setExpanded] = useSessionState(expandKey, false)
+  const [expanded, setExpanded] = useSessionState<boolean>(expandKey, false)
   const [bugTarget, setBugTarget] = useState<'github' | 'jira' | null>(null)
   const [reviewingAll, setReviewingAll] = useState(false)
   const [reviewAllError, setReviewAllError] = useState<string | null>(null)


### PR DESCRIPTION
Closes #172

## Features

- Changelog data source (`frontend/src/changelog.json`)
- WhatsNewDialog component with feature list
- Smart dismissal: stores `last_seen_changelog_version` in localStorage
- Popup reappears when new entries are added (version changes)
- "Don't show again" checkbox stores current version, not permanent flag
- Only shows on dashboard page load

## Testing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "What's New" dialog that auto-opens for new changelog versions, shows the latest release notes, and offers a "Don't show again" option.
  * Included changelog data for release 3.2.0 (five entries covering mentions & notifications, job filtering, re-analysis, monitoring, and an AI token admin dashboard).
* **Tests**
  * Added unit tests covering dialog display, dismissal, and "Don't show again" persistence.
* **Chores**
  * Integrated the dialog into the Dashboard and tightened some local state typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->