### PR TITLE
feat: support commit SHA as test repository ref

### DIFF
--- a/src/jenkins_job_insight/repository.py
+++ b/src/jenkins_job_insight/repository.py
@@ -194,6 +194,37 @@ def _clone_with_ssl_retry(
             raise
 
 
+def _clone_by_ref_type(
+    repo_url: str,
+    target_dir: Path,
+    *,
+    branch: str = "",
+    depth: int | None = None,
+    log_prefix: str = "Cloning repository",
+) -> None:
+    """Clone a repository, choosing strategy based on whether *branch* is a commit SHA.
+
+    For commit SHAs a full (unshallow) clone is performed followed by an explicit
+    checkout, because ``git clone --branch`` does not accept raw SHAs.  For
+    regular refs (branches / tags) the standard shallow-clone path is used.
+
+    Args:
+        repo_url: URL of the git repository to clone.
+        target_dir: Directory to clone into.
+        branch: Git ref or commit SHA.  Empty string means default branch.
+        depth: Shallow-clone depth (ignored for SHA clones).
+        log_prefix: Human-readable prefix for the log message.
+    """
+    if branch and _is_commit_sha(branch):
+        logger.info(f"{log_prefix} to {target_dir} (sha={branch})")
+        _clone_with_ssl_retry(repo_url, target_dir)
+        Repo(target_dir).git.checkout(branch)
+    else:
+        ref_msg = f" (ref={branch})" if branch else ""
+        logger.info(f"{log_prefix} to {target_dir}{ref_msg}")
+        _clone_with_ssl_retry(repo_url, target_dir, depth, branch=branch)
+
+
 class RepositoryManager:
     """Manages temporary git repository clones."""
 
@@ -226,14 +257,13 @@ class RepositoryManager:
         clone_dir = self.base_path / f"{repo_name}-{clone_id}"
         clone_dir.mkdir(parents=True, exist_ok=True)
         self.temp_dirs.append(clone_dir)
-        if branch and _is_commit_sha(branch):
-            logger.info(f"Cloning repository to {clone_dir} (sha={branch})")
-            _clone_with_ssl_retry(str(repo_url), clone_dir)
-            Repo(clone_dir).git.checkout(branch)
-        else:
-            ref_msg = f" (ref={branch})" if branch else ""
-            logger.info(f"Cloning repository to {clone_dir}{ref_msg}")
-            _clone_with_ssl_retry(str(repo_url), clone_dir, depth, branch=branch)
+        _clone_by_ref_type(
+            str(repo_url),
+            clone_dir,
+            branch=branch,
+            depth=depth,
+            log_prefix="Cloning repository",
+        )
         return clone_dir
 
     def clone_into(
@@ -270,14 +300,13 @@ class RepositoryManager:
         if token:
             clone_url = _inject_token_into_url(clone_url, token)
         try:
-            if branch and _is_commit_sha(branch):
-                logger.info(f"Cloning repository into {target_dir} (sha={branch})")
-                _clone_with_ssl_retry(clone_url, target_dir)
-                Repo(target_dir).git.checkout(branch)
-            else:
-                ref_msg = f" (ref={branch})" if branch else ""
-                logger.info(f"Cloning repository into {target_dir}{ref_msg}")
-                _clone_with_ssl_retry(clone_url, target_dir, depth, branch=branch)
+            _clone_by_ref_type(
+                clone_url,
+                target_dir,
+                branch=branch,
+                depth=depth,
+                log_prefix="Cloning repository into",
+            )
         finally:
             if token:
                 _scrub_credentials(target_dir, repo_url)

--- a/src/jenkins_job_insight/repository.py
+++ b/src/jenkins_job_insight/repository.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
+import subprocess
 import tempfile
 import uuid
 from pathlib import Path
@@ -20,6 +22,13 @@ if TYPE_CHECKING:
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
 RESERVED_REPO_NAMES = frozenset({"build-artifacts"})
+
+_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+
+def _is_commit_sha(ref: str) -> bool:
+    """Check if a ref looks like a commit SHA (7-40 hex chars)."""
+    return bool(_SHA_PATTERN.match(ref))
 
 
 def _redact_url(url: str) -> str:
@@ -98,6 +107,24 @@ def derive_test_repo_name(
     return fallback
 
 
+def _scrub_credentials(target_dir: Path, repo_url: str | HttpUrl) -> None:
+    """Reset remote.origin.url to strip embedded credentials from .git/config.
+
+    Called after clone operations that inject auth tokens into the clone URL.
+    No-op if .git directory does not exist (e.g. clone failed before creating it).
+    """
+    if not (target_dir / ".git").exists():
+        return
+    git_executable = shutil.which("git")
+    if git_executable:
+        subprocess.run(  # noqa: S603
+            [git_executable, "remote", "set-url", "origin", str(repo_url)],
+            cwd=target_dir,
+            check=False,
+            capture_output=True,
+        )
+
+
 def _validate_repo_url(repo_url: str | HttpUrl) -> None:
     """Validate repository URL scheme to prevent SSRF."""
     url_str = str(repo_url).lower()
@@ -125,17 +152,19 @@ def _inject_token_into_url(url: str, token: str) -> str:
 
 
 def _clone_with_ssl_retry(
-    repo_url: str, clone_dir: Path, depth: int, branch: str = ""
+    repo_url: str, clone_dir: Path, depth: int | None = None, branch: str = ""
 ) -> None:
     """Clone a repo, retrying without SSL verification on cert errors.
 
     Args:
         repo_url: Repository URL to clone.
         clone_dir: Target directory for the clone.
-        depth: Number of commits to fetch.
+        depth: Number of commits to fetch. None means full clone (no --depth).
         branch: Git ref (branch/tag) to check out. Empty string means default branch.
     """
-    kwargs: dict[str, object] = {"depth": depth}
+    kwargs: dict[str, object] = {}
+    if depth is not None:
+        kwargs["depth"] = depth
     if branch:
         kwargs["branch"] = branch
     try:
@@ -183,6 +212,7 @@ class RepositoryManager:
             repo_url: URL of the git repository to clone (string or HttpUrl).
             depth: Number of commits to fetch for git history context.
             branch: Git ref (branch/tag) to check out. Empty string means default branch.
+                    Accepts both branch/tag names and commit SHAs (7-40 hex chars).
 
         Returns:
             Path to the cloned repository.
@@ -196,8 +226,14 @@ class RepositoryManager:
         clone_dir = self.base_path / f"{repo_name}-{clone_id}"
         clone_dir.mkdir(parents=True, exist_ok=True)
         self.temp_dirs.append(clone_dir)
-        logger.info(f"Cloning repository to {clone_dir}")
-        _clone_with_ssl_retry(str(repo_url), clone_dir, depth, branch=branch)
+        if branch and _is_commit_sha(branch):
+            logger.info(f"Cloning repository to {clone_dir} (sha={branch})")
+            _clone_with_ssl_retry(str(repo_url), clone_dir)
+            Repo(clone_dir).git.checkout(branch)
+        else:
+            ref_msg = f" (ref={branch})" if branch else ""
+            logger.info(f"Cloning repository to {clone_dir}{ref_msg}")
+            _clone_with_ssl_retry(str(repo_url), clone_dir, depth, branch=branch)
         return clone_dir
 
     def clone_into(
@@ -233,23 +269,18 @@ class RepositoryManager:
         clone_url = str(repo_url)
         if token:
             clone_url = _inject_token_into_url(clone_url, token)
-        logger.info(f"Cloning repository into {target_dir}")
         try:
-            _clone_with_ssl_retry(clone_url, target_dir, depth, branch=branch)
+            if branch and _is_commit_sha(branch):
+                logger.info(f"Cloning repository into {target_dir} (sha={branch})")
+                _clone_with_ssl_retry(clone_url, target_dir)
+                Repo(target_dir).git.checkout(branch)
+            else:
+                ref_msg = f" (ref={branch})" if branch else ""
+                logger.info(f"Cloning repository into {target_dir}{ref_msg}")
+                _clone_with_ssl_retry(clone_url, target_dir, depth, branch=branch)
         finally:
-            # Scrub credentials from .git/config to prevent at-rest exposure,
-            # including partial clones that failed after writing remote.origin.url.
-            if token and (target_dir / ".git").exists():
-                import subprocess
-
-                git_executable = shutil.which("git")
-                if git_executable:
-                    subprocess.run(  # noqa: S603
-                        [git_executable, "remote", "set-url", "origin", str(repo_url)],
-                        cwd=target_dir,
-                        check=False,
-                        capture_output=True,
-                    )
+            if token:
+                _scrub_credentials(target_dir, repo_url)
         return target_dir
 
     def create_workspace(self) -> Path:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -6,7 +6,11 @@ import git.exc
 import pytest
 from git.exc import GitCommandError
 
-from jenkins_job_insight.repository import RepositoryManager, repo_name_from_url
+from jenkins_job_insight.repository import (
+    RepositoryManager,
+    _is_commit_sha,
+    repo_name_from_url,
+)
 
 
 class TestRepositoryManager:
@@ -730,6 +734,200 @@ class TestInjectTokenIntoUrl:
         )
         expected = "https://x-token-auth:tok@github.com/org/repo.git"  # pragma: allowlist secret
         assert result == expected
+
+
+class TestIsCommitSha:
+    """Tests for _is_commit_sha utility function."""
+
+    def test_full_40_char_sha(self) -> None:
+        assert _is_commit_sha("a" * 40) is True
+
+    def test_short_7_char_sha(self) -> None:
+        assert _is_commit_sha("abc1234") is True
+
+    def test_mixed_case_sha(self) -> None:
+        assert (
+            _is_commit_sha(
+                "aBcDeF1234567890aBcDeF1234567890aBcDeF12"  # pragma: allowlist secret
+            )
+            is True
+        )
+
+    def test_20_char_sha(self) -> None:
+        assert (
+            _is_commit_sha("1234567890abcdef1234") is True  # pragma: allowlist secret
+        )
+
+    def test_too_short_6_chars(self) -> None:
+        assert _is_commit_sha("abc123") is False
+
+    def test_too_long_41_chars(self) -> None:
+        assert _is_commit_sha("a" * 41) is False
+
+    def test_non_hex_chars(self) -> None:
+        assert _is_commit_sha("xyz1234") is False
+
+    def test_branch_name(self) -> None:
+        assert _is_commit_sha("main") is False
+
+    def test_branch_with_slash(self) -> None:
+        assert _is_commit_sha("feature/my-branch") is False
+
+    def test_tag_name(self) -> None:
+        assert _is_commit_sha("v1.2.3") is False
+
+    def test_empty_string(self) -> None:
+        assert _is_commit_sha("") is False
+
+    def test_release_branch(self) -> None:
+        assert _is_commit_sha("release-1.8") is False
+
+
+class TestCloneShaFlow:
+    """Tests for SHA-based clone flow (full clone + checkout)."""
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_with_sha_uses_full_clone_and_checkout(
+        self, mock_repo_cls: MagicMock
+    ) -> None:
+        """clone() with a SHA ref does full clone (no depth/branch) then checkout."""
+        manager = RepositoryManager()
+        sha = "abc1234def5678"  # pragma: allowlist secret
+        mock_instance = MagicMock()
+        mock_repo_cls.return_value = mock_instance
+
+        manager.clone("https://github.com/org/repo", depth=50, branch=sha)
+
+        # clone_from should be called WITHOUT depth and branch
+        mock_repo_cls.clone_from.assert_called_once()
+        call_kwargs = mock_repo_cls.clone_from.call_args[1]
+        assert "depth" not in call_kwargs
+        assert "branch" not in call_kwargs
+        # checkout should be called on the repo instance
+        mock_instance.git.checkout.assert_called_once_with(sha)
+        manager.cleanup()
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_with_branch_uses_depth_and_branch(
+        self, mock_repo_cls: MagicMock
+    ) -> None:
+        """clone() with a branch name uses --depth and --branch as before."""
+        manager = RepositoryManager()
+        manager.clone("https://github.com/org/repo", depth=50, branch="release-1.8")
+
+        mock_repo_cls.clone_from.assert_called_once()
+        call_kwargs = mock_repo_cls.clone_from.call_args[1]
+        assert call_kwargs["depth"] == 50
+        assert call_kwargs["branch"] == "release-1.8"
+        # No checkout call (Repo() not instantiated for checkout)
+        mock_repo_cls.return_value.git.checkout.assert_not_called()
+        manager.cleanup()
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_into_with_sha_uses_full_clone_and_checkout(
+        self, mock_repo_cls: MagicMock, tmp_path
+    ) -> None:
+        """clone_into() with a SHA does full clone then checkout."""
+        manager = RepositoryManager()
+        sha = "deadbeef1234567"  # pragma: allowlist secret
+        target = tmp_path / "my-repo"
+        mock_instance = MagicMock()
+        mock_repo_cls.return_value = mock_instance
+
+        manager.clone_into("https://github.com/org/repo", target, depth=1, branch=sha)
+
+        # clone_from without depth/branch
+        mock_repo_cls.clone_from.assert_called_once()
+        call_kwargs = mock_repo_cls.clone_from.call_args[1]
+        assert "depth" not in call_kwargs
+        assert "branch" not in call_kwargs
+        # checkout with SHA
+        mock_instance.git.checkout.assert_called_once_with(sha)
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_into_with_branch_uses_depth_and_branch(
+        self, mock_repo_cls: MagicMock, tmp_path
+    ) -> None:
+        """clone_into() with a branch name preserves existing behavior."""
+        manager = RepositoryManager()
+        target = tmp_path / "my-repo"
+
+        manager.clone_into(
+            "https://github.com/org/repo", target, depth=1, branch="develop"
+        )
+
+        mock_repo_cls.clone_from.assert_called_once_with(
+            "https://github.com/org/repo", target, depth=1, branch="develop"
+        )
+
+    @patch("jenkins_job_insight.repository.Repo")
+    def test_clone_into_sha_with_token_scrubs_credentials(
+        self, mock_repo_cls: MagicMock, tmp_path
+    ) -> None:
+        """clone_into() with SHA + token still scrubs credentials."""
+        manager = RepositoryManager()
+        sha = "abc1234def5678"  # pragma: allowlist secret
+        target = tmp_path / "my-repo"
+        mock_instance = MagicMock()
+        mock_repo_cls.return_value = mock_instance
+
+        # Create .git directory to trigger scrubbing
+        target.mkdir(parents=True)
+        (target / ".git").mkdir()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/git"),
+            patch("jenkins_job_insight.repository.subprocess") as mock_subprocess,
+        ):
+            mock_run = mock_subprocess.run
+            manager.clone_into(
+                "https://github.com/org/repo",
+                target,
+                depth=1,
+                branch=sha,
+                token="tok123",  # noqa: S106  # pragma: allowlist secret
+            )
+
+        # Token injected in clone URL
+        clone_url = mock_repo_cls.clone_from.call_args[0][0]
+        assert "tok123" in clone_url  # pragma: allowlist secret
+        # Credentials scrubbed
+        mock_run.assert_called_once()
+        scrub_cmd = mock_run.call_args[0][0]
+        assert scrub_cmd[-1] == "https://github.com/org/repo"
+
+    def test_clone_into_sha_with_ssl_retry(self, tmp_path) -> None:
+        """clone_into() with SHA retries on SSL error."""
+        manager = RepositoryManager()
+        sha = "abc1234def5678"  # pragma: allowlist secret
+        target = tmp_path / "repo"
+        target.mkdir()
+
+        mock_instance = MagicMock()
+        with patch("jenkins_job_insight.repository.Repo") as mock_repo_cls:
+            mock_repo_cls.return_value = mock_instance
+            mock_repo_cls.clone_from = MagicMock()
+            mock_clone = mock_repo_cls.clone_from
+            mock_clone.side_effect = [
+                GitCommandError(
+                    "git clone",
+                    128,
+                    stderr="server verification failed: certificate signer not trusted",
+                ),
+                MagicMock(),
+            ]
+            manager.clone_into("https://example.com/repo", target, branch=sha)
+
+            assert mock_clone.call_count == 2
+            # Both calls should have no depth/branch
+            for call in mock_clone.call_args_list:
+                assert "depth" not in call[1] or call[1].get("depth") is None
+                assert "branch" not in call[1]
+            # Retry should have SSL disabled
+            _, kwargs = mock_clone.call_args
+            assert kwargs.get("env", {}).get("GIT_SSL_NO_VERIFY") == "1"
+            # Checkout should still happen
+            mock_instance.git.checkout.assert_called_once_with(sha)
 
 
 class TestCloneIntoWithToken:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -921,7 +921,7 @@ class TestCloneShaFlow:
             assert mock_clone.call_count == 2
             # Both calls should have no depth/branch
             for call in mock_clone.call_args_list:
-                assert "depth" not in call[1] or call[1].get("depth") is None
+                assert "depth" not in call[1]
                 assert "branch" not in call[1]
             # Retry should have SSL disabled
             _, kwargs = mock_clone.call_args


### PR DESCRIPTION
Closes #196

## Changes
- Detect SHA refs (7-40 hex chars) vs branch/tag names via `_is_commit_sha()`
- Use full clone + `git checkout <sha>` for SHA refs
- Keep existing shallow `clone --branch` for branches/tags
- Update both `clone()` and `clone_into()` methods
- Extract `_scrub_credentials()` helper to avoid code duplication
- Log ref type: `(ref=...)` vs `(sha=...)`

## Done
- [x] Detect SHA vs branch/tag ref format
- [x] Two-step clone+checkout for SHA refs
- [x] Existing branch/tag flow unchanged
- [x] `clone_into()` updated to handle both
- [x] Logging distinguishes ref type
- [x] Tests cover both flows
- [x] CLI and API accept SHA refs seamlessly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of commit SHAs and adjusted cloning behavior to perform full clones and explicit checkouts when a SHA is used.
  * Centralized credential cleanup during clone operations to ensure tokens are not exposed.
  * Preserved retry behavior for SSL issues while ensuring checkouts occur after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->