### PR TITLE
fix: prevent double-encoding of special characters in username cookie (#177)

### DIFF
--- a/frontend/src/lib/__tests__/cookies.test.ts
+++ b/frontend/src/lib/__tests__/cookies.test.ts
@@ -35,6 +35,21 @@ describe('cookies', () => {
     expect(getUsername()).toBe('user@example.com')
   })
 
+  it('handles usernames with + character', () => {
+    setUsername('user+tag@example.com')
+    expect(getUsername()).toBe('user+tag@example.com')
+    // No double-encoding on re-read/re-write
+    setUsername(getUsername())
+    expect(getUsername()).toBe('user+tag@example.com')
+  })
+
+  it('handles usernames with spaces', () => {
+    setUsername('John Doe')
+    expect(getUsername()).toBe('John Doe')
+    setUsername(getUsername())
+    expect(getUsername()).toBe('John Doe')
+  })
+
   it('rejects already-encoded usernames', () => {
     expect(() => setUsername('user%40example.com')).toThrow(/looks URL-encoded/)
     expect(() => setUsername('user%2540example.com')).toThrow(/looks URL-encoded/)

--- a/frontend/src/lib/__tests__/cookies.test.ts
+++ b/frontend/src/lib/__tests__/cookies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getUsername, setUsername, isLoggedIn, getGithubToken, setGithubToken, getJiraToken, setJiraToken, getJiraEmail, setJiraEmail, clearTokens } from '../cookies'
+import { getUsername, setUsername, isLoggedIn, getGithubToken, setGithubToken, getJiraToken, setJiraToken, getJiraEmail, setJiraEmail, clearTokens, looksUrlEncoded } from '../cookies'
 
 describe('cookies', () => {
   beforeEach(() => {
@@ -24,6 +24,36 @@ describe('cookies', () => {
   it('setUsername trims whitespace', () => {
     setUsername('  padded  ')
     expect(getUsername()).toBe('padded')
+  })
+
+  it('handles usernames with special characters without double-encoding', () => {
+    setUsername('user@example.com')
+    expect(getUsername()).toBe('user@example.com')
+    // Writing the same value again should not mutate it
+    const readBack = getUsername()
+    setUsername(readBack)
+    expect(getUsername()).toBe('user@example.com')
+  })
+
+  it('rejects already-encoded usernames', () => {
+    expect(() => setUsername('user%40example.com')).toThrow(/looks URL-encoded/)
+    expect(() => setUsername('user%2540example.com')).toThrow(/looks URL-encoded/)
+    expect(() => setUsername('hello%25world')).toThrow(/looks URL-encoded/)
+  })
+
+  describe('looksUrlEncoded', () => {
+    it('returns true for percent-encoded strings', () => {
+      expect(looksUrlEncoded('%40')).toBe(true)
+      expect(looksUrlEncoded('user%40domain')).toBe(true)
+      expect(looksUrlEncoded('%25')).toBe(true)
+      expect(looksUrlEncoded('%2540')).toBe(true)
+    })
+
+    it('returns false for normal strings', () => {
+      expect(looksUrlEncoded('hello')).toBe(false)
+      expect(looksUrlEncoded('user@domain.com')).toBe(false)
+      expect(looksUrlEncoded('')).toBe(false)
+    })
   })
 
   it('isLoggedIn returns false when no cookie', () => {

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -7,16 +7,26 @@ const JIRA_EMAIL_KEY = 'jji_jira_email'
 const ADMIN_KEY = 'jji_is_admin'
 const ROLE_KEY = 'jji_role'
 
+/** Detects values that look like they've been URL-encoded (e.g. %40, %25). */
+const ENCODED_PATTERN = /%[0-9A-Fa-f]{2}/
+
+export function looksUrlEncoded(value: string): boolean {
+  return ENCODED_PATTERN.test(value)
+}
+
 export function getUsername(): string {
   const match = document.cookie.match(
     new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]*)`)
   )
-  return match ? decodeURIComponent(match[1]) : ''
+  return match ? match[1] : ''
 }
 
 export function setUsername(username: string): void {
-  const encoded = encodeURIComponent(username.trim())
-  document.cookie = `${COOKIE_NAME}=${encoded}; path=/; max-age=${365 * 24 * 60 * 60}; SameSite=Lax`
+  const trimmed = username.trim()
+  if (looksUrlEncoded(trimmed)) {
+    throw new Error(`Username "${trimmed}" looks URL-encoded. Use the raw value.`)
+  }
+  document.cookie = `${COOKIE_NAME}=${trimmed}; path=/; max-age=${365 * 24 * 60 * 60}; SameSite=Lax`
 }
 
 export function clearUsername(): void {

--- a/frontend/src/lib/cookies.ts
+++ b/frontend/src/lib/cookies.ts
@@ -10,6 +10,16 @@ const ROLE_KEY = 'jji_role'
 /** Detects values that look like they've been URL-encoded (e.g. %40, %25). */
 const ENCODED_PATTERN = /%[0-9A-Fa-f]{2}/
 
+/**
+ * RFC 6265 cookie-octet invalid characters:
+ * CTL (0x00-0x1F, 0x7F), SP (0x20), DQUOTE (0x22), comma (0x2C),
+ * semicolon (0x3B), backslash (0x5C).
+ *
+ * Note: @ (0x40) and + (0x2B) are valid cookie-octet characters,
+ * so email-style usernames like user@example.com need no encoding.
+ */
+const RFC6265_INVALID = /[\x00-\x1f\x7f\x20",;\\]/g
+
 export function looksUrlEncoded(value: string): boolean {
   return ENCODED_PATTERN.test(value)
 }
@@ -18,7 +28,12 @@ export function getUsername(): string {
   const match = document.cookie.match(
     new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]*)`)
   )
-  return match ? match[1] : ''
+  if (!match) return ''
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
 }
 
 export function setUsername(username: string): void {
@@ -26,7 +41,11 @@ export function setUsername(username: string): void {
   if (looksUrlEncoded(trimmed)) {
     throw new Error(`Username "${trimmed}" looks URL-encoded. Use the raw value.`)
   }
-  document.cookie = `${COOKIE_NAME}=${trimmed}; path=/; max-age=${365 * 24 * 60 * 60}; SameSite=Lax`
+  // Percent-encode only RFC 6265 invalid characters for safe cookie storage
+  const safe = trimmed.replace(RFC6265_INVALID, (ch) =>
+    `%${ch.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()}`
+  )
+  document.cookie = `${COOKIE_NAME}=${safe}; path=/; max-age=${365 * 24 * 60 * 60}; SameSite=Lax`
 }
 
 export function clearUsername(): void {


### PR DESCRIPTION
Closes #177

## Bug

Usernames with special characters (e.g., `@` in email addresses) got URL-encoded repeatedly on each page visit, creating cascading duplicate user entries.

## Fix

- Fixed cookie read/write to store raw username without encoding
- Added validation to reject already-encoded usernames

## Testing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username cookie handling: preserves raw values when decoding fails and avoids unintended double-encoding.
  * Added validation to reject percent-encoded usernames, preventing storage/round-trip errors.

* **Tests**
  * Expanded coverage for usernames with special characters (e.g., `@`, `+`, spaces).
  * Added tests for URL-encoding detection to verify encoded vs. unencoded inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->