### PR TITLE
feat: auto-identify users from OAuth proxy X-Forwarded-User header (#173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,40 @@ Subscribe/unsubscribe is browser-only (managed via the web UI). To list users av
 jji mentionable-users
 ```
 
+## OAuth Proxy / SSO Integration
+
+When deployed behind an OAuth proxy (e.g., OpenShift `oauth-proxy`), JJI can automatically identify users from the `X-Forwarded-User` header set by the proxy, eliminating the need for manual registration.
+
+### Configuration
+
+Set the following environment variable on the JJI server:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUST_PROXY_HEADERS` | `false` | Trust `X-Forwarded-User` header for user identification |
+
+> **Security:** Only enable `TRUST_PROXY_HEADERS` when JJI is behind a trusted reverse proxy that sets the `X-Forwarded-User` header. If enabled without a proxy, any client can spoof the header.
+
+### Behavior
+
+When `TRUST_PROXY_HEADERS=true` and `X-Forwarded-User` is present:
+
+1. The header value is used as the JJI username
+2. A `jji_username` cookie is automatically set so all downstream code works unchanged
+3. The `/register` page redirects to the dashboard (no manual registration needed)
+4. Admin sessions and Bearer tokens still take precedence over the header
+
+When the header is absent, the standard cookie-based registration flow is used (backward compatible).
+
+### Example: OpenShift OAuth Proxy
+
+```yaml
+# In your Deployment, add the oauth-proxy sidecar:
+env:
+  - name: TRUST_PROXY_HEADERS
+    value: "true"
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ When the header is absent, the standard cookie-based registration flow is used (
 ### Example: OpenShift OAuth Proxy
 
 ```yaml
-# In your Deployment, add the oauth-proxy sidecar:
+# In your Deployment, add to the JJI app container (not the oauth-proxy sidecar):
 env:
   - name: TRUST_PROXY_HEADERS
     value: "true"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ProfileForm } from '@/components/shared/ProfileForm'
 import { useAuth } from '@/lib/auth'
+import { getUsername } from '@/lib/cookies'
 
 export function RegisterPage() {
   const navigate = useNavigate()
   const { login, refreshAuth } = useAuth()
+
+  // Auto-redirect if user is already identified (e.g., via SSO proxy cookie)
+  useEffect(() => {
+    if (getUsername()) {
+      navigate('/', { replace: true })
+    }
+  }, [navigate])
 
   return (
     <div className="relative flex min-h-screen items-center justify-center bg-surface-page overflow-hidden">

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -233,6 +233,11 @@ class Settings(BaseSettings):
     )  # JJI_ADMIN_KEY — bootstraps admin superuser
     secure_cookies: bool = True  # Set to False for local HTTP dev
 
+    # Trust reverse-proxy headers (e.g., X-Forwarded-User from OAuth proxy).
+    # When enabled, auto-identifies users from the X-Forwarded-User header.
+    # Only enable behind a trusted reverse proxy (e.g., OpenShift oauth-proxy).
+    trust_proxy_headers: bool = False
+
     # Trusted public base URL — used for result_url and tracker links.
     # When set, _extract_base_url() returns this value verbatim.
     # When unset, _extract_base_url() returns an empty string (relative

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -632,6 +632,18 @@ class ErrorTrackingMiddleware(BaseHTTPMiddleware):
         return response
 
 
+def _set_username_cookie(response: Response, username: str, *, secure: bool) -> None:
+    """Set the jji_username cookie with consistent attributes."""
+    response.set_cookie(
+        "jji_username",
+        username,
+        path="/",
+        max_age=365 * 24 * 60 * 60,
+        samesite="lax",
+        secure=secure,
+    )
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Authenticate requests: admin via session/Bearer, regular users via cookie."""
 
@@ -671,25 +683,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
             proxy_username = request.headers.get("x-forwarded-user", "").strip()
 
         if path.startswith("/register"):
-            # Session auth takes precedence over X-Forwarded-User
-            session_token = request.cookies.get("jji_session")
-            has_session = False
-            if session_token:
-                session = await storage.get_session(session_token)
-                if session:
-                    has_session = True
-
-            if proxy_username and proxy_username.lower() != "admin" and not has_session:
+            if proxy_username and proxy_username.lower() != "admin":
+                # Session auth takes precedence over X-Forwarded-User —
+                # only check when an SSO redirect would otherwise fire.
+                session_token = request.cookies.get("jji_session")
+                if session_token and await storage.get_session(session_token):
+                    return await call_next(request)
                 # SSO user hitting /register — redirect to dashboard
                 response = RedirectResponse(url="/", status_code=303)
                 if request.cookies.get("jji_username", "") != proxy_username:
-                    response.set_cookie(
-                        "jji_username",
-                        proxy_username,
-                        path="/",
-                        max_age=365 * 24 * 60 * 60,
-                        samesite="lax",
-                        secure=settings.secure_cookies,
+                    _set_username_cookie(
+                        response, proxy_username, secure=settings.secure_cookies
                     )
                 return response
             return await call_next(request)
@@ -791,13 +795,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if getattr(request.state, "set_proxy_cookie", None):
             proxy_cookie_value = request.state.set_proxy_cookie
             if request.cookies.get("jji_username", "") != proxy_cookie_value:
-                response.set_cookie(
-                    "jji_username",
-                    proxy_cookie_value,
-                    path="/",
-                    max_age=365 * 24 * 60 * 60,
-                    samesite="lax",
-                    secure=settings.secure_cookies,
+                _set_username_cookie(
+                    response, proxy_cookie_value, secure=settings.secure_cookies
                 )
 
         # Refresh session cookie max_age if session was renewed

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -682,14 +682,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if proxy_username and proxy_username.lower() != "admin" and not has_session:
                 # SSO user hitting /register — redirect to dashboard
                 response = RedirectResponse(url="/", status_code=303)
-                response.set_cookie(
-                    "jji_username",
-                    proxy_username,
-                    path="/",
-                    max_age=365 * 24 * 60 * 60,
-                    samesite="lax",
-                    secure=settings.secure_cookies,
-                )
+                if request.cookies.get("jji_username", "") != proxy_username:
+                    response.set_cookie(
+                        "jji_username",
+                        proxy_username,
+                        path="/",
+                        max_age=365 * 24 * 60 * 60,
+                        samesite="lax",
+                        secure=settings.secure_cookies,
+                    )
                 return response
             return await call_next(request)
 
@@ -788,14 +789,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # Set jji_username cookie from X-Forwarded-User header (SSO)
         if getattr(request.state, "set_proxy_cookie", None):
-            response.set_cookie(
-                "jji_username",
-                request.state.set_proxy_cookie,
-                path="/",
-                max_age=365 * 24 * 60 * 60,
-                samesite="lax",
-                secure=settings.secure_cookies,
-            )
+            proxy_cookie_value = request.state.set_proxy_cookie
+            if request.cookies.get("jji_username", "") != proxy_cookie_value:
+                response.set_cookie(
+                    "jji_username",
+                    proxy_cookie_value,
+                    path="/",
+                    max_age=365 * 24 * 60 * 60,
+                    samesite="lax",
+                    secure=settings.secure_cookies,
+                )
 
         # Refresh session cookie max_age if session was renewed
         if getattr(request.state, "renew_session_token", None):

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -672,7 +672,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
             proxy_username = request.headers.get("x-forwarded-user", "").strip()
 
         if path.startswith("/register"):
-            if proxy_username:
+            # Session auth takes precedence over X-Forwarded-User
+            session_token = request.cookies.get("jji_session")
+            has_session = False
+            if session_token:
+                session = await storage.get_session(session_token)
+                if session:
+                    has_session = True
+
+            if proxy_username and not has_session:
                 # SSO user hitting /register — redirect to dashboard
                 response = RedirectResponse(url="/", status_code=303)
                 response.set_cookie(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -655,11 +655,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request.state.role = "user"
 
         # Public paths and static assets — pass through
-        # (but /register may need SSO redirect, handled below)
-        if (
-            path.startswith("/assets/")
-            or path in self._PUBLIC_PATHS
-            and not path.startswith("/register")
+        # (but /register may need SSO redirect, handled below;
+        #  it stays in _PUBLIC_PATHS for non-SSO users who need the page)
+        if path.startswith("/assets/") or (
+            path in self._PUBLIC_PATHS and path != "/register"
         ):
             return await call_next(request)
 
@@ -680,7 +679,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 if session:
                     has_session = True
 
-            if proxy_username and not has_session:
+            if proxy_username and proxy_username.lower() != "admin" and not has_session:
                 # SSO user hitting /register — redirect to dashboard
                 response = RedirectResponse(url="/", status_code=303)
                 response.set_cookie(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -655,14 +655,37 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request.state.role = "user"
 
         # Public paths and static assets — pass through
+        # (but /register may need SSO redirect, handled below)
         if (
-            path in self._PUBLIC_PATHS
-            or path.startswith("/assets/")
-            or path.startswith("/register")
+            path.startswith("/assets/")
+            or path in self._PUBLIC_PATHS
+            and not path.startswith("/register")
         ):
             return await call_next(request)
 
         settings = get_settings()
+
+        # SSO: when trust_proxy_headers is enabled and X-Forwarded-User is
+        # present, auto-identify the user and redirect /register → /
+        proxy_username = ""
+        if settings.trust_proxy_headers:
+            proxy_username = request.headers.get("x-forwarded-user", "").strip()
+
+        if path.startswith("/register"):
+            if proxy_username:
+                # SSO user hitting /register — redirect to dashboard
+                response = RedirectResponse(url="/", status_code=303)
+                response.set_cookie(
+                    "jji_username",
+                    proxy_username,
+                    path="/",
+                    max_age=365 * 24 * 60 * 60,
+                    samesite="lax",
+                    secure=settings.secure_cookies,
+                )
+                return response
+            return await call_next(request)
+
         is_admin = False
         username = ""
         authenticated_admin = False
@@ -716,7 +739,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         username = str(user["username"])
                         authenticated_admin = True
 
-        # 3. Fall back to jji_username cookie (regular users)
+        # 3. Check X-Forwarded-User header (SSO via trusted proxy)
+        if not username and proxy_username:
+            if proxy_username.lower() != "admin":
+                username = proxy_username
+                # Flag that we need to set the jji_username cookie on the response
+                request.state.set_proxy_cookie = proxy_username
+
+        # 4. Fall back to jji_username cookie (regular users)
         if not username:
             cookie_username = request.cookies.get("jji_username", "")
             if cookie_username.lower() == "admin":
@@ -748,6 +778,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return RedirectResponse(url="/register", status_code=303)
 
         response = await call_next(request)
+
+        # Set jji_username cookie from X-Forwarded-User header (SSO)
+        if getattr(request.state, "set_proxy_cookie", None):
+            response.set_cookie(
+                "jji_username",
+                request.state.set_proxy_cookie,
+                path="/",
+                max_age=365 * 24 * 60 * 60,
+                samesite="lax",
+                secure=settings.secure_cookies,
+            )
 
         # Refresh session cookie max_age if session was renewed
         if getattr(request.state, "renew_session_token", None):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -878,3 +878,128 @@ class TestSessionRenewalMiddleware:
                 assert row[0] == "2000-01-01 00:00:00"
 
         asyncio.run(check_still_expired())
+
+
+class TestProxyHeaders:
+    """Tests for X-Forwarded-User header handling via TRUST_PROXY_HEADERS."""
+
+    @pytest.fixture
+    def proxy_client(self, _init_db, temp_db_path):
+        """Create a test client with TRUST_PROXY_HEADERS enabled."""
+        with patch.dict(
+            os.environ,
+            {
+                "ADMIN_KEY": "test-admin-key-16chars",  # pragma: allowlist secret
+                "JJI_ENCRYPTION_KEY": "test-encryption-key-for-hmac",  # pragma: allowlist secret
+                "SECURE_COOKIES": "false",
+                "DB_PATH": str(temp_db_path),
+                "TRUST_PROXY_HEADERS": "true",
+            },
+        ):
+            get_settings.cache_clear()
+            with patch.object(storage, "DB_PATH", temp_db_path):
+                from jenkins_job_insight.main import app
+
+                with TestClient(app) as c:
+                    yield c
+            get_settings.cache_clear()
+
+    def test_header_ignored_when_disabled(self, client):
+        """X-Forwarded-User is ignored when TRUST_PROXY_HEADERS is false (default)."""
+        resp = client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "sso-user"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Without cookie or session, username should be empty
+        assert data["username"] == ""
+        assert data["is_admin"] is False
+
+    def test_header_sets_username_when_enabled(self, proxy_client):
+        """X-Forwarded-User sets username when TRUST_PROXY_HEADERS is true."""
+        resp = proxy_client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "sso-user"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "sso-user"
+        assert data["is_admin"] is False
+        assert data["role"] == "user"
+
+    def test_header_sets_cookie(self, proxy_client):
+        """X-Forwarded-User sets jji_username cookie on the response."""
+        resp = proxy_client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "sso-user"},
+        )
+        assert resp.status_code == 200
+        assert resp.cookies.get("jji_username") == "sso-user"
+
+    def test_cookie_flow_works_without_header(self, proxy_client):
+        """Existing cookie-based flow still works when header is absent."""
+        resp = proxy_client.get(
+            "/api/auth/me",
+            cookies={"jji_username": "cookie-user"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "cookie-user"
+        # No proxy cookie should be set when using regular cookie flow
+        assert "jji_username" not in resp.cookies
+
+    def test_header_admin_reserved(self, proxy_client):
+        """X-Forwarded-User with 'admin' is rejected (reserved username)."""
+        resp = proxy_client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "admin"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == ""
+        assert data["is_admin"] is False
+
+    def test_register_redirects_for_sso_user(self, proxy_client):
+        """SSO user hitting /register is redirected to dashboard."""
+        resp = proxy_client.get(
+            "/register",
+            headers={"X-Forwarded-User": "sso-user"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/"
+        assert resp.cookies.get("jji_username") == "sso-user"
+
+    def test_register_no_redirect_without_header(self, proxy_client):
+        """Non-SSO user can access /register normally (no SSO redirect)."""
+        resp = proxy_client.get(
+            "/register",
+            follow_redirects=False,
+        )
+        # Should NOT redirect — either 200 (SPA served) or 404 (no frontend build)
+        assert resp.status_code != 303
+
+    def test_session_auth_takes_precedence_over_header(self, proxy_client):
+        """Admin session takes precedence over X-Forwarded-User."""
+        cookies = _admin_login(proxy_client)
+        resp = proxy_client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "sso-user"},
+            cookies=cookies,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "admin"
+        assert data["is_admin"] is True
+
+    def test_empty_header_ignored(self, proxy_client):
+        """Empty X-Forwarded-User header is treated as absent."""
+        resp = proxy_client.get(
+            "/api/auth/me",
+            headers={"X-Forwarded-User": "  "},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == ""
+        assert "jji_username" not in resp.cookies

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -993,6 +993,20 @@ class TestProxyHeaders:
         assert data["username"] == "admin"
         assert data["is_admin"] is True
 
+    def test_register_session_takes_precedence_over_header(self, proxy_client):
+        """Session auth takes precedence over X-Forwarded-User on /register."""
+        cookies = _admin_login(proxy_client)
+        resp = proxy_client.get(
+            "/register",
+            headers={"X-Forwarded-User": "header_user"},
+            cookies=cookies,
+            follow_redirects=False,
+        )
+        # Should NOT redirect (session user is already authenticated)
+        assert resp.status_code != 303
+        # The jji_username cookie should NOT be overwritten with header_user
+        assert resp.cookies.get("jji_username") != "header_user"
+
     def test_empty_header_ignored(self, proxy_client):
         """Empty X-Forwarded-User header is treated as absent."""
         resp = proxy_client.get(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -971,6 +971,17 @@ class TestProxyHeaders:
         assert resp.headers["location"] == "/"
         assert resp.cookies.get("jji_username") == "sso-user"
 
+    def test_register_admin_no_redirect(self, proxy_client):
+        """SSO user 'admin' hitting /register must NOT redirect (prevents loop)."""
+        for name in ("admin", "Admin", "ADMIN"):
+            resp = proxy_client.get(
+                "/register",
+                headers={"X-Forwarded-User": name},
+                follow_redirects=False,
+            )
+            assert resp.status_code != 303, f"admin variant '{name}' caused redirect"
+            assert resp.cookies.get("jji_username") is None
+
     def test_register_no_redirect_without_header(self, proxy_client):
         """Non-SSO user can access /register normally (no SSO redirect)."""
         resp = proxy_client.get(


### PR DESCRIPTION
Closes #173

## Features

- `TRUST_PROXY_HEADERS` config option (default: `false`)
- When enabled, reads `X-Forwarded-User` header and auto-sets `jji_username` cookie
- Skips/redirects registration page for SSO-identified users
- Backward compatible — no behavior change when disabled
- Tests for both SSO and non-SSO flows
- README documentation

## Security

- Header only trusted when `TRUST_PROXY_HEADERS=true` is explicitly set
- Assumes trusted reverse proxy (OAuth proxy sidecar)

## Testing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OAuth proxy/SSO support: auto-identify users from reverse-proxy identity headers, set a compatibility username cookie, and redirect SSO-identified users away from registration to the dashboard.

* **Configuration**
  * New toggle to enable trusting proxy-provided authentication headers; admin sessions and bearer tokens continue to take precedence.

* **Documentation**
  * README updated with setup steps, security guidance, and a sample proxy configuration.

* **Tests**
  * New tests validating proxy-header SSO behavior, redirects, precedence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->