### PR TITLE
feat: support authentication token for private tests repo (#189)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,6 @@ Sensitive data (passwords, API tokens, credentials) must be:
 2. **Stripped from responses** — use `strip_sensitive_from_response()` before returning to API consumers
 3. **Never logged** — do not log passwords, tokens, or credentials at any log level
 
-Sensitive fields: `jenkins_password`, `jenkins_user`, `jira_api_token`, `jira_pat`, `jira_email`, `github_token`, `reportportal_api_token`, `vapid_private_key`
+Sensitive fields: `jenkins_password`, `jenkins_user`, `jira_api_token`, `jira_pat`, `jira_email`, `github_token`, `tests_repo_token`, `reportportal_api_token`, `vapid_private_key`
 
 Encryption uses Fernet (AES-128-CBC + HMAC-SHA256). Set `JJI_ENCRYPTION_KEY` env var for production; falls back to an auto-generated file-based key under `$XDG_DATA_HOME/jji/.encryption_key` (default: `~/.local/share/jji/.encryption_key`) for development.

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1665,7 +1665,8 @@ async def analyze_job(
                         clean_tests_url, additional_repos_list
                     )
                     logger.info(
-                        f"Cloning test repository: {clean_tests_url} (ref={tests_ref or 'default'})"
+                        f"Cloning test repository: {clean_tests_url}"
+                        + (f" (ref={tests_ref})" if tests_ref else "")
                     )
                     await asyncio.to_thread(
                         repo_manager.clone_into,

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1643,6 +1643,13 @@ async def analyze_job(
         # Clone repo for context BEFORE child job analysis so it's available for all jobs
         # Use request value if provided, otherwise fall back to settings
         tests_repo_url = request.tests_repo_url or settings.tests_repo_url
+        tests_repo_token = (
+            request.tests_repo_token
+            if request.tests_repo_token is not None
+            else settings.tests_repo_token.get_secret_value()
+            if settings.tests_repo_token
+            else ""
+        )
         repo_context = ""
         custom_prompt = ""
 
@@ -1669,6 +1676,7 @@ async def analyze_job(
                         repo_path / repo_name,
                         depth=50,
                         branch=tests_ref,
+                        token=tests_repo_token or None,
                     )
                     cloned_repos[repo_name] = repo_path / repo_name
                     repo_context = f"\nTest repository cloned from: {clean_tests_url} (at {repo_name}/)"

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1643,6 +1643,8 @@ async def analyze_job(
         # Clone repo for context BEFORE child job analysis so it's available for all jobs
         # Use request value if provided, otherwise fall back to settings
         tests_repo_url = request.tests_repo_url or settings.tests_repo_url
+        # Resolve token (mirrors _resolve_tests_repo_token in main.py;
+        # duplicated here to avoid circular import)
         tests_repo_token = (
             request.tests_repo_token
             if request.tests_repo_token is not None
@@ -1680,7 +1682,7 @@ async def analyze_job(
                     )
                     cloned_repos[repo_name] = repo_path / repo_name
                     repo_context = f"\nTest repository cloned from: {clean_tests_url} (at {repo_name}/)"
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 — non-fatal tests repo clone failure
                     logger.warning(
                         "Failed to clone repository (%s)",
                         type(e).__name__,

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1664,7 +1664,9 @@ async def analyze_job(
                     repo_name = derive_test_repo_name(
                         clean_tests_url, additional_repos_list
                     )
-                    logger.info(f"Cloning test repository: {clean_tests_url}")
+                    logger.info(
+                        f"Cloning test repository: {clean_tests_url} (ref={tests_ref or 'default'})"
+                    )
                     await asyncio.to_thread(
                         repo_manager.clone_into,
                         clean_tests_url,
@@ -1674,6 +1676,9 @@ async def analyze_job(
                         token=tests_repo_token or None,
                     )
                     cloned_repos[repo_name] = repo_path / repo_name
+                    logger.info(
+                        f"Successfully cloned test repository into {repo_name}/"
+                    )
                     repo_context = f"\nTest repository cloned from: {clean_tests_url} (at {repo_name}/)"
                 except Exception as e:  # noqa: BLE001 — non-fatal tests repo clone failure
                     logger.warning(

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException
 from simple_logger.logger import get_logger
 
 from jenkins_job_insight.config import Settings, parse_additional_repos, parse_repo_ref
+from jenkins_job_insight.request_resolution import resolve_tests_repo_token
 from jenkins_job_insight.jenkins_artifacts import (
     cleanup_extract_dir,
     process_build_artifacts,
@@ -1643,15 +1644,7 @@ async def analyze_job(
         # Clone repo for context BEFORE child job analysis so it's available for all jobs
         # Use request value if provided, otherwise fall back to settings
         tests_repo_url = request.tests_repo_url or settings.tests_repo_url
-        # Resolve token (mirrors _resolve_tests_repo_token in main.py;
-        # duplicated here to avoid circular import)
-        tests_repo_token = (
-            request.tests_repo_token
-            if request.tests_repo_token is not None
-            else settings.tests_repo_token.get_secret_value()
-            if settings.tests_repo_token
-            else ""
-        )
+        tests_repo_token = resolve_tests_repo_token(request, settings)
         repo_context = ""
         custom_prompt = ""
 

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -43,6 +43,7 @@ from jenkins_job_insight.models import (
 )
 from jenkins_job_insight.repository import (
     RepositoryManager,
+    _redact_url,
     derive_test_repo_name,
 )
 from jenkins_job_insight.storage import update_progress_phase
@@ -1665,7 +1666,7 @@ async def analyze_job(
                         clean_tests_url, additional_repos_list
                     )
                     logger.info(
-                        f"Cloning test repository: {clean_tests_url}"
+                        f"Cloning test repository: {_redact_url(clean_tests_url)}"
                         + (f" (ref={tests_ref})" if tests_ref else "")
                     )
                     await asyncio.to_thread(

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -1681,8 +1681,11 @@ async def analyze_job(
                     cloned_repos[repo_name] = repo_path / repo_name
                     repo_context = f"\nTest repository cloned from: {clean_tests_url} (at {repo_name}/)"
                 except Exception as e:
-                    logger.warning(f"Failed to clone repository: {e}")
-                    repo_context = f"\nFailed to clone repo: {e}"
+                    logger.warning(
+                        "Failed to clone repository (%s)",
+                        type(e).__name__,
+                    )
+                    repo_context = "\nFailed to clone repository (details redacted)"
 
             custom_prompt = (request.raw_prompt or "").strip()
 

--- a/src/jenkins_job_insight/cli/config.py
+++ b/src/jenkins_job_insight/cli/config.py
@@ -30,6 +30,7 @@ class ServerConfig:
     jenkins_timeout: int = 0  # 0 means use server default
     # Tests
     tests_repo_url: str = ""
+    tests_repo_token: str = ""
     # AI
     ai_provider: str = ""
     ai_model: str = ""
@@ -219,6 +220,7 @@ def _server_config_from_dict(data: dict) -> ServerConfig:
         jenkins_timeout=_validated_non_negative_int(data, "jenkins_timeout"),
         # Tests
         tests_repo_url=data.get("tests_repo_url", ""),
+        tests_repo_token=data.get("tests_repo_token", ""),
         # AI
         ai_provider=data.get("ai_provider", ""),
         ai_model=data.get("ai_model", ""),

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -607,6 +607,12 @@ def analyze(
     tests_repo_url: str = typer.Option(
         "", "--tests-repo-url", envvar="TESTS_REPO_URL", help="Tests repository URL."
     ),
+    tests_repo_token: str = typer.Option(
+        "",
+        "--tests-repo-token",
+        envvar="TESTS_REPO_TOKEN",
+        help="Token for cloning private tests repository.",
+    ),
     jira_url: str = typer.Option(
         "", "--jira-url", envvar="JIRA_URL", help="Jira instance URL."
     ),
@@ -715,6 +721,7 @@ def analyze(
             "jenkins_user": cfg.jenkins_user,
             "jenkins_password": cfg.jenkins_password,
             "tests_repo_url": cfg.tests_repo_url,
+            "tests_repo_token": cfg.tests_repo_token,
             "jira_url": cfg.jira_url,
             "jira_email": cfg.jira_email,
             "jira_api_token": cfg.jira_api_token,
@@ -786,6 +793,7 @@ def analyze(
         "jenkins_user": jenkins_user,
         "jenkins_password": jenkins_password,
         "tests_repo_url": tests_repo_url,
+        "tests_repo_token": tests_repo_token,
         "jira_url": jira_url,
         "jira_email": jira_email,
         "jira_api_token": jira_api_token,

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -169,6 +169,7 @@ class Settings(BaseSettings):
 
     # Optional defaults (can be overridden per-request in webhook)
     tests_repo_url: str | None = None
+    tests_repo_token: SecretStr | None = None  # NEW
     # Jira integration (optional)
     jira_url: str | None = None
     jira_email: str | None = None
@@ -298,6 +299,7 @@ class Settings(BaseSettings):
         # Strip whitespace from secret fields; blank becomes None
         for field_name in (
             "github_token",
+            "tests_repo_token",
             "jira_api_token",
             "jira_pat",
             "reportportal_api_token",

--- a/src/jenkins_job_insight/encryption.py
+++ b/src/jenkins_job_insight/encryption.py
@@ -36,6 +36,7 @@ SENSITIVE_KEYS: frozenset[str] = frozenset(
         "jira_email",
         "jira_token",
         "github_token",
+        "tests_repo_token",
         "reportportal_api_token",
     }
 )

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -96,7 +96,11 @@ from jenkins_job_insight.xml_enrichment import (
     build_enriched_xml,
     extract_test_failures,
 )
-from jenkins_job_insight.repository import RepositoryManager, derive_test_repo_name
+from jenkins_job_insight.repository import (
+    RepositoryManager,
+    _redact_url,
+    derive_test_repo_name,
+)
 from jenkins_job_insight.request_resolution import resolve_tests_repo_token
 from jenkins_job_insight import storage
 from jenkins_job_insight.storage import (
@@ -405,8 +409,9 @@ def _reconstruct_from_params(
         overrides["jira_pat"] = SecretStr(params["jira_pat"])
     if params.get("github_token"):
         overrides["github_token"] = SecretStr(params["github_token"])
-    if "tests_repo_token" in params and params["tests_repo_token"]:
-        overrides["tests_repo_token"] = SecretStr(params["tests_repo_token"])
+    if "tests_repo_token" in params:
+        token_value = params["tests_repo_token"]
+        overrides["tests_repo_token"] = SecretStr(token_value) if token_value else None
 
     # Enable jira
     if params.get("enable_jira") is not None:
@@ -1754,7 +1759,7 @@ async def analyze_failures(
                     str(tests_repo_url), additional_repos_list
                 )
                 logger.info(
-                    f"Cloning test repository: {tests_repo_url}"
+                    f"Cloning test repository: {_redact_url(str(tests_repo_url))}"
                     + (f" (ref={tests_repo_ref})" if tests_repo_ref else "")
                 )
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -97,6 +97,7 @@ from jenkins_job_insight.xml_enrichment import (
     extract_test_failures,
 )
 from jenkins_job_insight.repository import RepositoryManager, derive_test_repo_name
+from jenkins_job_insight.request_resolution import resolve_tests_repo_token
 from jenkins_job_insight import storage
 from jenkins_job_insight.storage import (
     get_ai_configs,
@@ -353,7 +354,9 @@ def _reconstruct_from_params(
         additional_repos=(
             params["additional_repos"] if "additional_repos" in params else None
         ),
-        tests_repo_token=params.get("tests_repo_token") or None,
+        tests_repo_token=(
+            params["tests_repo_token"] if "tests_repo_token" in params else None
+        ),
         **({"force": params["force"]} if "force" in params else {}),
     )
     # Build Settings from env defaults, then layer stored overrides
@@ -402,7 +405,7 @@ def _reconstruct_from_params(
         overrides["jira_pat"] = SecretStr(params["jira_pat"])
     if params.get("github_token"):
         overrides["github_token"] = SecretStr(params["github_token"])
-    if params.get("tests_repo_token"):
+    if "tests_repo_token" in params and params["tests_repo_token"]:
         overrides["tests_repo_token"] = SecretStr(params["tests_repo_token"])
 
     # Enable jira
@@ -982,15 +985,6 @@ def _resolve_peer_ai_configs(
     return None
 
 
-def _resolve_tests_repo_token(body: BaseAnalysisRequest, merged: Settings) -> str:
-    """Resolve the effective tests repo token from request body or settings."""
-    if body.tests_repo_token is not None:
-        return body.tests_repo_token
-    if merged.tests_repo_token:
-        return merged.tests_repo_token.get_secret_value()
-    return ""
-
-
 def _validate_peer_configs(
     body: BaseAnalysisRequest, settings: Settings
 ) -> list | None:
@@ -1527,7 +1521,7 @@ def _build_request_params(
         else ""
     )
     resolved_tests_repo, tests_repo_ref = parse_repo_ref(resolved_tests_repo)
-    resolved_tests_repo_token = _resolve_tests_repo_token(body, merged)
+    resolved_tests_repo_token = resolve_tests_repo_token(body, merged)
     resolved_additional = resolve_additional_repos(body, merged)
     params = _build_base_request_params(
         ai_provider,
@@ -1709,7 +1703,7 @@ async def analyze_failures(
     # (including env-var / config-file defaults, not just request-body values).
     tests_repo_url_raw = str(body.tests_repo_url or merged.tests_repo_url or "")
     tests_repo_url, tests_repo_ref = parse_repo_ref(tests_repo_url_raw)
-    resolved_tests_repo_token = _resolve_tests_repo_token(body, merged)
+    resolved_tests_repo_token = resolve_tests_repo_token(body, merged)
     additional_repos_list = resolve_additional_repos(body, merged)
 
     job_id = str(uuid.uuid4())
@@ -1770,7 +1764,7 @@ async def analyze_failures(
                     token=resolved_tests_repo_token or None,
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — non-fatal tests repo clone failure
                 logger.warning(
                     "Failed to clone test repository (%s)",
                     type(e).__name__,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1754,7 +1754,8 @@ async def analyze_failures(
                     str(tests_repo_url), additional_repos_list
                 )
                 logger.info(
-                    f"Cloning test repository: {tests_repo_url} (ref={tests_repo_ref or 'default'})"
+                    f"Cloning test repository: {tests_repo_url}"
+                    + (f" (ref={tests_repo_ref})" if tests_repo_ref else "")
                 )
 
                 await asyncio.to_thread(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -411,7 +411,9 @@ def _reconstruct_from_params(
         overrides["github_token"] = SecretStr(params["github_token"])
     if "tests_repo_token" in params:
         token_value = params["tests_repo_token"]
-        overrides["tests_repo_token"] = SecretStr(token_value) if token_value else None
+        overrides["tests_repo_token"] = (
+            SecretStr(token_value) if token_value is not None else None
+        )
 
     # Enable jira
     if params.get("enable_jira") is not None:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -979,6 +979,15 @@ def _resolve_peer_ai_configs(
     return None
 
 
+def _resolve_tests_repo_token(body: BaseAnalysisRequest, merged: Settings) -> str:
+    """Resolve the effective tests repo token from request body or settings."""
+    if body.tests_repo_token is not None:
+        return body.tests_repo_token
+    if merged.tests_repo_token:
+        return merged.tests_repo_token.get_secret_value()
+    return ""
+
+
 def _validate_peer_configs(
     body: BaseAnalysisRequest, settings: Settings
 ) -> list | None:
@@ -1059,6 +1068,8 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
         overrides["jira_pat"] = SecretStr(body.jira_pat)
     if body.github_token is not None:
         overrides["github_token"] = SecretStr(body.github_token)
+    if body.tests_repo_token is not None:
+        overrides["tests_repo_token"] = SecretStr(body.tests_repo_token)
 
     # AnalyzeRequest-specific fields (Jenkins overrides + monitoring)
     if isinstance(body, AnalyzeRequest):
@@ -1442,6 +1453,7 @@ def _build_base_request_params(
     peer_ai_configs_resolved: list | None = None,
     *,
     tests_repo_url: str = "",
+    tests_repo_token: str = "",
     tests_repo_ref: str = "",
     additional_repos: list | None = None,
 ) -> dict:
@@ -1476,6 +1488,7 @@ def _build_base_request_params(
         if additional_repos is not None
         else None,
         "tests_repo_url": tests_repo_url,
+        "tests_repo_token": tests_repo_token,
         "tests_repo_ref": tests_repo_ref,
     }
 
@@ -1509,12 +1522,14 @@ def _build_request_params(
         else ""
     )
     resolved_tests_repo, tests_repo_ref = parse_repo_ref(resolved_tests_repo)
+    resolved_tests_repo_token = _resolve_tests_repo_token(body, merged)
     resolved_additional = resolve_additional_repos(body, merged)
     params = _build_base_request_params(
         ai_provider,
         ai_model,
         peer_ai_configs_resolved,
         tests_repo_url=resolved_tests_repo,
+        tests_repo_token=resolved_tests_repo_token,
         tests_repo_ref=tests_repo_ref,
         additional_repos=resolved_additional,
     )
@@ -1689,6 +1704,7 @@ async def analyze_failures(
     # (including env-var / config-file defaults, not just request-body values).
     tests_repo_url_raw = str(body.tests_repo_url or merged.tests_repo_url or "")
     tests_repo_url, tests_repo_ref = parse_repo_ref(tests_repo_url_raw)
+    resolved_tests_repo_token = _resolve_tests_repo_token(body, merged)
     additional_repos_list = resolve_additional_repos(body, merged)
 
     job_id = str(uuid.uuid4())
@@ -1705,6 +1721,7 @@ async def analyze_failures(
             ai_model,
             peer_ai_configs,
             tests_repo_url=tests_repo_url,
+            tests_repo_token=resolved_tests_repo_token,
             tests_repo_ref=tests_repo_ref,
             additional_repos=additional_repos_list or None,
         ),
@@ -1736,12 +1753,15 @@ async def analyze_failures(
                     str(tests_repo_url), additional_repos_list
                 )
                 logger.info(f"Cloning test repository: {tests_repo_url}")
+                tests_repo_token = _resolve_tests_repo_token(body, merged)
+
                 await asyncio.to_thread(
                     repo_manager.clone_into,
                     str(tests_repo_url),
                     repo_path / repo_name,
                     depth=50,
                     branch=tests_repo_ref,
+                    token=tests_repo_token or None,
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
             except Exception as e:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1753,7 +1753,9 @@ async def analyze_failures(
                 repo_name = derive_test_repo_name(
                     str(tests_repo_url), additional_repos_list
                 )
-                logger.info(f"Cloning test repository: {tests_repo_url}")
+                logger.info(
+                    f"Cloning test repository: {tests_repo_url} (ref={tests_repo_ref or 'default'})"
+                )
 
                 await asyncio.to_thread(
                     repo_manager.clone_into,
@@ -1764,6 +1766,7 @@ async def analyze_failures(
                     token=resolved_tests_repo_token or None,
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
+                logger.info(f"Successfully cloned test repository into {repo_name}/")
             except Exception as e:  # noqa: BLE001 — non-fatal tests repo clone failure
                 logger.warning(
                     "Failed to clone test repository (%s)",

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1721,14 +1721,16 @@ async def analyze_failures(
     # Save initial pending state with request_params so GET /results/{job_id}
     # works immediately and _preserve_request_params can find them later.
     initial_result: dict = {
-        "request_params": _build_base_request_params(
-            ai_provider,
-            ai_model,
-            peer_ai_configs,
-            tests_repo_url=tests_repo_url,
-            tests_repo_token=resolved_tests_repo_token,
-            tests_repo_ref=tests_repo_ref,
-            additional_repos=additional_repos_list or None,
+        "request_params": encrypt_sensitive_fields(
+            _build_base_request_params(
+                ai_provider,
+                ai_model,
+                peer_ai_configs,
+                tests_repo_url=tests_repo_url,
+                tests_repo_token=resolved_tests_repo_token,
+                tests_repo_ref=tests_repo_ref,
+                additional_repos=additional_repos_list or None,
+            )
         ),
     }
     await save_result(job_id, "", "pending", initial_result)
@@ -1769,7 +1771,10 @@ async def analyze_failures(
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
             except Exception as e:
-                logger.warning(f"Failed to clone test repository: {e}")
+                logger.warning(
+                    "Failed to clone test repository (%s)",
+                    type(e).__name__,
+                )
 
         # Clone additional repositories for AI context
         if additional_repos_list:

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -353,6 +353,7 @@ def _reconstruct_from_params(
         additional_repos=(
             params["additional_repos"] if "additional_repos" in params else None
         ),
+        tests_repo_token=params.get("tests_repo_token") or None,
         **({"force": params["force"]} if "force" in params else {}),
     )
     # Build Settings from env defaults, then layer stored overrides
@@ -401,6 +402,8 @@ def _reconstruct_from_params(
         overrides["jira_pat"] = SecretStr(params["jira_pat"])
     if params.get("github_token"):
         overrides["github_token"] = SecretStr(params["github_token"])
+    if params.get("tests_repo_token"):
+        overrides["tests_repo_token"] = SecretStr(params["tests_repo_token"])
 
     # Enable jira
     if params.get("enable_jira") is not None:
@@ -1469,6 +1472,8 @@ def _build_base_request_params(
         peer_ai_configs_resolved: Resolved peer AI configs (already validated).
         tests_repo_url: Effective tests repo URL (already resolved from
             request body / env / config).
+        tests_repo_token: Authentication token for cloning private tests repo.
+        tests_repo_ref: Git ref (branch/tag) for tests repo checkout.
         additional_repos: Effective additional repos list (already resolved).
 
     Returns:
@@ -1753,7 +1758,6 @@ async def analyze_failures(
                     str(tests_repo_url), additional_repos_list
                 )
                 logger.info(f"Cloning test repository: {tests_repo_url}")
-                tests_repo_token = _resolve_tests_repo_token(body, merged)
 
                 await asyncio.to_thread(
                     repo_manager.clone_into,
@@ -1761,7 +1765,7 @@ async def analyze_failures(
                     repo_path / repo_name,
                     depth=50,
                     branch=tests_repo_ref,
-                    token=tests_repo_token or None,
+                    token=resolved_tests_repo_token or None,
                 )
                 cloned_repos[repo_name] = repo_path / repo_name
             except Exception as e:

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -163,6 +163,14 @@ class BaseAnalysisRequest(BaseModel):
         ),
     )
 
+    @field_validator("tests_repo_token")
+    @classmethod
+    def _normalize_tests_repo_token(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        stripped = v.strip()
+        return stripped or None
+
     @field_validator("additional_repos")
     @classmethod
     def _unique_additional_repo_names(

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -78,6 +78,11 @@ class BaseAnalysisRequest(BaseModel):
         default=None,
         description="URL of the tests repository (overrides env var default)",
     )
+    tests_repo_token: str | None = Field(
+        default=None,
+        description="Authentication token for cloning private tests repo (overrides TESTS_REPO_TOKEN env var)",
+        json_schema_extra={"format": "password"},
+    )
     ai_provider: Literal["claude", "gemini", "cursor"] | None = Field(
         default=None,
         description="AI provider to use: claude, gemini, or cursor (overrides env var default)",

--- a/src/jenkins_job_insight/request_resolution.py
+++ b/src/jenkins_job_insight/request_resolution.py
@@ -1,0 +1,31 @@
+"""Shared request-parameter resolution helpers.
+
+Extracted to avoid circular imports between main.py and analyzer.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jenkins_job_insight.config import Settings
+    from jenkins_job_insight.models import BaseAnalysisRequest
+
+
+def resolve_tests_repo_token(body: BaseAnalysisRequest, merged: Settings) -> str:
+    """Resolve the effective tests repo token from request body or settings.
+
+    Request body value takes precedence over the server-level setting.
+
+    Args:
+        body: The analysis request (may contain per-request token override).
+        merged: Application settings (may contain server-level token).
+
+    Returns:
+        The resolved token string, or empty string if none configured.
+    """
+    if body.tests_repo_token is not None:
+        return body.tests_repo_token
+    if merged.tests_repo_token:
+        return merged.tests_repo_token.get_secret_value()
+    return ""


### PR DESCRIPTION
Closes #189

## Summary

Adds `TESTS_REPO_TOKEN` setting to authenticate when cloning the main tests repository (`TESTS_REPO_URL`). Previously only `additional_repos` supported per-repo tokens — the tests repo could only clone public repos.

## Changes

### Configuration parity
- **Env var**: `TESTS_REPO_TOKEN`
- **API payload**: `tests_repo_token` field in `BaseAnalysisRequest`
- **CLI option**: `--tests-repo-token`
- **Config file**: `tests_repo_token` in `ServerConfig`

### Security
- Added to `SENSITIVE_KEYS` — encrypted at rest, stripped from API responses
- `clone_into()` already scrubs credentials from `.git/config` after cloning
- Token is provider-agnostic (GitHub PAT, GitLab token, Bitbucket app password, etc.)

### Implementation
- Token resolution uses `_resolve_tests_repo_token()` helper to avoid duplication
- Passed to `clone_into(..., token=)` in both `main.py` (analyze-failures) and `analyzer.py` (analyze)

## Testing
- All 1,634 backend + 150 frontend tests pass
- Pre-commit checks pass

Assisted-by: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for authenticated test-repo access via token (CLI flag, env var, or per-request); token is resolved and used during analysis and resume.

* **Bug Fixes**
  * Clone logging now redacts repository details, may include selected ref, logs explicit success, and limits failure logs to the exception type only.

* **Documentation**
  * Docs mark test-repo tokens as sensitive: encrypted at rest, removed from API responses, and never logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->