### PR TITLE
feat: make max concurrent AI CLI calls configurable (#185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ Key patterns:
 - **User identification**: Cookie-based (`jji_username`), read/written client-side; display-only, not an authentication/authorization boundary
 - **Grouping**: `lib/grouping.ts` ports Python's `_grouping_key()` to TypeScript
 
+### Auto-Generated Documentation
+
+The `docs/` directory is **auto-generated** by [docsfy](https://github.com/myk-org/docsfy) and served via GitHub Pages. **NEVER edit files in `docs/` manually** — all changes will be overwritten on the next generation. To update documentation, either:
+- Update the source code and regenerate with docsfy
+- Update `AGENTS.md` or `README.md` for project-level documentation
+
 ### AI Tool Access (IMPORTANT)
 
 Never pre-feed data to the AI in the prompt. Instead, give the AI tools (API endpoints, scripts, commands) and let it decide what data it needs and extract it itself.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ docker run -d -p 8000:8000 -v ./data:/data \
 |----------|---------|-------------|
 | `MAX_CONCURRENT_AI_CALLS` | `3` | Maximum concurrent AI CLI processes. Prevents OOM with heavy models. |
 
+`MAX_CONCURRENT_AI_CALLS` can be set via any of the supported interfaces:
+- Environment variable: `MAX_CONCURRENT_AI_CALLS`
+- API request field: `max_concurrent_ai_calls`
+- CLI flag: `--max-concurrent`
+- Config file (`~/.config/jji/config.toml`): `max_concurrent_ai_calls`
+
 ## Features
 
 - **AI-Powered Failure Analysis** — Classifies test failures as code issues or product bugs

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ docker run -d -p 8000:8000 -v ./data:/data \
 - CLI flag: `--max-concurrent`
 - Config file (`~/.config/jji/config.toml`): `max_concurrent_ai_calls`
 
+Example API override:
+```bash
+curl -X POST http://localhost:8000/analyze \
+  -H "Content-Type: application/json" \
+  -d '{"job_name": "my-job", "build_number": 42, "max_concurrent_ai_calls": 2}'
+```
+
 ## Features
 
 - **AI-Powered Failure Analysis** — Classifies test failures as code issues or product bugs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker run -d -p 8000:8000 -v ./data:/data \
 - Config file (`~/.config/jji/config.toml`): `max_concurrent_ai_calls`
 
 Example API override:
+
 ```bash
 curl -X POST http://localhost:8000/analyze \
   -H "Content-Type: application/json" \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ docker run -d -p 8000:8000 -v ./data:/data \
   ghcr.io/myk-org/jenkins-job-insight:latest
 ```
 
+### Analysis Tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_CONCURRENT_AI_CALLS` | `3` | Maximum concurrent AI CLI processes. Prevents OOM with heavy models. |
+
 ## Features
 
 - **AI-Powered Failure Analysis** — Classifies test failures as code issues or product bugs

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1143,8 +1143,9 @@ async def analyze_failure_group(
 ) -> list[FailureAnalysis]:
     """Analyze a group of failures with the same error signature.
 
-    Only calls Claude CLI once for the group, then applies the analysis
-    to all failures in the group.
+    Uses a single AI call for the group (or multi-AI peer consensus
+    when peers are configured), then applies the analysis to all
+    failures in the group.
 
     Args:
         failures: List of test failures with the same error signature.
@@ -1836,6 +1837,7 @@ async def analyze_job(
                             if total_groups > 1
                             else "",
                             additional_repos=cloned_repos or None,
+                            max_concurrent_ai_calls=settings.max_concurrent_ai_calls,
                         )
                     )
                 group_results = await run_parallel_with_limit(

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1237,6 +1237,7 @@ async def analyze_child_job(
     peer_ai_configs: list | None = None,
     peer_analysis_max_rounds: int = 3,
     additional_repos: dict[str, Path] | None = None,
+    max_concurrent_ai_calls: int = 3,
 ) -> ChildJobAnalysis:
     """Analyze a single child job, recursively analyzing its failed children.
 
@@ -1328,10 +1329,13 @@ async def analyze_child_job(
                 peer_ai_configs=peer_ai_configs,
                 peer_analysis_max_rounds=peer_analysis_max_rounds,
                 additional_repos=additional_repos,
+                max_concurrent_ai_calls=max_concurrent_ai_calls,
             )
             for child_name, child_num in failed_children
         ]
-        child_results = await run_parallel_with_limit(child_tasks)
+        child_results = await run_parallel_with_limit(
+            child_tasks, max_concurrency=max_concurrent_ai_calls
+        )
 
         # Handle exceptions in results
         child_analyses = []
@@ -1415,7 +1419,9 @@ async def analyze_child_job(
                     additional_repos=additional_repos,
                 )
             )
-        group_results = await run_parallel_with_limit(tasks)
+        group_results = await run_parallel_with_limit(
+            tasks, max_concurrency=max_concurrent_ai_calls
+        )
 
         # Flatten results and handle exceptions
         failures = []
@@ -1722,10 +1728,13 @@ async def analyze_job(
                         peer_ai_configs=peer_ai_configs,
                         peer_analysis_max_rounds=peer_analysis_max_rounds,
                         additional_repos=cloned_repos or None,
+                        max_concurrent_ai_calls=settings.max_concurrent_ai_calls,
                     )
                     for child_name, child_num in failed_child_jobs
                 ]
-                child_results = await run_parallel_with_limit(child_tasks)
+                child_results = await run_parallel_with_limit(
+                    child_tasks, max_concurrency=settings.max_concurrent_ai_calls
+                )
 
                 # Handle exceptions in results
                 for i, result in enumerate(child_results):
@@ -1819,7 +1828,9 @@ async def analyze_job(
                             additional_repos=cloned_repos or None,
                         )
                     )
-                group_results = await run_parallel_with_limit(failure_tasks)
+                group_results = await run_parallel_with_limit(
+                    failure_tasks, max_concurrency=settings.max_concurrent_ai_calls
+                )
 
                 # Flatten results and handle exceptions
                 failures = []

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1139,6 +1139,7 @@ async def analyze_failure_group(
     peer_analysis_max_rounds: int = 3,
     group_label: str = "",
     additional_repos: dict[str, Path] | None = None,
+    max_concurrent_ai_calls: int = 3,
 ) -> list[FailureAnalysis]:
     """Analyze a group of failures with the same error signature.
 
@@ -1159,6 +1160,9 @@ async def analyze_failure_group(
         group_label: Human-readable label identifying which failure group is
             being analyzed (e.g. ``"2/3"``). Forwarded to peer analysis for
             progress phase disambiguation.
+        additional_repos: Extra cloned repositories for AI context.
+        max_concurrent_ai_calls: Maximum concurrent AI CLI processes for
+            peer analysis parallelism (default: 3).
 
     Returns:
         List of FailureAnalysis objects, one per failure in the group.
@@ -1189,6 +1193,7 @@ async def analyze_failure_group(
             job_id=job_id,
             group_label=group_label,
             additional_repos=additional_repos,
+            max_concurrent_ai_calls=max_concurrent_ai_calls,
         )
 
     parsed, error_signature = await _run_single_ai_analysis(
@@ -1258,6 +1263,10 @@ async def analyze_child_job(
         artifacts_context: Jenkins artifacts context for AI analysis (optional).
         server_url: Base URL of this server for AI history API access.
         job_id: Current job ID to exclude from history queries.
+        peer_ai_configs: Peer AI configurations for multi-AI consensus analysis.
+        peer_analysis_max_rounds: Maximum debate rounds for peer analysis (default: 3).
+        additional_repos: Extra cloned repositories for AI context.
+        max_concurrent_ai_calls: Maximum concurrent AI CLI processes (default: 3).
 
     Returns:
         ChildJobAnalysis with analysis results or nested child analyses.
@@ -1417,6 +1426,7 @@ async def analyze_child_job(
                     if total_groups > 1
                     else "",
                     additional_repos=additional_repos,
+                    max_concurrent_ai_calls=max_concurrent_ai_calls,
                 )
             )
         group_results = await run_parallel_with_limit(

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -34,6 +34,7 @@ class ServerConfig:
     ai_provider: str = ""
     ai_model: str = ""
     ai_cli_timeout: int = 0  # 0 means use server default
+    max_concurrent_ai_calls: int = 0  # 0 means use server default
     # Jira
     jira_url: str = ""
     jira_email: str = ""
@@ -222,6 +223,9 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         ai_provider=data.get("ai_provider", ""),
         ai_model=data.get("ai_model", ""),
         ai_cli_timeout=data.get("ai_cli_timeout", 0),
+        max_concurrent_ai_calls=_validated_non_negative_int(
+            data, "max_concurrent_ai_calls"
+        ),
         # Peer analysis
         peers=_validated_str(data, "peers"),
         peer_analysis_max_rounds=_validated_int(data, "peer_analysis_max_rounds"),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -679,7 +679,7 @@ def analyze(
     max_concurrent: int = typer.Option(
         0,
         "--max-concurrent",
-        help="Max concurrent AI CLI calls (0 = use server default).",
+        help="Max concurrent AI CLI calls (0 = no CLI override; config or server default will be used).",
     ),
     json_output: bool = _JSON_OPTION,
 ):

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -676,6 +676,11 @@ def analyze(
         "--force/--no-force",
         help="Force analysis even if the build succeeded.",
     ),
+    max_concurrent: int = typer.Option(
+        0,
+        "--max-concurrent",
+        help="Max concurrent AI CLI calls (0 = use server default).",
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Submit a Jenkins job for analysis."""
@@ -695,6 +700,9 @@ def analyze(
             raise typer.Exit(1)
     if max_wait is not None and max_wait < 0:
         typer.echo("Error: --max-wait must be non-negative.", err=True)
+        raise typer.Exit(1)
+    if max_concurrent < 0:
+        typer.echo("Error: --max-concurrent must be non-negative.", err=True)
         raise typer.Exit(1)
 
     # Start from config defaults (lowest priority), then overlay CLI flags.
@@ -724,6 +732,7 @@ def analyze(
         # the dataclass default (0 = "use server default" for all these fields).
         _cfg_int_fields = {
             "ai_cli_timeout": cfg.ai_cli_timeout,
+            "max_concurrent_ai_calls": cfg.max_concurrent_ai_calls,
             "jira_max_results": cfg.jira_max_results,
             "jenkins_timeout": cfg.jenkins_timeout,
             "poll_interval_minutes": cfg.poll_interval_minutes,
@@ -731,6 +740,7 @@ def analyze(
         }
         _cfg_int_defaults = {
             "ai_cli_timeout": ServerConfig.ai_cli_timeout,
+            "max_concurrent_ai_calls": ServerConfig.max_concurrent_ai_calls,
             "jira_max_results": ServerConfig.jira_max_results,
             "jenkins_timeout": ServerConfig.jenkins_timeout,
             "poll_interval_minutes": ServerConfig.poll_interval_minutes,
@@ -800,6 +810,10 @@ def analyze(
     for key, value in _int_fields.items():
         if value is not None:
             extras[key] = value
+
+    # max_concurrent: 0 means "not set" (use server default).
+    if max_concurrent > 0:
+        extras["max_concurrent_ai_calls"] = max_concurrent
 
     # Boolean options: include only if explicitly set (not None).
     _bool_fields = {

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -196,6 +196,9 @@ class Settings(BaseSettings):
     # AI CLI timeout in minutes
     ai_cli_timeout: int = Field(default=10, gt=0)
 
+    # Max concurrent AI CLI calls
+    max_concurrent_ai_calls: int = Field(default=3, gt=0)
+
     # Peer analysis configuration
     peer_ai_configs: str = ""  # "provider:model,provider:model" format
     peer_analysis_max_rounds: int = Field(default=3, ge=1, le=10)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -373,6 +373,7 @@ def _reconstruct_from_params(
         "jira_ssl_verify",
         "jira_max_results",
         "ai_cli_timeout",
+        "max_concurrent_ai_calls",
         "jenkins_artifacts_max_size_mb",
         "get_job_artifacts",
         "peer_analysis_max_rounds",
@@ -1036,6 +1037,7 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
         "jira_ssl_verify",
         "jira_max_results",
         "ai_cli_timeout",
+        "max_concurrent_ai_calls",
         "enable_jira",
         "jenkins_artifacts_max_size_mb",
         "get_job_artifacts",
@@ -1542,6 +1544,7 @@ def _build_request_params(
             if merged.github_token
             else "",
             "ai_cli_timeout": merged.ai_cli_timeout,
+            "max_concurrent_ai_calls": merged.max_concurrent_ai_calls,
             "jenkins_artifacts_max_size_mb": merged.jenkins_artifacts_max_size_mb,
             "get_job_artifacts": merged.get_job_artifacts,
             "raw_prompt": body.raw_prompt or "",

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1773,11 +1773,14 @@ async def analyze_failures(
                 peer_ai_configs=peer_ai_configs,
                 peer_analysis_max_rounds=merged.peer_analysis_max_rounds,
                 additional_repos=cloned_repos or None,
+                max_concurrent_ai_calls=merged.max_concurrent_ai_calls,
             )
             for group_failures in groups.values()
         ]
 
-        results = await run_parallel_with_limit(coroutines)
+        results = await run_parallel_with_limit(
+            coroutines, max_concurrency=merged.max_concurrent_ai_calls
+        )
 
         # Flatten results and filter out exceptions
         all_analyses = []

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -94,6 +94,10 @@ class BaseAnalysisRequest(BaseModel):
         default=None,
         description="AI CLI timeout in minutes (overrides AI_CLI_TIMEOUT env var)",
     )
+    max_concurrent_ai_calls: Annotated[int, Field(gt=0)] | None = Field(
+        default=None,
+        description="Max concurrent AI CLI calls (overrides MAX_CONCURRENT_AI_CALLS env var)",
+    )
     jira_url: str | None = Field(
         default=None,
         description="Jira instance URL (overrides JIRA_URL env var)",

--- a/src/jenkins_job_insight/peer_analysis.py
+++ b/src/jenkins_job_insight/peer_analysis.py
@@ -329,6 +329,7 @@ async def analyze_failure_group_with_peers(
     job_id: str = "",
     group_label: str = "",
     additional_repos: dict[str, Path] | None = None,
+    max_concurrent_ai_calls: int = 3,
 ) -> list[FailureAnalysis]:
     """Analyze a failure group using multi-AI peer consensus.
 
@@ -492,7 +493,9 @@ async def analyze_failure_group_with_peers(
         peer_tasks: list[Coroutine[Any, Any, Any]] = [
             _call_peer(idx, cfg) for idx, cfg in enumerate(peer_ai_configs)
         ]
-        peer_results = await run_parallel_with_limit(peer_tasks)
+        peer_results = await run_parallel_with_limit(
+            peer_tasks, max_concurrency=max_concurrent_ai_calls
+        )
 
         # Process peer responses
         round_peer_entries: list[PeerRound] = []

--- a/src/jenkins_job_insight/peer_analysis.py
+++ b/src/jenkins_job_insight/peer_analysis.py
@@ -356,6 +356,9 @@ async def analyze_failure_group_with_peers(
         group_label: Human-readable label identifying which failure group is
             being analyzed (e.g. ``"2/3"`` for group 2 of 3). Used in progress
             phase names to disambiguate concurrent groups.
+        additional_repos: Extra cloned repositories for AI context.
+        max_concurrent_ai_calls: Maximum concurrent AI CLI processes for
+            peer analysis parallelism (default: 3).
 
     Returns:
         List of FailureAnalysis objects, one per failure in the group.
@@ -437,8 +440,8 @@ async def analyze_failure_group_with_peers(
         # Collect previous round peer data for cross-peer visibility.
         # Build a mapping from peer_ai_configs index to PeerResponseSummary
         # (None for peers that failed).  Peer entries in all_rounds appear in
-        # the same order as peer_ai_configs because asyncio.gather preserves
-        # input order, so we can zip them by position.
+        # the same order as peer_ai_configs because run_parallel_with_limit
+        # preserves input order, so we can zip them by position.
         prev_round_by_idx: dict[int, PeerResponseSummary] = {}
         if round_num > 1:
             prev_round_entries = [

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -573,6 +573,49 @@ class TestAnalyzeFailureGroupPeerDelegation:
         )
         assert mock_peer.call_args.kwargs["group_label"] == ""
 
+    @pytest.mark.asyncio
+    async def test_max_concurrent_ai_calls_forwarded_to_peer_analysis(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """max_concurrent_ai_calls is forwarded from analyze_failure_group to analyze_failure_group_with_peers."""
+        from jenkins_job_insight.analyzer import TestFailure, analyze_failure_group
+        from jenkins_job_insight.models import (
+            AiConfigEntry,
+            AnalysisDetail,
+            FailureAnalysis,
+        )
+
+        mock_peer = AsyncMock(
+            return_value=[
+                FailureAnalysis(
+                    test_name="t",
+                    error="e",
+                    analysis=AnalysisDetail(details="d"),
+                    error_signature="s",
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            "jenkins_job_insight.peer_analysis.analyze_failure_group_with_peers",
+            mock_peer,
+        )
+
+        failure = TestFailure(
+            test_name="test_foo", error_message="err", stack_trace="st"
+        )
+        peers = [AiConfigEntry(ai_provider="gemini", ai_model="pro")]
+
+        await analyze_failure_group(
+            [failure],
+            "",
+            None,
+            ai_provider="claude",
+            ai_model="opus",
+            peer_ai_configs=peers,
+            max_concurrent_ai_calls=7,
+        )
+        assert mock_peer.call_args.kwargs["max_concurrent_ai_calls"] == 7
+
 
 class TestConsoleOnlyPeerWarning:
     """Tests that console-only fallback branches warn when peer analysis is configured."""

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -36,6 +36,7 @@ tests_repo_url = "https://github.com/org/tests"
 ai_provider = "claude"
 ai_model = "opus-4"
 ai_cli_timeout = 15
+max_concurrent_ai_calls = 7
 jira_url = "https://jira.dev.local"
 jira_email = "dev@example.com"
 jira_api_token = "jira-tok-dev"
@@ -243,6 +244,7 @@ class TestGetServerConfig:
         assert cfg.ai_provider == "claude"
         assert cfg.ai_model == "opus-4"
         assert cfg.ai_cli_timeout == 15
+        assert cfg.max_concurrent_ai_calls == 7
         assert cfg.jira_url == "https://jira.dev.local"
         assert cfg.jira_email == "dev@example.com"
         assert cfg.jira_api_token == "jira-tok-dev"  # noqa: S105
@@ -267,6 +269,7 @@ class TestGetServerConfig:
         assert cfg.jenkins_ssl_verify is None
         assert cfg.ai_provider == ""
         assert cfg.ai_cli_timeout == 0
+        assert cfg.max_concurrent_ai_calls == 0
         assert cfg.jira_ssl_verify is None
         assert cfg.jira_max_results == 0
         assert cfg.enable_jira is None

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -782,3 +782,27 @@ class TestServerConfigFromDictTypeValidation:
         data = {"url": "http://test", "peer_analysis_max_rounds": 5}
         cfg = _server_config_from_dict(data)
         assert cfg.peer_analysis_max_rounds == 5
+
+    def test_max_concurrent_ai_calls_negative_raises(self) -> None:
+        """Negative 'max_concurrent_ai_calls' raises ValueError."""
+        data = {"url": "http://test", "max_concurrent_ai_calls": -1}
+        with pytest.raises(
+            ValueError, match=r"max_concurrent_ai_calls.*non-negative integer"
+        ):
+            _server_config_from_dict(data)
+
+    def test_max_concurrent_ai_calls_bool_raises(self) -> None:
+        """Boolean 'max_concurrent_ai_calls' raises ValueError (bool is subclass of int)."""
+        data = {"url": "http://test", "max_concurrent_ai_calls": True}
+        with pytest.raises(
+            ValueError, match=r"max_concurrent_ai_calls.*must be an integer"
+        ):
+            _server_config_from_dict(data)
+
+    def test_max_concurrent_ai_calls_string_raises(self) -> None:
+        """String 'max_concurrent_ai_calls' raises ValueError."""
+        data = {"url": "http://test", "max_concurrent_ai_calls": "five"}
+        with pytest.raises(
+            ValueError, match=r"max_concurrent_ai_calls.*must be an integer"
+        ):
+            _server_config_from_dict(data)

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -957,6 +957,36 @@ class TestAnalyzeAllOptions:
         kwargs = mock_client.analyze.call_args[1]
         assert kwargs[body_key] == expected_value
 
+    def test_max_concurrent_option(self, mock_client):
+        """--max-concurrent should be forwarded as max_concurrent_ai_calls."""
+        mock_client.analyze.return_value = self._ANALYZE_RESPONSE
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                "--job-name",
+                "my-job",
+                "--build-number",
+                "1",
+                "--max-concurrent",
+                "5",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_client.analyze.call_args[1]
+        assert kwargs["max_concurrent_ai_calls"] == 5
+
+    def test_max_concurrent_zero_not_forwarded(self, mock_client):
+        """--max-concurrent 0 (default) should not forward the field."""
+        mock_client.analyze.return_value = self._ANALYZE_RESPONSE
+        result = runner.invoke(
+            app,
+            ["analyze", "--job-name", "my-job", "--build-number", "1"],
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_client.analyze.call_args[1]
+        assert "max_concurrent_ai_calls" not in kwargs
+
     def test_no_optional_fields_when_not_provided(self, mock_client):
         """When no optional flags are given and no env vars set, extras should be empty."""
         mock_client.analyze.return_value = self._ANALYZE_RESPONSE
@@ -1696,6 +1726,7 @@ class TestAnalyzeConfigDefaults:
         ai_provider="gemini",
         ai_model="2.5-pro",
         ai_cli_timeout=20,
+        max_concurrent_ai_calls=5,
         jira_url="https://jira.cfg.local",
         jira_email="cfg@example.com",
         jira_api_token=_FAKE_JIRA_API_TOKEN,
@@ -1752,6 +1783,7 @@ class TestAnalyzeConfigDefaults:
         assert result.exit_code == 0
         kwargs = client.analyze.call_args[1]
         assert kwargs["ai_cli_timeout"] == 20
+        assert kwargs["max_concurrent_ai_calls"] == 5
         assert kwargs["jira_max_results"] == 40
         assert kwargs["jenkins_timeout"] == 45
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -572,3 +572,27 @@ class TestForceAnalysisSettings:
         with patch.dict(os.environ, env, clear=True):
             settings = Settings(_env_file=None)
             assert settings.force_analysis is False
+
+
+class TestMaxConcurrentAiCalls:
+    """Tests for max_concurrent_ai_calls setting."""
+
+    def test_default_value_is_3(self) -> None:
+        """Default max_concurrent_ai_calls is 3."""
+        with patch.dict(os.environ, _build_env(), clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.max_concurrent_ai_calls == 3
+
+    def test_env_override(self) -> None:
+        """MAX_CONCURRENT_AI_CALLS env var overrides the default."""
+        env = _build_env(MAX_CONCURRENT_AI_CALLS="5")
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.max_concurrent_ai_calls == 5
+
+    def test_env_value_of_1(self) -> None:
+        """MAX_CONCURRENT_AI_CALLS=1 is valid."""
+        env = _build_env(MAX_CONCURRENT_AI_CALLS="1")
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings(_env_file=None)
+            assert settings.max_concurrent_ai_calls == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3180,6 +3180,37 @@ class TestPeerAnalysisParams:
 
         assert merged.peer_analysis_max_rounds == 9
 
+    def test_merge_settings_max_concurrent_ai_calls_override(self) -> None:
+        """max_concurrent_ai_calls in request body overrides env default via _merge_settings."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+            ai_provider="claude",
+            ai_model="test-model",
+            max_concurrent_ai_calls=7,
+        )
+        settings = Settings()
+        merged = _merge_settings(body, settings)
+        assert merged.max_concurrent_ai_calls == 7
+
+    def test_merge_settings_max_concurrent_ai_calls_preserves_default(self) -> None:
+        """Omitted max_concurrent_ai_calls preserves the server default."""
+        from jenkins_job_insight.main import _merge_settings
+        from jenkins_job_insight.models import AnalyzeRequest
+
+        body = AnalyzeRequest(
+            job_name="test",
+            build_number=1,
+            ai_provider="claude",
+            ai_model="test-model",
+        )
+        settings = Settings()
+        merged = _merge_settings(body, settings)
+        assert merged.max_concurrent_ai_calls == 3
+
     def test_resolve_peer_ai_configs_none_uses_env(self, test_client) -> None:
         """When peer_ai_configs is None in request, _resolve_peer_ai_configs falls back to env default."""
         from jenkins_job_insight.main import _merge_settings, _resolve_peer_ai_configs

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3196,8 +3196,10 @@ class TestPeerAnalysisParams:
         merged = _merge_settings(body, settings)
         assert merged.max_concurrent_ai_calls == 7
 
-    def test_merge_settings_max_concurrent_ai_calls_preserves_default(self) -> None:
-        """Omitted max_concurrent_ai_calls preserves the server default."""
+    def test_merge_settings_max_concurrent_ai_calls_preserves_server_setting_when_omitted(
+        self,
+    ) -> None:
+        """Omitted max_concurrent_ai_calls preserves the existing server setting."""
         from jenkins_job_insight.main import _merge_settings
         from jenkins_job_insight.models import AnalyzeRequest
 
@@ -3207,9 +3209,9 @@ class TestPeerAnalysisParams:
             ai_provider="claude",
             ai_model="test-model",
         )
-        settings = Settings()
+        settings = Settings(max_concurrent_ai_calls=9)
         merged = _merge_settings(body, settings)
-        assert merged.max_concurrent_ai_calls == 3
+        assert merged.max_concurrent_ai_calls == 9
 
     def test_resolve_peer_ai_configs_none_uses_env(self, test_client) -> None:
         """When peer_ai_configs is None in request, _resolve_peer_ai_configs falls back to env default."""

--- a/tests/test_metadata_rules.py
+++ b/tests/test_metadata_rules.py
@@ -478,8 +478,25 @@ class TestMetadataRulesCLI:
             "jenkins_job_insight.cli.main._get_client",
             return_value=make_test_client(handler),
         ):
-            result = runner.invoke(cli_app, args, catch_exceptions=False)
-        return result
+            result = runner.invoke(cli_app, args)
+            if result.exit_code != 0:
+                import sys
+
+                print(
+                    f"CLI FAILED: args={args}, exit_code={result.exit_code}",
+                    file=sys.stderr,
+                )
+                print(f"CLI OUTPUT: {result.output!r}", file=sys.stderr)
+                if result.exception:
+                    import traceback
+
+                    traceback.print_exception(
+                        type(result.exception),
+                        result.exception,
+                        result.exception.__traceback__,
+                        file=sys.stderr,
+                    )
+            return result
 
     def test_metadata_rules_command(self) -> None:
         response_data = {

--- a/tests/test_metadata_rules.py
+++ b/tests/test_metadata_rules.py
@@ -478,7 +478,8 @@ class TestMetadataRulesCLI:
             "jenkins_job_insight.cli.main._get_client",
             return_value=make_test_client(handler),
         ):
-            return runner.invoke(cli_app, args)
+            result = runner.invoke(cli_app, args, catch_exceptions=False)
+        return result
 
     def test_metadata_rules_command(self) -> None:
         response_data = {

--- a/tests/test_metadata_rules.py
+++ b/tests/test_metadata_rules.py
@@ -474,28 +474,18 @@ class TestMetadataRulesCLI:
 
     def _invoke(self, args: list[str], handler) -> object:
         runner = CliRunner()
-        with patch(
-            "jenkins_job_insight.cli.main._get_client",
-            return_value=make_test_client(handler),
+        with (
+            patch.dict(os.environ, {"JJI_SERVER": "http://test-server"}),
+            patch(
+                "jenkins_job_insight.cli.main.get_server_config",
+                return_value=None,
+            ),
+            patch(
+                "jenkins_job_insight.cli.main._get_client",
+                return_value=make_test_client(handler),
+            ),
         ):
             result = runner.invoke(cli_app, args)
-            if result.exit_code != 0:
-                import sys
-
-                print(
-                    f"CLI FAILED: args={args}, exit_code={result.exit_code}",
-                    file=sys.stderr,
-                )
-                print(f"CLI OUTPUT: {result.output!r}", file=sys.stderr)
-                if result.exception:
-                    import traceback
-
-                    traceback.print_exception(
-                        type(result.exception),
-                        result.exception,
-                        result.exception.__traceback__,
-                        file=sys.stderr,
-                    )
             return result
 
     def test_metadata_rules_command(self) -> None:


### PR DESCRIPTION
Closes #185

## Problem

Max concurrent AI CLI calls was hardcoded to 10 in ai-cli-runner. With heavy models like Claude Opus (1M context), 7 concurrent processes OOM'd the 8Gi pod.

## Fix

Add `MAX_CONCURRENT_AI_CALLS` config setting (default: 3) following config parity:
- **Env var**: `MAX_CONCURRENT_AI_CALLS`
- **API field**: `max_concurrent_ai_calls` (per-request override)
- **CLI flag**: `--max-concurrent`
- **Config file**: `max_concurrent_ai_calls` in `~/.config/jji/config.toml`

Passes configured value to all 4 `run_parallel_with_limit()` calls in analyzer.py.

Also: added note to AGENTS.md that `docs/` is auto-generated by docsfy — never edit manually.

## Testing

All tests pass including new tests for config default, env override, merge_settings, and CLI forwarding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable concurrency limit for AI analysis (default 3), controllable via env var, CLI flag (--max-concurrent, 0 treated as unset), API request field, and config file; persisted for resumed analyses.

* **Documentation**
  * Added "Analysis Tuning" guidance and clarified docs/ is auto-generated (manual edits will be overwritten).

* **Tests**
  * Added tests for config parsing/validation, CLI forwarding/omit behavior, settings merge, and concurrency propagation to peer analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->