### PR TITLE
Add pytest-xdist for parallel test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,11 @@ jenkins-job-insight = "jenkins_job_insight.main:run"
 jji = "jenkins_job_insight.cli.main:app"
 
 [project.optional-dependencies]
-tests = ["pytest", "pytest-asyncio"]
+tests = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-xdist>=3.8.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -41,12 +45,3 @@ pythonpath = ["src"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/jenkins_job_insight"]
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-]
-tests = [
-    "pytest-xdist>=3.8.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,6 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
 ]
+tests = [
+    "pytest-xdist>=3.8.0",
+]

--- a/tox.toml
+++ b/tox.toml
@@ -3,7 +3,19 @@ envlist = ["backend", "frontend"]
 
 [env.backend]
 description = "Run Python tests"
-commands = [["uv", "run", "--extra", "tests", "pytest", "tests/", "-q"]]
+commands = [
+  [
+    "uv",
+    "run",
+    "--extra",
+    "tests",
+    "pytest",
+    "-n",
+    "auto",
+    "tests/",
+    "-q",
+  ],
+]
 allowlist_externals = ["uv"]
 
 [env.frontend]

--- a/uv.lock
+++ b/uv.lock
@@ -614,14 +614,6 @@ dependencies = [
 tests = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-tests = [
     { name = "pytest-xdist" },
 ]
 
@@ -637,6 +629,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'tests'" },
     { name = "pytest-asyncio", marker = "extra == 'tests'" },
+    { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.8.0" },
     { name = "python-jenkins" },
     { name = "python-multipart" },
     { name = "python-simple-logger" },
@@ -648,13 +641,6 @@ requires-dist = [
     { name = "uvicorn" },
 ]
 provides-extras = ["tests"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-]
-tests = [{ name = "pytest-xdist", specifier = ">=3.8.0" }]
 
 [[package]]
 name = "markdown-it-py"

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.133.1"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +621,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+tests = [
+    { name = "pytest-xdist" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -642,6 +654,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
+tests = [{ name = "pytest-xdist", specifier = ">=3.8.0" }]
 
 [[package]]
 name = "markdown-it-py"
@@ -1040,6 +1053,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enable distributed test running with pytest-xdist by adding it as a tests extra dependency and configuring tox to run pytest with the `-n auto` flag for automatic worker count detection.