### PR TITLE
feat: auto-suggest marking failure as reviewed on comment/linked issue

### DIFF
--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -35,6 +35,8 @@ interface BugCreationDialogProps {
   includeLinks?: boolean
   availableRepos?: Array<{ name: string; url: string }>
   defaultProjectKey?: string
+  /** Called after a bug issue is successfully created (with the issue URL). */
+  onIssueCreated?: (url: string) => void
 }
 
 export function BugCreationDialog({
@@ -50,6 +52,7 @@ export function BugCreationDialog({
   aiModel,
   availableRepos,
   defaultProjectKey,
+  onIssueCreated,
 }: BugCreationDialogProps) {
   const dispatch = useReportDispatch()
   const refreshEnrichments = useRefreshEnrichments()
@@ -166,6 +169,7 @@ export function BugCreationDialog({
       })
       setCreatedUrl(res.url)
       setPhase('success')
+      onIssueCreated?.(res.url)
 
       // After successful creation, refresh comments to get the server-added comment
       api.get<CommentsAndReviews>(`/results/${jobId}/comments`)

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -144,7 +144,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
       }
       dispatch({ type: 'ADD_COMMENT', payload: fresh })
       refreshEnrichments(jobId)
-      maybeSuggest(submittedText)
+      void maybeSuggest(submittedText)
       // Clear text
       setText('')
     } catch (err) {

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -71,7 +71,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
   const scopedChildJobName = childJobName ?? ''
   const scopedChildBuildNumber = childBuildNumber ?? 0
 
-  const { showSuggestion, loading: reviewLoading, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
+  const { showSuggestion, loading: reviewLoading, error: reviewError, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
     jobId,
     testName: testNames[0],
     childJobName,
@@ -283,6 +283,9 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
         onConfirm={confirmSuggestion}
         loading={reviewLoading}
       />
+      {reviewError && (
+        <span className="text-sm text-destructive">{reviewError}</span>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { LinkedText } from '@/components/shared/LinkedText'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { MentionTextarea } from './MentionTextarea'
+import { useReviewSuggestion } from './useReviewSuggestion'
 import { Trash2, MessageSquare } from 'lucide-react'
 import type { Comment } from '@/types'
 
@@ -69,6 +70,13 @@ interface CommentsSectionProps {
 export function CommentsSection({ jobId, testNames, childJobName, childBuildNumber }: CommentsSectionProps) {
   const scopedChildJobName = childJobName ?? ''
   const scopedChildBuildNumber = childBuildNumber ?? 0
+
+  const { showSuggestion, loading: reviewLoading, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
+    jobId,
+    testName: testNames[0],
+    childJobName,
+    childBuildNumber,
+  })
 
   const { comments, enrichments } = useReportState()
   const dispatch = useReportDispatch()
@@ -136,6 +144,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
       }
       dispatch({ type: 'ADD_COMMENT', payload: fresh })
       refreshEnrichments(jobId)
+      maybeSuggest(submittedText)
       // Clear text
       setText('')
     } catch (err) {
@@ -262,6 +271,17 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
         variant="destructive"
         onConfirm={() => { if (deleteTarget !== null) handleDelete(deleteTarget) }}
         loading={deleteTarget !== null && deletingIds.has(deleteTarget)}
+      />
+
+      <ConfirmDialog
+        open={showSuggestion}
+        onOpenChange={(open) => { if (!open) dismissSuggestion() }}
+        title="Mark as reviewed?"
+        description="Your comment suggests this failure has been reviewed. Would you like to mark it as reviewed?"
+        confirmLabel="Yes"
+        cancelLabel="No"
+        onConfirm={confirmSuggestion}
+        loading={reviewLoading}
       />
     </div>
   )

--- a/frontend/src/pages/report/CommentsSection.tsx
+++ b/frontend/src/pages/report/CommentsSection.tsx
@@ -284,7 +284,7 @@ export function CommentsSection({ jobId, testNames, childJobName, childBuildNumb
         loading={reviewLoading}
       />
       {reviewError && (
-        <span className="text-sm text-destructive">{reviewError}</span>
+        <span className="text-sm text-destructive" role="alert">{reviewError}</span>
       )}
     </div>
   )

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -519,7 +519,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
               ? repoUrls.map(({ name, url }) => ({ name, url }))
               : undefined
           }
-          onIssueCreated={(url) => maybeSuggestBugReview(url)}
+          onIssueCreated={(url) => void maybeSuggestBugReview(url)}
         />
       )}
 

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -534,7 +534,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
         loading={bugReviewLoading}
       />
       {bugReviewError && (
-        <span className="text-sm text-destructive">{bugReviewError}</span>
+        <span className="text-sm text-destructive" role="alert">{bugReviewError}</span>
       )}
     </>
   )

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -107,7 +107,10 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const [includeLinks, setIncludeLinks] = useState(false)
   const { copiedKey: copiedSection, copy: copyToClipboard } = useClipboard()
 
-  const { showSuggestion: showBugReviewSuggestion, loading: bugReviewLoading, maybeSuggest: maybeSuggestBugReview, dismissSuggestion: dismissBugReviewSuggestion, confirmSuggestion: confirmBugReviewSuggestion } = useReviewSuggestion({
+  const rep = group.tests[0]
+  const analysis = rep.analysis
+
+  const { showSuggestion: showBugReviewSuggestion, loading: bugReviewLoading, error: bugReviewError, maybeSuggest: maybeSuggestBugReview, dismissSuggestion: dismissBugReviewSuggestion, confirmSuggestion: confirmBugReviewSuggestion } = useReviewSuggestion({
     jobId,
     testName: rep.test_name,
     childJobName,
@@ -139,8 +142,6 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const scopedReviewKey = (testName: string) =>
     reviewKey(testName, scopedChildJobName, scopedChildBuildNumber)
 
-  const rep = group.tests[0]
-  const analysis = rep.analysis
   const repKey = scopedReviewKey(rep.test_name)
   const classification = classifications[repKey] ?? analysis.classification
   const borderColor = classification === 'PRODUCT BUG' ? 'border-l-signal-orange' : 'border-l-signal-blue'
@@ -532,6 +533,9 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
         onConfirm={confirmBugReviewSuggestion}
         loading={bugReviewLoading}
       />
+      {bugReviewError && (
+        <span className="text-sm text-destructive">{bugReviewError}</span>
+      )}
     </>
   )
 }

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -19,6 +19,8 @@ import { ReviewToggle } from './ReviewToggle'
 import { CommentsSection } from './CommentsSection'
 import { ClassificationSelect } from './ClassificationSelect'
 import { BugCreationDialog } from './BugCreationDialog'
+import { useReviewSuggestion } from './useReviewSuggestion'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { ChevronDown, ChevronRight, Bug, MessageSquare, CheckCircle2, Copy, Check, Clock } from 'lucide-react'
 
 function IssueButton({ disabled, tooltip, label, onClick }: {
@@ -104,6 +106,13 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
   const [selectedModel, setSelectedModel] = useState(result?.ai_model ?? '')
   const [includeLinks, setIncludeLinks] = useState(false)
   const { copiedKey: copiedSection, copy: copyToClipboard } = useClipboard()
+
+  const { showSuggestion: showBugReviewSuggestion, loading: bugReviewLoading, maybeSuggest: maybeSuggestBugReview, dismissSuggestion: dismissBugReviewSuggestion, confirmSuggestion: confirmBugReviewSuggestion } = useReviewSuggestion({
+    jobId,
+    testName: rep.test_name,
+    childJobName,
+    childBuildNumber,
+  })
 
   const repoUrls = useMemo<RepoUrl[]>(
     () => buildRepoUrls(result?.request_params),
@@ -509,8 +518,20 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
               ? repoUrls.map(({ name, url }) => ({ name, url }))
               : undefined
           }
+          onIssueCreated={(url) => maybeSuggestBugReview(url)}
         />
       )}
+
+      <ConfirmDialog
+        open={showBugReviewSuggestion}
+        onOpenChange={(open) => { if (!open) dismissBugReviewSuggestion() }}
+        title="Mark as reviewed?"
+        description="A bug issue was linked to this failure. Would you like to mark it as reviewed?"
+        confirmLabel="Yes"
+        cancelLabel="No"
+        onConfirm={confirmBugReviewSuggestion}
+        loading={bugReviewLoading}
+      />
     </>
   )
 }

--- a/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
+++ b/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
@@ -65,7 +65,7 @@ describe('suggestsReviewed', () => {
 /** Test harness that exposes hook state and actions via rendered UI. */
 function HookHarness({ setReviewed }: { setReviewed?: boolean }) {
   const dispatch = useReportDispatch()
-  const { showSuggestion, loading, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
+  const { showSuggestion, loading, error, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
     jobId: 'job-1',
     testName: 'test-a',
   })
@@ -84,6 +84,7 @@ function HookHarness({ setReviewed }: { setReviewed?: boolean }) {
     <>
       <span data-testid="show">{String(showSuggestion)}</span>
       <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ?? ''}</span>
       <button data-testid="suggest-url" onClick={() => maybeSuggest('See https://jira.example.com/BUG-1')}>Suggest URL</button>
       <button data-testid="suggest-keyword" onClick={() => maybeSuggest('This is a known issue')}>Suggest Keyword</button>
       <button data-testid="suggest-generic" onClick={() => maybeSuggest('Looking into it')}>Suggest Generic</button>
@@ -142,7 +143,9 @@ describe('useReviewSuggestion hook', () => {
   it('does not show suggestion when already reviewed', async () => {
     renderHarness({ setReviewed: true })
     // Wait for the SET_REVIEW dispatch to take effect
-    await waitFor(() => {})
+    await waitFor(() => {
+      expect(screen.getByTestId('show').textContent).toBe('false')
+    })
     fireEvent.click(screen.getByTestId('suggest-url'))
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
@@ -173,6 +176,21 @@ describe('useReviewSuggestion hook', () => {
       })
     })
 
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('sets error when review API call fails', async () => {
+    mockPut.mockRejectedValueOnce(new Error('Network error'))
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toBe('Network error')
+    })
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
 })

--- a/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
+++ b/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { useEffect } from 'react'
 import { ReportProvider, useReportDispatch } from '../ReportContext'
-import { suggestsReviewed, useReviewSuggestion } from '../useReviewSuggestion'
+import { useReviewSuggestion } from '../useReviewSuggestion'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 
 /* ------------------------------------------------------------------ */
@@ -14,49 +14,15 @@ vi.mock('@/lib/cookies', () => ({
 }))
 
 const mockPut = vi.fn()
+const mockPost = vi.fn()
 
 vi.mock('@/lib/api', () => ({
   api: {
     put: (...args: unknown[]) => mockPut(...args),
+    post: (...args: unknown[]) => mockPost(...args),
     get: vi.fn().mockResolvedValue({ users: [] }),
-    post: vi.fn().mockResolvedValue({}),
   },
 }))
-
-/* ------------------------------------------------------------------ */
-/*  suggestsReviewed unit tests                                        */
-/* ------------------------------------------------------------------ */
-
-describe('suggestsReviewed', () => {
-  it('returns true for text containing a URL', () => {
-    expect(suggestsReviewed('See https://jira.example.com/browse/BUG-123')).toBe(true)
-    expect(suggestsReviewed('Fixed in http://github.com/org/repo/pull/42')).toBe(true)
-  })
-
-  it('returns true for text containing review-suggesting keywords', () => {
-    expect(suggestsReviewed('This is a known issue')).toBe(true)
-    expect(suggestsReviewed('Root cause identified')).toBe(true)
-    expect(suggestsReviewed('Already fixed in main')).toBe(true)
-    expect(suggestsReviewed('Workaround applied')).toBe(true)
-    expect(suggestsReviewed('Issue resolved')).toBe(true)
-    expect(suggestsReviewed('Bug filed for this')).toBe(true)
-    expect(suggestsReviewed('Created JIRA ticket')).toBe(true)
-    expect(suggestsReviewed('Tracked in backlog')).toBe(true)
-    expect(suggestsReviewed('This is a duplicate of another failure')).toBe(true)
-  })
-
-  it('is case-insensitive for keywords', () => {
-    expect(suggestsReviewed('KNOWN ISSUE with this test')).toBe(true)
-    expect(suggestsReviewed('Root Cause: config mismatch')).toBe(true)
-  })
-
-  it('returns false for generic comments', () => {
-    expect(suggestsReviewed('Looking into this')).toBe(false)
-    expect(suggestsReviewed('Need to investigate')).toBe(false)
-    expect(suggestsReviewed('Not sure what happened')).toBe(false)
-    expect(suggestsReviewed('')).toBe(false)
-  })
-})
 
 /* ------------------------------------------------------------------ */
 /*  useReviewSuggestion hook integration tests                         */
@@ -85,9 +51,8 @@ function HookHarness({ setReviewed }: { setReviewed?: boolean }) {
       <span data-testid="show">{String(showSuggestion)}</span>
       <span data-testid="loading">{String(loading)}</span>
       <span data-testid="error">{error ?? ''}</span>
-      <button data-testid="suggest-url" onClick={() => maybeSuggest('See https://jira.example.com/BUG-1')}>Suggest URL</button>
-      <button data-testid="suggest-keyword" onClick={() => maybeSuggest('This is a known issue')}>Suggest Keyword</button>
-      <button data-testid="suggest-generic" onClick={() => maybeSuggest('Looking into it')}>Suggest Generic</button>
+      <button data-testid="suggest-reviewed" onClick={() => void maybeSuggest('This is a known issue')}>Suggest Reviewed</button>
+      <button data-testid="suggest-not-reviewed" onClick={() => void maybeSuggest('Looking into it')}>Suggest Not Reviewed</button>
       <ConfirmDialog
         open={showSuggestion}
         onOpenChange={(open) => { if (!open) dismissSuggestion() }}
@@ -121,47 +86,91 @@ describe('useReviewSuggestion hook', () => {
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
 
-  it('shows suggestion when comment contains a URL', () => {
+  it('shows suggestion when API returns suggests_reviewed: true', async () => {
+    mockPost.mockResolvedValueOnce({ suggests_reviewed: true, reason: 'Contains known issue reference' })
     renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-url'))
-    expect(screen.getByTestId('show').textContent).toBe('true')
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('show').textContent).toBe('true')
+    })
+    expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue' })
     expect(screen.getByText('Mark as reviewed?')).toBeDefined()
   })
 
-  it('shows suggestion when comment contains a keyword', () => {
+  it('does not show suggestion when API returns suggests_reviewed: false', async () => {
+    mockPost.mockResolvedValueOnce({ suggests_reviewed: false, reason: 'Generic comment' })
     renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-keyword'))
-    expect(screen.getByTestId('show').textContent).toBe('true')
-  })
 
-  it('does not show suggestion for generic comments', () => {
-    renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-generic'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-not-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'Looking into it' })
+    })
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
 
-  it('does not show suggestion when already reviewed', async () => {
+  it('does not show suggestion when API call fails (safe default)', async () => {
+    mockPost.mockRejectedValueOnce(new Error('Network error'))
+    renderHarness()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue' })
+    })
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('does not call API when already reviewed', async () => {
     renderHarness({ setReviewed: true })
     // Wait for the SET_REVIEW dispatch to take effect
     await waitFor(() => {
       expect(screen.getByTestId('show').textContent).toBe('false')
     })
-    fireEvent.click(screen.getByTestId('suggest-url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    expect(mockPost).not.toHaveBeenCalled()
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
 
-  it('dismisses suggestion when No is clicked', () => {
+  it('dismisses suggestion when No is clicked', async () => {
+    mockPost.mockResolvedValueOnce({ suggests_reviewed: true, reason: 'Match' })
     renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-url'))
-    expect(screen.getByTestId('show').textContent).toBe('true')
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('show').textContent).toBe('true')
+    })
 
     fireEvent.click(screen.getByRole('button', { name: 'No' }))
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
 
   it('calls review API and hides dialog when Yes is clicked', async () => {
+    mockPost.mockResolvedValueOnce({ suggests_reviewed: true, reason: 'Match' })
     renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('show').textContent).toBe('true')
+    })
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
@@ -180,9 +189,17 @@ describe('useReviewSuggestion hook', () => {
   })
 
   it('sets error when review API call fails', async () => {
+    mockPost.mockResolvedValueOnce({ suggests_reviewed: true, reason: 'Match' })
     mockPut.mockRejectedValueOnce(new Error('Network error'))
     renderHarness()
-    fireEvent.click(screen.getByTestId('suggest-url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('suggest-reviewed'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('show').textContent).toBe('true')
+    })
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Yes' }))

--- a/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
+++ b/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { useEffect } from 'react'
+import { ReportProvider, useReportDispatch } from '../ReportContext'
+import { suggestsReviewed, useReviewSuggestion } from '../useReviewSuggestion'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+vi.mock('@/lib/cookies', () => ({
+  getUsername: () => 'testuser',
+}))
+
+const mockPut = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    put: (...args: unknown[]) => mockPut(...args),
+    get: vi.fn().mockResolvedValue({ users: [] }),
+    post: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+/* ------------------------------------------------------------------ */
+/*  suggestsReviewed unit tests                                        */
+/* ------------------------------------------------------------------ */
+
+describe('suggestsReviewed', () => {
+  it('returns true for text containing a URL', () => {
+    expect(suggestsReviewed('See https://jira.example.com/browse/BUG-123')).toBe(true)
+    expect(suggestsReviewed('Fixed in http://github.com/org/repo/pull/42')).toBe(true)
+  })
+
+  it('returns true for text containing review-suggesting keywords', () => {
+    expect(suggestsReviewed('This is a known issue')).toBe(true)
+    expect(suggestsReviewed('Root cause identified')).toBe(true)
+    expect(suggestsReviewed('Already fixed in main')).toBe(true)
+    expect(suggestsReviewed('Workaround applied')).toBe(true)
+    expect(suggestsReviewed('Issue resolved')).toBe(true)
+    expect(suggestsReviewed('Bug filed for this')).toBe(true)
+    expect(suggestsReviewed('Created JIRA ticket')).toBe(true)
+    expect(suggestsReviewed('Tracked in backlog')).toBe(true)
+    expect(suggestsReviewed('This is a duplicate of another failure')).toBe(true)
+  })
+
+  it('is case-insensitive for keywords', () => {
+    expect(suggestsReviewed('KNOWN ISSUE with this test')).toBe(true)
+    expect(suggestsReviewed('Root Cause: config mismatch')).toBe(true)
+  })
+
+  it('returns false for generic comments', () => {
+    expect(suggestsReviewed('Looking into this')).toBe(false)
+    expect(suggestsReviewed('Need to investigate')).toBe(false)
+    expect(suggestsReviewed('Not sure what happened')).toBe(false)
+    expect(suggestsReviewed('')).toBe(false)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  useReviewSuggestion hook integration tests                         */
+/* ------------------------------------------------------------------ */
+
+/** Test harness that exposes hook state and actions via rendered UI. */
+function HookHarness({ setReviewed }: { setReviewed?: boolean }) {
+  const dispatch = useReportDispatch()
+  const { showSuggestion, loading, maybeSuggest, dismissSuggestion, confirmSuggestion } = useReviewSuggestion({
+    jobId: 'job-1',
+    testName: 'test-a',
+  })
+
+  // Optionally pre-set the review state
+  useEffect(() => {
+    if (setReviewed) {
+      dispatch({
+        type: 'SET_REVIEW',
+        payload: { key: 'test-a', state: { reviewed: true, username: 'someone', updated_at: new Date().toISOString() } },
+      })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <>
+      <span data-testid="show">{String(showSuggestion)}</span>
+      <span data-testid="loading">{String(loading)}</span>
+      <button data-testid="suggest-url" onClick={() => maybeSuggest('See https://jira.example.com/BUG-1')}>Suggest URL</button>
+      <button data-testid="suggest-keyword" onClick={() => maybeSuggest('This is a known issue')}>Suggest Keyword</button>
+      <button data-testid="suggest-generic" onClick={() => maybeSuggest('Looking into it')}>Suggest Generic</button>
+      <ConfirmDialog
+        open={showSuggestion}
+        onOpenChange={(open) => { if (!open) dismissSuggestion() }}
+        title="Mark as reviewed?"
+        description="Would you like to mark it as reviewed?"
+        confirmLabel="Yes"
+        cancelLabel="No"
+        onConfirm={confirmSuggestion}
+        loading={loading}
+      />
+    </>
+  )
+}
+
+function renderHarness(props: { setReviewed?: boolean } = {}) {
+  return render(
+    <ReportProvider>
+      <HookHarness {...props} />
+    </ReportProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPut.mockResolvedValue({ status: 'ok', reviewed_by: 'testuser' })
+})
+
+describe('useReviewSuggestion hook', () => {
+  it('does not show suggestion initially', () => {
+    renderHarness()
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('shows suggestion when comment contains a URL', () => {
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-url'))
+    expect(screen.getByTestId('show').textContent).toBe('true')
+    expect(screen.getByText('Mark as reviewed?')).toBeDefined()
+  })
+
+  it('shows suggestion when comment contains a keyword', () => {
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-keyword'))
+    expect(screen.getByTestId('show').textContent).toBe('true')
+  })
+
+  it('does not show suggestion for generic comments', () => {
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-generic'))
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('does not show suggestion when already reviewed', async () => {
+    renderHarness({ setReviewed: true })
+    // Wait for the SET_REVIEW dispatch to take effect
+    await waitFor(() => {})
+    fireEvent.click(screen.getByTestId('suggest-url'))
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('dismisses suggestion when No is clicked', () => {
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-url'))
+    expect(screen.getByTestId('show').textContent).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'No' }))
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+
+  it('calls review API and hides dialog when Yes is clicked', async () => {
+    renderHarness()
+    fireEvent.click(screen.getByTestId('suggest-url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+    })
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith('/results/job-1/reviewed', {
+        test_name: 'test-a',
+        reviewed: true,
+        child_job_name: '',
+        child_build_number: 0,
+      })
+    })
+
+    expect(screen.getByTestId('show').textContent).toBe('false')
+  })
+})

--- a/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
+++ b/frontend/src/pages/report/__tests__/useReviewSuggestion.test.tsx
@@ -97,7 +97,7 @@ describe('useReviewSuggestion hook', () => {
     await waitFor(() => {
       expect(screen.getByTestId('show').textContent).toBe('true')
     })
-    expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue' })
+    expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue', job_id: 'job-1' })
     expect(screen.getByText('Mark as reviewed?')).toBeDefined()
   })
 
@@ -110,7 +110,7 @@ describe('useReviewSuggestion hook', () => {
     })
 
     await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'Looking into it' })
+      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'Looking into it', job_id: 'job-1' })
     })
     expect(screen.getByTestId('show').textContent).toBe('false')
   })
@@ -124,7 +124,7 @@ describe('useReviewSuggestion hook', () => {
     })
 
     await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue' })
+      expect(mockPost).toHaveBeenCalledWith('/api/analyze-comment-intent', { comment: 'This is a known issue', job_id: 'job-1' })
     })
     expect(screen.getByTestId('show').textContent).toBe('false')
   })

--- a/frontend/src/pages/report/useReviewSuggestion.ts
+++ b/frontend/src/pages/report/useReviewSuggestion.ts
@@ -31,7 +31,7 @@ export function useReviewSuggestion({ jobId, testName, childJobName, childBuildN
       try {
         const res = await api.post<{ suggests_reviewed: boolean; reason: string }>(
           '/api/analyze-comment-intent',
-          { comment: commentText },
+          { comment: commentText, job_id: jobId },
         )
         if (res.suggests_reviewed) {
           setShowSuggestion(true)

--- a/frontend/src/pages/report/useReviewSuggestion.ts
+++ b/frontend/src/pages/report/useReviewSuggestion.ts
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react'
+import { api } from '@/lib/api'
+import { getUsername } from '@/lib/cookies'
+import { useReportState, useReportDispatch, reviewKey } from './ReportContext'
+
+/* ------------------------------------------------------------------ */
+/*  Detection helper                                                   */
+/* ------------------------------------------------------------------ */
+
+const URL_RE = /https?:\/\//
+const KEYWORD_RE = /\b(known issue|fixed|root cause|workaround|resolved|bug filed|jira|tracked|duplicate)\b/i
+
+/** Returns true if the comment text implies the failure has been reviewed. */
+export function suggestsReviewed(commentText: string): boolean {
+  if (URL_RE.test(commentText)) return true
+  return KEYWORD_RE.test(commentText)
+}
+
+/* ------------------------------------------------------------------ */
+/*  Hook                                                               */
+/* ------------------------------------------------------------------ */
+
+interface UseReviewSuggestionOptions {
+  jobId: string
+  testName: string
+  childJobName?: string
+  childBuildNumber?: number
+}
+
+export function useReviewSuggestion({ jobId, testName, childJobName, childBuildNumber }: UseReviewSuggestionOptions) {
+  const { reviews } = useReportState()
+  const dispatch = useReportDispatch()
+  const [showSuggestion, setShowSuggestion] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const key = reviewKey(testName, childJobName, childBuildNumber)
+  const isAlreadyReviewed = reviews[key]?.reviewed ?? false
+
+  /** Call after a comment is added. If it implies review and not already reviewed, show the prompt. */
+  const maybeSuggest = useCallback(
+    (commentText: string) => {
+      if (isAlreadyReviewed) return
+      if (suggestsReviewed(commentText)) {
+        setShowSuggestion(true)
+      }
+    },
+    [isAlreadyReviewed],
+  )
+
+  const dismissSuggestion = useCallback(() => {
+    setShowSuggestion(false)
+  }, [])
+
+  const confirmSuggestion = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await api.put<{ status: string; reviewed_by: string }>(`/results/${jobId}/reviewed`, {
+        test_name: testName,
+        reviewed: true,
+        child_job_name: childJobName ?? '',
+        child_build_number: childBuildNumber ?? 0,
+      })
+      const username = res.reviewed_by ?? getUsername()
+      dispatch({
+        type: 'SET_REVIEW',
+        payload: { key, state: { reviewed: true, username, updated_at: new Date().toISOString() } },
+      })
+    } finally {
+      setLoading(false)
+      setShowSuggestion(false)
+    }
+  }, [jobId, testName, childJobName, childBuildNumber, key, dispatch])
+
+  return { showSuggestion, loading, maybeSuggest, dismissSuggestion, confirmSuggestion }
+}

--- a/frontend/src/pages/report/useReviewSuggestion.ts
+++ b/frontend/src/pages/report/useReviewSuggestion.ts
@@ -32,6 +32,7 @@ export function useReviewSuggestion({ jobId, testName, childJobName, childBuildN
   const dispatch = useReportDispatch()
   const [showSuggestion, setShowSuggestion] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const key = reviewKey(testName, childJobName, childBuildNumber)
   const isAlreadyReviewed = reviews[key]?.reviewed ?? false
@@ -53,6 +54,7 @@ export function useReviewSuggestion({ jobId, testName, childJobName, childBuildN
 
   const confirmSuggestion = useCallback(async () => {
     setLoading(true)
+    setError(null)
     try {
       const res = await api.put<{ status: string; reviewed_by: string }>(`/results/${jobId}/reviewed`, {
         test_name: testName,
@@ -65,11 +67,13 @@ export function useReviewSuggestion({ jobId, testName, childJobName, childBuildN
         type: 'SET_REVIEW',
         payload: { key, state: { reviewed: true, username, updated_at: new Date().toISOString() } },
       })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to mark as reviewed')
     } finally {
       setLoading(false)
       setShowSuggestion(false)
     }
   }, [jobId, testName, childJobName, childBuildNumber, key, dispatch])
 
-  return { showSuggestion, loading, maybeSuggest, dismissSuggestion, confirmSuggestion }
+  return { showSuggestion, loading, error, maybeSuggest, dismissSuggestion, confirmSuggestion }
 }

--- a/frontend/src/pages/report/useReviewSuggestion.ts
+++ b/frontend/src/pages/report/useReviewSuggestion.ts
@@ -4,19 +4,6 @@ import { getUsername } from '@/lib/cookies'
 import { useReportState, useReportDispatch, reviewKey } from './ReportContext'
 
 /* ------------------------------------------------------------------ */
-/*  Detection helper                                                   */
-/* ------------------------------------------------------------------ */
-
-const URL_RE = /https?:\/\//
-const KEYWORD_RE = /\b(known issue|fixed|root cause|workaround|resolved|bug filed|jira|tracked|duplicate)\b/i
-
-/** Returns true if the comment text implies the failure has been reviewed. */
-export function suggestsReviewed(commentText: string): boolean {
-  if (URL_RE.test(commentText)) return true
-  return KEYWORD_RE.test(commentText)
-}
-
-/* ------------------------------------------------------------------ */
 /*  Hook                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -37,12 +24,20 @@ export function useReviewSuggestion({ jobId, testName, childJobName, childBuildN
   const key = reviewKey(testName, childJobName, childBuildNumber)
   const isAlreadyReviewed = reviews[key]?.reviewed ?? false
 
-  /** Call after a comment is added. If it implies review and not already reviewed, show the prompt. */
+  /** Call after a comment is added. Asks the backend whether the comment implies the failure has been reviewed. */
   const maybeSuggest = useCallback(
-    (commentText: string) => {
+    async (commentText: string) => {
       if (isAlreadyReviewed) return
-      if (suggestsReviewed(commentText)) {
-        setShowSuggestion(true)
+      try {
+        const res = await api.post<{ suggests_reviewed: boolean; reason: string }>(
+          '/api/analyze-comment-intent',
+          { comment: commentText },
+        )
+        if (res.suggests_reviewed) {
+          setShowSuggestion(true)
+        }
+      } catch {
+        // AI analysis failed — don't prompt (safe default)
       }
     },
     [isAlreadyReviewed],

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -818,3 +818,9 @@ class JJIClient:
         return self._request(
             "POST", "/api/jobs/metadata/rules/preview", json={"job_name": job_name}
         )
+
+    def analyze_comment_intent(self, comment: str) -> dict:
+        """Analyze whether a comment suggests a failure is reviewed. POST /api/analyze-comment-intent"""
+        return self._request(
+            "POST", "/api/analyze-comment-intent", json={"comment": comment}
+        )

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -819,8 +819,13 @@ class JJIClient:
             "POST", "/api/jobs/metadata/rules/preview", json={"job_name": job_name}
         )
 
-    def analyze_comment_intent(self, comment: str) -> dict:
+    def analyze_comment_intent(
+        self, comment: str, *, ai_provider: str = "", ai_model: str = ""
+    ) -> dict:
         """Analyze whether a comment suggests a failure is reviewed. POST /api/analyze-comment-intent"""
-        return self._request(
-            "POST", "/api/analyze-comment-intent", json={"comment": comment}
-        )
+        payload: dict = {"comment": comment}
+        if ai_provider:
+            payload["ai_provider"] = ai_provider
+        if ai_model:
+            payload["ai_model"] = ai_model
+        return self._request("POST", "/api/analyze-comment-intent", json=payload)

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -820,10 +820,17 @@ class JJIClient:
         )
 
     def analyze_comment_intent(
-        self, comment: str, *, ai_provider: str = "", ai_model: str = ""
+        self,
+        comment: str,
+        *,
+        job_id: str = "",
+        ai_provider: str = "",
+        ai_model: str = "",
     ) -> dict:
         """Analyze whether a comment suggests a failure is reviewed. POST /api/analyze-comment-intent"""
         payload: dict = {"comment": comment}
+        if job_id:
+            payload["job_id"] = job_id
         if ai_provider:
             payload["ai_provider"] = ai_provider
         if ai_model:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1817,6 +1817,29 @@ def override_classification_cmd(
         typer.echo(f"Classification overridden to: {data.get('classification', '')}")
 
 
+@app.command("analyze-comment-intent")
+def analyze_comment_intent_cmd(
+    comment: str = typer.Argument(help="Comment text to analyze."),
+    json_output: bool = _JSON_OPTION,
+):
+    """Analyze whether a comment suggests a failure has been reviewed/resolved."""
+    _set_json(json_output)
+    try:
+        client = _get_client()
+        data = client.analyze_comment_intent(comment=comment)
+    except JJIError as err:
+        _handle_error(err)
+
+    if _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
+    else:
+        reviewed = data.get("suggests_reviewed", False)
+        reason = data.get("reason", "")
+        typer.echo(f"Suggests reviewed: {reviewed}")
+        if reason:
+            typer.echo(f"Reason: {reason}")
+
+
 # -- Auth ---------------------------------------------------------------------
 
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1820,13 +1820,21 @@ def override_classification_cmd(
 @app.command("analyze-comment-intent")
 def analyze_comment_intent_cmd(
     comment: str = typer.Argument(help="Comment text to analyze."),
+    ai_provider: str = typer.Option(
+        "", "--ai-provider", help="AI provider for content generation."
+    ),
+    ai_model: str = typer.Option(
+        "", "--ai-model", help="AI model for content generation."
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Analyze whether a comment suggests a failure has been reviewed/resolved."""
     _set_json(json_output)
     try:
         client = _get_client()
-        data = client.analyze_comment_intent(comment=comment)
+        data = client.analyze_comment_intent(
+            comment=comment, ai_provider=ai_provider, ai_model=ai_model
+        )
     except JJIError as err:
         _handle_error(err)
 

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1820,6 +1820,9 @@ def override_classification_cmd(
 @app.command("analyze-comment-intent")
 def analyze_comment_intent_cmd(
     comment: str = typer.Argument(help="Comment text to analyze."),
+    job_id: str = typer.Option(
+        "", "--job-id", help="Job ID to resolve AI config from the analyzed job."
+    ),
     ai_provider: str = typer.Option(
         "", "--ai-provider", help="AI provider for content generation."
     ),
@@ -1833,7 +1836,7 @@ def analyze_comment_intent_cmd(
     try:
         client = _get_client()
         data = client.analyze_comment_intent(
-            comment=comment, ai_provider=ai_provider, ai_model=ai_model
+            comment=comment, job_id=job_id, ai_provider=ai_provider, ai_model=ai_model
         )
     except JJIError as err:
         _handle_error(err)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4701,7 +4701,18 @@ async def analyze_comment_intent(
 ) -> AnalyzeCommentResponse:
     """Analyze a comment to determine if it implies a failure has been reviewed/resolved."""
     _check_allow_list(request)
-    ai_provider, ai_model = _resolve_ai_config_values(body.ai_provider, body.ai_model)
+
+    ai_provider = body.ai_provider or AI_PROVIDER
+    ai_model = body.ai_model or AI_MODEL
+    if (not ai_provider or not ai_model) and body.job_id:
+        stored = await storage.get_result(body.job_id)
+        if stored and stored.get("result"):
+            params = stored["result"].get("request_params", {})
+            if not ai_provider:
+                ai_provider = params.get("ai_provider", "")
+            if not ai_model:
+                ai_model = params.get("ai_model", "")
+    ai_provider, ai_model = _resolve_ai_config_values(ai_provider, ai_model)
 
     from ai_cli_runner import call_ai_cli
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -70,6 +70,8 @@ from jenkins_job_insight.notifications import send_mention_notifications
 from jenkins_job_insight.vapid import get_vapid_config
 from jenkins_job_insight.models import (
     AddCommentRequest,
+    AnalyzeCommentRequest,
+    AnalyzeCommentResponse,
     AnalyzeFailuresRequest,
     AnalyzeRequest,
     BaseAnalysisRequest,
@@ -4691,6 +4693,76 @@ async def get_mentionable_users(request: Request):
     _check_allow_list(request)
     users = await storage.list_users()
     return {"usernames": [u["username"] for u in users]}
+
+
+@app.post("/api/analyze-comment-intent", response_model=AnalyzeCommentResponse)
+async def analyze_comment_intent(
+    request: Request, body: AnalyzeCommentRequest
+) -> AnalyzeCommentResponse:
+    """Analyze a comment to determine if it implies a failure has been reviewed/resolved."""
+    _check_allow_list(request)
+    ai_provider, ai_model = _resolve_ai_config_values(None, None)
+
+    from ai_cli_runner import call_ai_cli
+
+    from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
+
+    prompt = """You are analyzing a comment left on a test failure report.
+Does this comment imply the failure has been reviewed or resolved?
+
+Examples that SUGGEST reviewed/resolved:
+- Bug filed with a link (e.g., "Filed JIRA-123 for this")
+- Root cause identified (e.g., "This is caused by the config change in PR #456")
+- Known issue noted (e.g., "Known flaky test, tracked in BUG-789")
+- Fix merged (e.g., "Fixed in commit abc123")
+
+Examples that DO NOT suggest reviewed/resolved:
+- Asking for more info (e.g., "Can someone check the logs?")
+- Sharing logs for context (e.g., "Here's the full stack trace: ...")
+- Linking docs (e.g., "See the troubleshooting guide: ...")
+- General discussion (e.g., "This started happening after the last deploy")
+
+Comment:
+"""
+    prompt += body.comment
+    prompt += """
+
+Respond with ONLY a JSON object:
+{"suggests_reviewed": true/false, "reason": "brief explanation"}"""
+
+    result = await call_ai_cli(
+        prompt,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        ai_cli_timeout=1,
+        cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
+    )
+
+    from jenkins_job_insight.token_tracking import record_ai_usage
+
+    await record_ai_usage(
+        job_id="comment-intent",
+        result=result,
+        call_type="comment_intent",
+        prompt_chars=len(prompt),
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+    )
+
+    if not result.success:
+        logger.debug("AI CLI call failed for comment intent analysis: %s", result.text)
+        return AnalyzeCommentResponse(suggests_reviewed=False)
+
+    try:
+        parsed = json.loads(result.text)
+        return AnalyzeCommentResponse(
+            suggests_reviewed=bool(parsed.get("suggests_reviewed", False)),
+            reason=str(parsed.get("reason", "")),
+        )
+    except (json.JSONDecodeError, AttributeError):
+        logger.debug("Failed to parse AI response for comment intent: %s", result.text)
+        return AnalyzeCommentResponse(suggests_reviewed=False)
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4701,7 +4701,7 @@ async def analyze_comment_intent(
 ) -> AnalyzeCommentResponse:
     """Analyze a comment to determine if it implies a failure has been reviewed/resolved."""
     _check_allow_list(request)
-    ai_provider, ai_model = _resolve_ai_config_values(None, None)
+    ai_provider, ai_model = _resolve_ai_config_values(body.ai_provider, body.ai_model)
 
     from ai_cli_runner import call_ai_cli
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4745,7 +4745,7 @@ Respond with ONLY a JSON object:
         prompt,
         ai_provider=ai_provider,
         ai_model=ai_model,
-        ai_cli_timeout=1,
+        ai_cli_timeout=2,
         cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
         output_format="json",
     )

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -827,6 +827,8 @@ class AnalyzeCommentRequest(BaseModel):
     """Request body for AI-driven comment intent analysis."""
 
     comment: str
+    ai_provider: str | None = None
+    ai_model: str | None = None
 
 
 class AnalyzeCommentResponse(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -827,6 +827,7 @@ class AnalyzeCommentRequest(BaseModel):
     """Request body for AI-driven comment intent analysis."""
 
     comment: str
+    job_id: str = ""  # Used to resolve AI config from the analyzed job
     ai_provider: str | None = None
     ai_model: str | None = None
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -821,3 +821,16 @@ class BulkJobMetadataRequest(BaseModel):
         max_length=1000,
         description="Metadata entries to import (1-1000 per request).",
     )
+
+
+class AnalyzeCommentRequest(BaseModel):
+    """Request body for AI-driven comment intent analysis."""
+
+    comment: str
+
+
+class AnalyzeCommentResponse(BaseModel):
+    """Response from comment intent analysis."""
+
+    suggests_reviewed: bool
+    reason: str = ""

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1499,12 +1499,20 @@ class TestTokenUsage:
 class TestAnalyzeCommentIntent:
     def test_analyze_comment_intent(self):
         expected = {"suggests_reviewed": True, "reason": "Bug filed"}
-        client = _make_client(lambda request: httpx.Response(200, json=expected))
+
+        def handler(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/analyze-comment-intent"
+            return httpx.Response(200, json=expected)
+
+        client = _make_client(handler)
         result = client.analyze_comment_intent(comment="Filed JIRA-123")
         assert result == expected
 
     def test_analyze_comment_intent_with_ai_config(self):
         def check_payload(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/analyze-comment-intent"
             body = json.loads(request.content)
             assert body["comment"] == "Filed JIRA-123"
             assert body["ai_provider"] == "claude"
@@ -1523,6 +1531,8 @@ class TestAnalyzeCommentIntent:
 
     def test_analyze_comment_intent_without_ai_config(self):
         def check_payload(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/analyze-comment-intent"
             body = json.loads(request.content)
             assert "ai_provider" not in body
             assert "ai_model" not in body
@@ -1530,6 +1540,23 @@ class TestAnalyzeCommentIntent:
 
         client = _make_client(check_payload)
         client.analyze_comment_intent(comment="test")
+
+    def test_analyze_comment_intent_with_job_id(self):
+        def check_payload(request):
+            assert request.method == "POST"
+            assert request.url.path == "/api/analyze-comment-intent"
+            body = json.loads(request.content)
+            assert body["comment"] == "Fixed in PR #42"
+            assert body["job_id"] == "job-abc-123"
+            return httpx.Response(
+                200, json={"suggests_reviewed": True, "reason": "PR reference"}
+            )
+
+        client = _make_client(check_payload)
+        result = client.analyze_comment_intent(
+            comment="Fixed in PR #42", job_id="job-abc-123"
+        )
+        assert result["suggests_reviewed"] is True
 
     def test_analyze_comment_intent_failure(self):
         client = _make_client(

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1496,6 +1496,22 @@ class TestTokenUsage:
         assert exc_info.value.status_code == 403
 
 
+class TestAnalyzeCommentIntent:
+    def test_analyze_comment_intent(self):
+        expected = {"suggests_reviewed": True, "reason": "Bug filed"}
+        client = _make_client(lambda request: httpx.Response(200, json=expected))
+        result = client.analyze_comment_intent(comment="Filed JIRA-123")
+        assert result == expected
+
+    def test_analyze_comment_intent_failure(self):
+        client = _make_client(
+            lambda request: httpx.Response(500, json={"detail": "Internal error"})
+        )
+        with pytest.raises(JJIError) as exc_info:
+            client.analyze_comment_intent(comment="test")
+        assert exc_info.value.status_code == 500
+
+
 class TestJJIClientApiKeyHeader:
     def test_api_key_sent_as_bearer_header(self):
         def check_header(request):

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1503,6 +1503,34 @@ class TestAnalyzeCommentIntent:
         result = client.analyze_comment_intent(comment="Filed JIRA-123")
         assert result == expected
 
+    def test_analyze_comment_intent_with_ai_config(self):
+        def check_payload(request):
+            body = json.loads(request.content)
+            assert body["comment"] == "Filed JIRA-123"
+            assert body["ai_provider"] == "claude"
+            assert body["ai_model"] == "claude-sonnet-4-20250514"
+            return httpx.Response(
+                200, json={"suggests_reviewed": True, "reason": "Bug filed"}
+            )
+
+        client = _make_client(check_payload)
+        result = client.analyze_comment_intent(
+            comment="Filed JIRA-123",
+            ai_provider="claude",
+            ai_model="claude-sonnet-4-20250514",
+        )
+        assert result["suggests_reviewed"] is True
+
+    def test_analyze_comment_intent_without_ai_config(self):
+        def check_payload(request):
+            body = json.loads(request.content)
+            assert "ai_provider" not in body
+            assert "ai_model" not in body
+            return httpx.Response(200, json={"suggests_reviewed": False, "reason": ""})
+
+        client = _make_client(check_payload)
+        client.analyze_comment_intent(comment="test")
+
     def test_analyze_comment_intent_failure(self):
         client = _make_client(
             lambda request: httpx.Response(500, json={"detail": "Internal error"})

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -3181,6 +3181,7 @@ class TestAnalyzeCommentIntentCommand:
         assert result.exit_code == 0
         mock_client.analyze_comment_intent.assert_called_once_with(
             comment="Filed JIRA-123",
+            job_id="",
             ai_provider="claude",
             ai_model="claude-sonnet-4-20250514",
         )

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -3129,6 +3129,40 @@ class TestTokenUsageCommand:
         assert "N/A" in result.output
 
 
+class TestAnalyzeCommentIntentCommand:
+    def test_analyze_comment_intent(self, mock_client):
+        mock_client.analyze_comment_intent.return_value = {
+            "suggests_reviewed": True,
+            "reason": "Bug filed with link",
+        }
+        result = runner.invoke(
+            app, ["analyze-comment-intent", "Filed JIRA-123 for this"]
+        )
+        assert result.exit_code == 0
+        assert "True" in result.output
+        assert "Bug filed with link" in result.output
+
+    def test_analyze_comment_intent_not_reviewed(self, mock_client):
+        mock_client.analyze_comment_intent.return_value = {
+            "suggests_reviewed": False,
+            "reason": "",
+        }
+        result = runner.invoke(
+            app, ["analyze-comment-intent", "Can someone check the logs?"]
+        )
+        assert result.exit_code == 0
+        assert "False" in result.output
+
+    def test_analyze_comment_intent_json(self, mock_client):
+        expected = {"suggests_reviewed": True, "reason": "Fix merged"}
+        mock_client.analyze_comment_intent.return_value = expected
+        result = runner.invoke(
+            app, ["--json", "analyze-comment-intent", "Fixed in commit abc123"]
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output) == expected
+
+
 class TestApiKeyOption:
     def test_api_key_passed_to_client(self):
         """--api-key should cause _get_client to create client with api_key."""

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -3162,6 +3162,29 @@ class TestAnalyzeCommentIntentCommand:
         assert result.exit_code == 0
         assert json.loads(result.output) == expected
 
+    def test_analyze_comment_intent_with_ai_options(self, mock_client):
+        mock_client.analyze_comment_intent.return_value = {
+            "suggests_reviewed": True,
+            "reason": "Bug filed",
+        }
+        result = runner.invoke(
+            app,
+            [
+                "analyze-comment-intent",
+                "Filed JIRA-123",
+                "--ai-provider",
+                "claude",
+                "--ai-model",
+                "claude-sonnet-4-20250514",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_client.analyze_comment_intent.assert_called_once_with(
+            comment="Filed JIRA-123",
+            ai_provider="claude",
+            ai_model="claude-sonnet-4-20250514",
+        )
+
 
 class TestApiKeyOption:
     def test_api_key_passed_to_client(self):

--- a/tests/test_comment_intent.py
+++ b/tests/test_comment_intent.py
@@ -142,3 +142,25 @@ class TestAnalyzeCommentIntent:
             json={},
         )
         assert response.status_code == 422
+
+    def test_accepts_ai_provider_and_model(self, client) -> None:
+        """Request body can include optional ai_provider and ai_model."""
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": true, "reason": "Bug filed"}',
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response) as mock_ai:
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={
+                    "comment": "Filed JIRA-123",
+                    "ai_provider": "claude",
+                    "ai_model": "claude-sonnet-4-20250514",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["suggests_reviewed"] is True
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs["ai_provider"] == "claude"
+        assert call_kwargs.kwargs["ai_model"] == "claude-sonnet-4-20250514"

--- a/tests/test_comment_intent.py
+++ b/tests/test_comment_intent.py
@@ -1,0 +1,144 @@
+"""Tests for the /api/analyze-comment-intent endpoint."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from ai_cli_runner import AIResult
+
+from jenkins_job_insight import storage
+from tests.conftest import build_test_env
+
+
+@pytest.fixture
+def _mock_settings(temp_db_path: Path):
+    """Mock settings with AI provider configured."""
+    env = build_test_env(
+        AI_PROVIDER="gemini",
+        AI_MODEL="gemini-2.5-flash",
+        DB_PATH=str(temp_db_path),
+        GEMINI_API_KEY="test-key",  # pragma: allowlist secret
+    )
+    with patch.dict(os.environ, env, clear=True):
+        from jenkins_job_insight.config import get_settings
+
+        get_settings.cache_clear()
+        try:
+            yield
+        finally:
+            get_settings.cache_clear()
+
+
+@pytest.fixture
+def client(_mock_settings, temp_db_path: Path):
+    """Create a test client with mocked dependencies."""
+    with patch.object(storage, "DB_PATH", temp_db_path):
+        from starlette.testclient import TestClient
+
+        from jenkins_job_insight.main import app
+
+        with TestClient(app) as c:
+            yield c
+
+
+class TestAnalyzeCommentIntent:
+    """Tests for /api/analyze-comment-intent endpoint."""
+
+    def test_comment_suggests_reviewed(self, client) -> None:
+        """Comment with a bug link implies reviewed."""
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": true, "reason": "Bug filed with Jira link"}',
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response) as mock_ai:
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={"comment": "Filed JIRA-123 for this failure"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggests_reviewed"] is True
+        assert data["reason"] == "Bug filed with Jira link"
+        mock_ai.assert_called_once()
+
+    def test_comment_does_not_suggest_reviewed(self, client) -> None:
+        """Comment sharing a URL for context does not imply reviewed."""
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": false, "reason": "Sharing a URL for context, no resolution indicated"}',
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response):
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={
+                    "comment": "Here's the docs link: https://docs.example.com/troubleshooting"
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggests_reviewed"] is False
+
+    def test_ai_failure_returns_false(self, client) -> None:
+        """AI call failure returns safe default (suggests_reviewed=False)."""
+        ai_response = AIResult(
+            success=False,
+            text="AI service unavailable",
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response):
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={"comment": "Fixed in commit abc123"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggests_reviewed"] is False
+        assert data["reason"] == ""
+
+    def test_ai_returns_invalid_json(self, client) -> None:
+        """Unparseable AI response returns safe default."""
+        ai_response = AIResult(
+            success=True,
+            text="This is not valid JSON at all",
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response):
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={"comment": "some comment"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["suggests_reviewed"] is False
+
+    def test_records_ai_usage(self, client) -> None:
+        """Token usage is recorded for comment intent calls."""
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": false, "reason": "test"}',
+        )
+        with (
+            patch("ai_cli_runner.call_ai_cli", return_value=ai_response),
+            patch("jenkins_job_insight.token_tracking.record_ai_usage") as mock_record,
+        ):
+            response = client.post(
+                "/api/analyze-comment-intent",
+                json={"comment": "test comment"},
+            )
+
+        assert response.status_code == 200
+        mock_record.assert_called_once()
+        call_kwargs = mock_record.call_args
+        assert call_kwargs.kwargs["job_id"] == "comment-intent"
+        assert call_kwargs.kwargs["call_type"] == "comment_intent"
+
+    def test_missing_comment_field(self, client) -> None:
+        """Missing comment field returns 422."""
+        response = client.post(
+            "/api/analyze-comment-intent",
+            json={},
+        )
+        assert response.status_code == 422

--- a/tests/test_comment_intent.py
+++ b/tests/test_comment_intent.py
@@ -1,5 +1,6 @@
 """Tests for the /api/analyze-comment-intent endpoint."""
 
+import asyncio
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -164,3 +165,175 @@ class TestAnalyzeCommentIntent:
         call_kwargs = mock_ai.call_args
         assert call_kwargs.kwargs["ai_provider"] == "claude"
         assert call_kwargs.kwargs["ai_model"] == "claude-sonnet-4-20250514"
+
+
+class TestAnalyzeCommentIntentJobFallback:
+    """Tests for AI config fallback from the analyzed job's stored config."""
+
+    @pytest.fixture
+    def _mock_settings_no_ai(self, temp_db_path: Path):
+        """Mock settings with NO AI provider/model env vars."""
+        env = build_test_env(
+            DB_PATH=str(temp_db_path),
+        )
+        # Remove AI_PROVIDER and AI_MODEL so env fallback is empty
+        env.pop("AI_PROVIDER", None)
+        env.pop("AI_MODEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            from jenkins_job_insight.config import get_settings
+
+            get_settings.cache_clear()
+            try:
+                yield
+            finally:
+                get_settings.cache_clear()
+
+    @pytest.fixture
+    def client_no_ai(self, _mock_settings_no_ai, temp_db_path: Path):
+        """Test client without server-level AI config."""
+        from jenkins_job_insight import main as main_mod
+
+        with (
+            patch.object(storage, "DB_PATH", temp_db_path),
+            patch.object(main_mod, "AI_PROVIDER", ""),
+            patch.object(main_mod, "AI_MODEL", ""),
+        ):
+            from starlette.testclient import TestClient
+
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as c:
+                yield c
+
+    @staticmethod
+    def _store_job_with_ai_config(
+        temp_db_path: Path, job_id: str, ai_provider: str, ai_model: str
+    ):
+        """Store a job result with AI config in request_params."""
+        result_data = {
+            "job_id": job_id,
+            "status": "completed",
+            "summary": "test",
+            "request_params": {
+                "ai_provider": ai_provider,
+                "ai_model": ai_model,
+            },
+            "failures": [],
+        }
+
+        async def _save():
+            await storage.init_db()
+            await storage.save_result(
+                job_id, "http://jenkins/1", "completed", result_data
+            )
+
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(_save())
+
+    def test_fallback_to_job_ai_config(self, client_no_ai, temp_db_path: Path) -> None:
+        """When no env vars or body AI config, fall back to job's stored config."""
+        self._store_job_with_ai_config(
+            temp_db_path, "job-123", "claude", "claude-sonnet-4-20250514"
+        )
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": true, "reason": "Bug filed"}',
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response) as mock_ai:
+            response = client_no_ai.post(
+                "/api/analyze-comment-intent",
+                json={"comment": "Filed JIRA-123", "job_id": "job-123"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["suggests_reviewed"] is True
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs["ai_provider"] == "claude"
+        assert call_kwargs.kwargs["ai_model"] == "claude-sonnet-4-20250514"
+
+    def test_no_ai_config_anywhere_returns_400(
+        self, client_no_ai, temp_db_path: Path
+    ) -> None:
+        """When no AI config available (no env, no body, no job), return 400."""
+        response = client_no_ai.post(
+            "/api/analyze-comment-intent",
+            json={"comment": "Filed JIRA-123"},
+        )
+        assert response.status_code == 400
+
+    def test_body_ai_config_takes_precedence_over_job(
+        self, client_no_ai, temp_db_path: Path
+    ) -> None:
+        """Body-level AI config takes precedence over job's stored config."""
+        self._store_job_with_ai_config(
+            temp_db_path, "job-456", "gemini", "gemini-2.5-flash"
+        )
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": false, "reason": "No resolution"}',
+        )
+        with patch("ai_cli_runner.call_ai_cli", return_value=ai_response) as mock_ai:
+            response = client_no_ai.post(
+                "/api/analyze-comment-intent",
+                json={
+                    "comment": "Checking logs",
+                    "job_id": "job-456",
+                    "ai_provider": "claude",
+                    "ai_model": "claude-sonnet-4-20250514",
+                },
+            )
+
+        assert response.status_code == 200
+        call_kwargs = mock_ai.call_args
+        assert call_kwargs.kwargs["ai_provider"] == "claude"
+        assert call_kwargs.kwargs["ai_model"] == "claude-sonnet-4-20250514"
+
+    def test_nonexistent_job_id_no_env_returns_400(
+        self, client_no_ai, temp_db_path: Path
+    ) -> None:
+        """Non-existent job_id with no other AI config returns 400."""
+        response = client_no_ai.post(
+            "/api/analyze-comment-intent",
+            json={"comment": "Filed JIRA-123", "job_id": "nonexistent"},
+        )
+        assert response.status_code == 400
+
+    def test_env_ai_config_takes_precedence_over_job(
+        self, _mock_settings, temp_db_path: Path
+    ) -> None:
+        """Server-level env AI config takes precedence over job's stored config."""
+        from jenkins_job_insight import main as main_mod
+
+        self._store_job_with_ai_config(
+            temp_db_path, "job-789", "claude", "claude-sonnet-4-20250514"
+        )
+        ai_response = AIResult(
+            success=True,
+            text='{"suggests_reviewed": true, "reason": "Bug filed"}',
+        )
+        with (
+            patch.object(storage, "DB_PATH", temp_db_path),
+            patch.object(main_mod, "AI_PROVIDER", "gemini"),
+            patch.object(main_mod, "AI_MODEL", "gemini-2.5-flash"),
+        ):
+            from starlette.testclient import TestClient
+
+            from jenkins_job_insight.main import app
+
+            with TestClient(app) as client_env:
+                with patch(
+                    "ai_cli_runner.call_ai_cli", return_value=ai_response
+                ) as mock_ai:
+                    response = client_env.post(
+                        "/api/analyze-comment-intent",
+                        json={
+                            "comment": "Filed JIRA-123",
+                            "job_id": "job-789",
+                        },
+                    )
+
+        assert response.status_code == 200
+        call_kwargs = mock_ai.call_args
+        # env vars are gemini/gemini-2.5-flash (from patched module constants)
+        assert call_kwargs.kwargs["ai_provider"] == "gemini"
+        assert call_kwargs.kwargs["ai_model"] == "gemini-2.5-flash"

--- a/tests/test_comment_intent.py
+++ b/tests/test_comment_intent.py
@@ -19,7 +19,7 @@ def _mock_settings(temp_db_path: Path):
         AI_PROVIDER="gemini",
         AI_MODEL="gemini-2.5-flash",
         DB_PATH=str(temp_db_path),
-        GEMINI_API_KEY="test-key",  # pragma: allowlist secret
+        GEMINI_API_KEY="test-key",  # noqa: S106  # pragma: allowlist secret
     )
     with patch.dict(os.environ, env, clear=True):
         from jenkins_job_insight.config import get_settings


### PR DESCRIPTION
Closes #194

## Changes
- Add `useReviewSuggestion` hook with URL/keyword detection logic
- Integrate suggestion prompt in CommentsSection after comment post
- Integrate in BugCreationDialog after Jira/GitHub issue creation
- Show ConfirmDialog when comment implies resolution
- Skip suggestion when failure is already reviewed

## Done
- [x] Detect when a comment is added to a failure (manual or via issue creation)
- [x] Analyze comment content/context to determine if it implies reviewed
- [x] Show confirmation popup when appropriate
- [x] Yes marks the failure as reviewed, No dismisses
- [x] Works for manual comments, Jira-linked comments, and GitHub-linked comments
- [x] Frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * After creating a bug or posting a comment, users may be prompted to mark the test/failure as reviewed; they can confirm or dismiss the suggestion.
  * Comment content is analyzed to determine when to suggest marking reviewed.
  * A new CLI command lets you analyze a comment’s “reviewed” intent and view the result.

* **Tests**
  * Added comprehensive tests covering suggestion logic, the CLI command, and the comment-analysis API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->