### PR TITLE
feat: prompt to update Report Portal when all failures reviewed

### DIFF
--- a/frontend/src/lib/failureKeys.ts
+++ b/frontend/src/lib/failureKeys.ts
@@ -1,0 +1,42 @@
+import { reviewKey } from '@/pages/report/ReportContext'
+import type { ChildJobAnalysis } from '@/types'
+
+/** Walk the child-job tree once, calling `visitor` at each node.
+ *  Centralises the recursion so every consumer stays in sync. */
+export function walkChildTree(
+  failures: { test_name: string }[],
+  children: ChildJobAnalysis[],
+  visitor: (failures: { test_name: string }[], parentJobName?: string, parentBuildNumber?: number) => void,
+  parentJobName?: string,
+  parentBuildNumber?: number,
+): void {
+  visitor(failures ?? [], parentJobName, parentBuildNumber)
+  for (const child of children ?? []) {
+    walkChildTree(child.failures ?? [], child.failed_children ?? [], visitor, child.job_name, child.build_number)
+  }
+}
+
+/** Recursively collect all review keys from failures + nested children. */
+export function collectAllTestKeys(
+  failures: { test_name: string }[],
+  children: ChildJobAnalysis[],
+  parentJobName?: string,
+  parentBuildNumber?: number,
+): string[] {
+  const keys: string[] = []
+  walkChildTree(failures, children, (nodeFailures, jobName, buildNumber) => {
+    for (const f of nodeFailures) {
+      keys.push(reviewKey(f.test_name, jobName, buildNumber))
+    }
+  }, parentJobName, parentBuildNumber)
+  return keys
+}
+
+/** Recursively count all failures including nested children. */
+export function countAllFailures(failures: { test_name: string }[], children: ChildJobAnalysis[]): number {
+  let count = 0
+  walkChildTree(failures, children, (nodeFailures) => {
+    count += nodeFailures.length
+  })
+  return count
+}

--- a/frontend/src/lib/failureKeys.ts
+++ b/frontend/src/lib/failureKeys.ts
@@ -1,4 +1,4 @@
-import { reviewKey } from '@/pages/report/ReportContext'
+import { reviewKey } from '@/lib/reviewKey'
 import type { ChildJobAnalysis } from '@/types'
 
 /** Walk the child-job tree once, calling `visitor` at each node.

--- a/frontend/src/lib/reviewKey.ts
+++ b/frontend/src/lib/reviewKey.ts
@@ -1,0 +1,5 @@
+/** Build the review lookup key matching the backend format. */
+export function reviewKey(testName: string, childJobName?: string, childBuildNumber?: number): string {
+  if (childJobName) return `${childJobName}#${childBuildNumber ?? 0}::${testName}`
+  return testName
+}

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -11,7 +11,9 @@ import { ReportProvider, useReportState, useReportDispatch, useRefreshEnrichment
 import { FailureCard } from './report/FailureCard'
 import { ChildJobSection } from './report/ChildJobSection'
 import { PeerAnalysisSummary } from './report/PeerAnalysisSummary'
+import { AllReviewedPrompt } from './report/AllReviewedPrompt'
 import { collectChildExpandKeys } from '@/lib/childJobHash'
+import { collectAllTestKeys, countAllFailures } from '@/lib/failureKeys'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -31,46 +33,6 @@ import type { ChildJobAnalysis } from '@/types'
 const COMMENT_POLL_MS = Math.max(5_000, Math.min(300_000,
   Number(import.meta.env.VITE_COMMENT_POLL_MS) || 30_000,
 ))
-
-/** Walk the child-job tree once, calling `visitor` at each node.
- *  Centralises the recursion so every consumer stays in sync. */
-function walkChildTree(
-  failures: { test_name: string }[],
-  children: ChildJobAnalysis[],
-  visitor: (failures: { test_name: string }[], parentJobName?: string, parentBuildNumber?: number) => void,
-  parentJobName?: string,
-  parentBuildNumber?: number,
-): void {
-  visitor(failures ?? [], parentJobName, parentBuildNumber)
-  for (const child of children ?? []) {
-    walkChildTree(child.failures ?? [], child.failed_children ?? [], visitor, child.job_name, child.build_number)
-  }
-}
-
-/** Recursively collect all review keys from failures + nested children. */
-function collectAllTestKeys(
-  failures: { test_name: string }[],
-  children: ChildJobAnalysis[],
-  parentJobName?: string,
-  parentBuildNumber?: number,
-): string[] {
-  const keys: string[] = []
-  walkChildTree(failures, children, (nodeFailures, jobName, buildNumber) => {
-    for (const f of nodeFailures) {
-      keys.push(reviewKey(f.test_name, jobName, buildNumber))
-    }
-  }, parentJobName, parentBuildNumber)
-  return keys
-}
-
-/** Recursively count all failures including nested children. */
-function countAllFailures(failures: { test_name: string }[], children: ChildJobAnalysis[]): number {
-  let count = 0
-  walkChildTree(failures, children, (nodeFailures) => {
-    count += nodeFailures.length
-  })
-  return count
-}
 
 export function ReportPage() {
   const { jobId } = useParams<{ jobId: string }>()
@@ -604,6 +566,7 @@ function ReportContent() {
         )}
       </footer>
     </div>
+      <AllReviewedPrompt jobId={result.job_id} />
       {result.request_params && (
         <ReAnalyzeDialog
           open={state.reAnalyzeOpen}

--- a/frontend/src/pages/report/AllReviewedPrompt.tsx
+++ b/frontend/src/pages/report/AllReviewedPrompt.tsx
@@ -12,9 +12,6 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
   const { result, reviews, reportportalAvailable } = useReportState()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [pushing, setPushing] = useState(false)
-  const prevAllReviewedRef = useRef(false)
-  const hasSettledRef = useRef(false)
-  const justSettledRef = useRef(false)
 
   const allKeys = useMemo(
     () =>
@@ -27,43 +24,33 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
     [result],
   )
 
-  const allReviewed = useMemo(() => {
-    if (allKeys.length === 0) return false
-    return allKeys.every((k) => reviews[k]?.reviewed)
-  }, [allKeys, reviews])
+  // Keep refs to latest values so the event handler always reads current state
+  const reviewsRef = useRef(reviews)
+  reviewsRef.current = reviews
+  const allKeysRef = useRef(allKeys)
+  allKeysRef.current = allKeys
+  const rpRef = useRef(reportportalAvailable)
+  rpRef.current = reportportalAvailable
 
-  // Keep a ref to the latest allReviewed value for the microtask
-  const allReviewedRef = useRef(allReviewed)
-  allReviewedRef.current = allReviewed
-
-  // Effect 1: Wait for result to load, then capture initial allReviewed state.
-  // Only watches `result` — immune to comment-poll re-renders.
   useEffect(() => {
-    if (!result || hasSettledRef.current) return
-    hasSettledRef.current = true
-    justSettledRef.current = true
-    // Use a microtask to ensure reviews have also been applied
-    // before we capture the initial allReviewed state
-    queueMicrotask(() => {
-      prevAllReviewedRef.current = allReviewedRef.current
-      justSettledRef.current = false
-    })
-  }, [result])
-
-  // Effect 2: Detect transitions from not-all-reviewed → all-reviewed (only after settled)
-  useEffect(() => {
-    if (!hasSettledRef.current || justSettledRef.current) return
-    if (allReviewed && !prevAllReviewedRef.current && reportportalAvailable) {
-      setDialogOpen(true)
+    function onReviewChanged() {
+      // Wait for React to process the state update and re-render
+      requestAnimationFrame(() => {
+        const currentReviews = reviewsRef.current
+        const currentKeys = allKeysRef.current
+        if (!rpRef.current || currentKeys.length === 0) return
+        const allNowReviewed = currentKeys.every((k) => currentReviews[k]?.reviewed)
+        if (allNowReviewed) {
+          setDialogOpen(true)
+        }
+      })
     }
-    prevAllReviewedRef.current = allReviewed
-  }, [allReviewed, reportportalAvailable])
+    window.addEventListener('jji:review-changed', onReviewChanged)
+    return () => window.removeEventListener('jji:review-changed', onReviewChanged)
+  }, []) // stable — reads from refs
 
-  // Reset state when navigating to a different report
+  // Reset on navigation
   useEffect(() => {
-    prevAllReviewedRef.current = false
-    hasSettledRef.current = false
-    justSettledRef.current = false
     setDialogOpen(false)
     setPushing(false)
   }, [jobId])

--- a/frontend/src/pages/report/AllReviewedPrompt.tsx
+++ b/frontend/src/pages/report/AllReviewedPrompt.tsx
@@ -13,6 +13,7 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [pushing, setPushing] = useState(false)
   const prevAllReviewedRef = useRef(false)
+  const hasSettledRef = useRef(false)
 
   const allKeys = useMemo(
     () =>
@@ -32,11 +33,31 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
 
   // Detect transition from not-all-reviewed → all-reviewed
   useEffect(() => {
+    // Don't track transitions until result data has loaded
+    if (!result) return
+
+    // First render with data — just record current state, don't trigger.
+    // This prevents a false positive when all failures are already reviewed
+    // on load, even if result and reviews arrive in separate render batches.
+    if (!hasSettledRef.current) {
+      hasSettledRef.current = true
+      prevAllReviewedRef.current = allReviewed
+      return
+    }
+
     if (allReviewed && !prevAllReviewedRef.current && reportportalAvailable) {
       setDialogOpen(true)
     }
     prevAllReviewedRef.current = allReviewed
-  }, [allReviewed, reportportalAvailable])
+  }, [allReviewed, reportportalAvailable, result])
+
+  // Reset state when navigating to a different report
+  useEffect(() => {
+    prevAllReviewedRef.current = false
+    hasSettledRef.current = false
+    setDialogOpen(false)
+    setPushing(false)
+  }, [jobId])
 
   const handleConfirm = async () => {
     setPushing(true)

--- a/frontend/src/pages/report/AllReviewedPrompt.tsx
+++ b/frontend/src/pages/report/AllReviewedPrompt.tsx
@@ -14,6 +14,7 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
   const [pushing, setPushing] = useState(false)
   const prevAllReviewedRef = useRef(false)
   const hasSettledRef = useRef(false)
+  const justSettledRef = useRef(false)
 
   const allKeys = useMemo(
     () =>
@@ -31,30 +32,38 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
     return allKeys.every((k) => reviews[k]?.reviewed)
   }, [allKeys, reviews])
 
-  // Detect transition from not-all-reviewed → all-reviewed
+  // Keep a ref to the latest allReviewed value for the microtask
+  const allReviewedRef = useRef(allReviewed)
+  allReviewedRef.current = allReviewed
+
+  // Effect 1: Wait for result to load, then capture initial allReviewed state.
+  // Only watches `result` — immune to comment-poll re-renders.
   useEffect(() => {
-    // Don't track transitions until result data has loaded
-    if (!result) return
+    if (!result || hasSettledRef.current) return
+    hasSettledRef.current = true
+    justSettledRef.current = true
+    // Use a microtask to ensure reviews have also been applied
+    // before we capture the initial allReviewed state
+    queueMicrotask(() => {
+      prevAllReviewedRef.current = allReviewedRef.current
+      justSettledRef.current = false
+    })
+  }, [result])
 
-    // First render with data — just record current state, don't trigger.
-    // This prevents a false positive when all failures are already reviewed
-    // on load, even if result and reviews arrive in separate render batches.
-    if (!hasSettledRef.current) {
-      hasSettledRef.current = true
-      prevAllReviewedRef.current = allReviewed
-      return
-    }
-
+  // Effect 2: Detect transitions from not-all-reviewed → all-reviewed (only after settled)
+  useEffect(() => {
+    if (!hasSettledRef.current || justSettledRef.current) return
     if (allReviewed && !prevAllReviewedRef.current && reportportalAvailable) {
       setDialogOpen(true)
     }
     prevAllReviewedRef.current = allReviewed
-  }, [allReviewed, reportportalAvailable, result])
+  }, [allReviewed, reportportalAvailable])
 
   // Reset state when navigating to a different report
   useEffect(() => {
     prevAllReviewedRef.current = false
     hasSettledRef.current = false
+    justSettledRef.current = false
     setDialogOpen(false)
     setPushing(false)
   }, [jobId])

--- a/frontend/src/pages/report/AllReviewedPrompt.tsx
+++ b/frontend/src/pages/report/AllReviewedPrompt.tsx
@@ -33,7 +33,9 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
   rpRef.current = reportportalAvailable
 
   useEffect(() => {
-    function onReviewChanged() {
+    function onReviewChanged(event: Event) {
+      const { detail } = event as CustomEvent<{ jobId?: string }>
+      if (detail?.jobId !== jobId) return
       // Wait for React to process the state update and re-render
       requestAnimationFrame(() => {
         const currentReviews = reviewsRef.current
@@ -47,7 +49,7 @@ export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
     }
     window.addEventListener('jji:review-changed', onReviewChanged)
     return () => window.removeEventListener('jji:review-changed', onReviewChanged)
-  }, []) // stable — reads from refs
+  }, [jobId]) // re-subscribe when jobId changes
 
   // Reset on navigation
   useEffect(() => {

--- a/frontend/src/pages/report/AllReviewedPrompt.tsx
+++ b/frontend/src/pages/report/AllReviewedPrompt.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { api } from '@/lib/api'
+import { collectAllTestKeys } from '@/lib/failureKeys'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { useReportState } from './ReportContext'
+
+interface AllReviewedPromptProps {
+  jobId: string
+}
+
+export function AllReviewedPrompt({ jobId }: AllReviewedPromptProps) {
+  const { result, reviews, reportportalAvailable } = useReportState()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [pushing, setPushing] = useState(false)
+  const prevAllReviewedRef = useRef(false)
+
+  const allKeys = useMemo(
+    () =>
+      result
+        ? collectAllTestKeys(
+            result.failures ?? [],
+            result.child_job_analyses ?? [],
+          )
+        : [],
+    [result],
+  )
+
+  const allReviewed = useMemo(() => {
+    if (allKeys.length === 0) return false
+    return allKeys.every((k) => reviews[k]?.reviewed)
+  }, [allKeys, reviews])
+
+  // Detect transition from not-all-reviewed → all-reviewed
+  useEffect(() => {
+    if (allReviewed && !prevAllReviewedRef.current && reportportalAvailable) {
+      setDialogOpen(true)
+    }
+    prevAllReviewedRef.current = allReviewed
+  }, [allReviewed, reportportalAvailable])
+
+  const handleConfirm = async () => {
+    setPushing(true)
+    try {
+      await api.post(`/results/${jobId}/push-reportportal`)
+    } catch {
+      // Best-effort — errors are not surfaced here
+    } finally {
+      setPushing(false)
+      setDialogOpen(false)
+    }
+  }
+
+  if (!reportportalAvailable) return null
+
+  return (
+    <ConfirmDialog
+      open={dialogOpen}
+      onOpenChange={setDialogOpen}
+      title="All failures reviewed"
+      description="All failures reviewed. Update Report Portal?"
+      confirmLabel="Yes"
+      cancelLabel="No"
+      onConfirm={handleConfirm}
+      loading={pushing}
+    />
+  )
+}

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -201,6 +201,11 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
       if (failedCount > 0) {
         setReviewAllError(`Failed to update ${failedCount} of ${group.tests.length} tests: ${failedTestNames.join(', ')}`)
       }
+
+      // Notify AllReviewedPrompt to check if all failures are now reviewed
+      if (newState) {
+        setTimeout(() => window.dispatchEvent(new Event('jji:review-changed')), 100)
+      }
     } finally {
       setReviewingAll(false)
     }

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -204,7 +204,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
 
       // Notify AllReviewedPrompt to check if all failures are now reviewed
       if (newState) {
-        setTimeout(() => window.dispatchEvent(new Event('jji:review-changed')), 100)
+        setTimeout(() => window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId } })), 100)
       }
     } finally {
       setReviewingAll(false)

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -203,9 +203,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
       }
 
       // Notify AllReviewedPrompt to check if all failures are now reviewed
-      if (newState) {
-        setTimeout(() => window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId } })), 100)
-      }
+      setTimeout(() => window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId } })), 100)
     } finally {
       setReviewingAll(false)
     }

--- a/frontend/src/pages/report/ReportContext.tsx
+++ b/frontend/src/pages/report/ReportContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useReducer, useRef, useCallback, type Dispatch, type ReactNode } from 'react'
 import { api } from '@/lib/api'
+import { reviewKey } from '@/lib/reviewKey'
 import type { AnalysisResult, Comment, ReviewState, CommentsAndReviews, AiConfig, CommentEnrichment } from '@/types'
 
 interface ReportState {
@@ -239,8 +240,5 @@ export const useReportState = () => useContext(StateCtx)
 export const useReportDispatch = () => useContext(DispatchCtx)
 export const useRefreshEnrichments = () => useContext(RefreshEnrichmentsCtx)
 
-/** Build the review lookup key matching the backend format. */
-export function reviewKey(testName: string, childJobName?: string, childBuildNumber?: number): string {
-  if (childJobName) return `${childJobName}#${childBuildNumber ?? 0}::${testName}`
-  return testName
-}
+// Re-export for backward compatibility
+export { reviewKey } from '@/lib/reviewKey'

--- a/frontend/src/pages/report/ReviewToggle.tsx
+++ b/frontend/src/pages/report/ReviewToggle.tsx
@@ -44,7 +44,7 @@ export function ReviewToggle({ jobId, testName, childJobName, childBuildNumber, 
       if (!reviewed) {
         // We just marked as reviewed — schedule check after React processes the dispatch
         setTimeout(() => {
-          window.dispatchEvent(new Event('jji:review-changed'))
+          window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId } }))
         }, 100)
       }
     } catch (err) {

--- a/frontend/src/pages/report/ReviewToggle.tsx
+++ b/frontend/src/pages/report/ReviewToggle.tsx
@@ -39,6 +39,14 @@ export function ReviewToggle({ jobId, testName, childJobName, childBuildNumber, 
         type: 'SET_REVIEW',
         payload: { key, state: { reviewed: !reviewed, username, updated_at: new Date().toISOString() } },
       })
+      // Notify AllReviewedPrompt to check if all failures are now reviewed.
+      // Using a custom event avoids useEffect timing issues entirely.
+      if (!reviewed) {
+        // We just marked as reviewed — schedule check after React processes the dispatch
+        setTimeout(() => {
+          window.dispatchEvent(new Event('jji:review-changed'))
+        }, 100)
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to toggle review status')
     } finally {

--- a/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
+++ b/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { AllReviewedPrompt } from '../AllReviewedPrompt'
+import { ReportProvider, useReportDispatch } from '../ReportContext'
+import type { AnalysisResult, ReviewState } from '@/types'
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mockPost = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    job_id: 'job-1',
+    job_name: 'test-job',
+    build_number: 1,
+    jenkins_url: null,
+    status: 'completed',
+    summary: 'Test summary',
+    ai_provider: 'test',
+    ai_model: 'test-model',
+    failures: [
+      {
+        test_name: 'test-a',
+        error: 'error-a',
+        analysis: { classification: 'PRODUCT BUG', affected_tests: ['test-a'], details: '', artifacts_evidence: '' },
+        error_signature: 'sig-a',
+      },
+      {
+        test_name: 'test-b',
+        error: 'error-b',
+        analysis: { classification: 'CODE ISSUE', affected_tests: ['test-b'], details: '', artifacts_evidence: '' },
+        error_signature: 'sig-b',
+      },
+    ],
+    child_job_analyses: [],
+    ...overrides,
+  }
+}
+
+function makeReview(reviewed: boolean): ReviewState {
+  return { reviewed, username: 'user', updated_at: '2025-01-01T00:00:00Z' }
+}
+
+/**
+ * Helper that injects state into ReportContext, then renders AllReviewedPrompt.
+ * Dispatches initial state, then allows further review updates via onMount callback.
+ */
+function Injector({
+  result,
+  reviews,
+  reportportalAvailable,
+  additionalReviews,
+}: {
+  result: AnalysisResult
+  reviews: Record<string, ReviewState>
+  reportportalAvailable: boolean
+  additionalReviews?: Record<string, ReviewState>
+}) {
+  const dispatch = useReportDispatch()
+  useEffect(() => {
+    dispatch({
+      type: 'SET_RESULT',
+      payload: { result, createdAt: '', completedAt: '', analysisStartedAt: '' },
+    })
+    dispatch({ type: 'SET_REPORTPORTAL_AVAILABLE', payload: reportportalAvailable })
+    dispatch({ type: 'SET_COMMENTS_AND_REVIEWS', payload: { comments: [], reviews } })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Dispatch additional reviews on second render cycle to simulate user action
+  useEffect(() => {
+    if (additionalReviews) {
+      for (const [key, state] of Object.entries(additionalReviews)) {
+        dispatch({ type: 'SET_REVIEW', payload: { key, state } })
+      }
+    }
+  }, [additionalReviews]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <AllReviewedPrompt jobId="job-1" />
+}
+
+function renderPrompt(opts: {
+  result?: AnalysisResult
+  reviews?: Record<string, ReviewState>
+  reportportalAvailable?: boolean
+  additionalReviews?: Record<string, ReviewState>
+}) {
+  return render(
+    <ReportProvider>
+      <Injector
+        result={opts.result ?? makeResult()}
+        reviews={opts.reviews ?? {}}
+        reportportalAvailable={opts.reportportalAvailable ?? true}
+        additionalReviews={opts.additionalReviews}
+      />
+    </ReportProvider>,
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPost.mockResolvedValue({})
+})
+
+describe('AllReviewedPrompt', () => {
+  it('shows dialog when all failures transition to reviewed', async () => {
+    renderPrompt({
+      reviews: { 'test-a': makeReview(false) },
+      additionalReviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+  })
+
+  it('does not show dialog when reportportal is not available', async () => {
+    renderPrompt({
+      reportportalAvailable: false,
+      additionalReviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    // Wait a tick to ensure effects have run
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+  })
+
+  it('does not show dialog when not all failures are reviewed', async () => {
+    renderPrompt({
+      additionalReviews: {
+        'test-a': makeReview(true),
+        // test-b not reviewed
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+  })
+
+  it('calls push-reportportal API on confirm', async () => {
+    renderPrompt({
+      additionalReviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/results/job-1/push-reportportal')
+    })
+  })
+
+  it('dismisses dialog on No without calling API', async () => {
+    renderPrompt({
+      additionalReviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'No' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('does not show dialog when no failures exist', async () => {
+    renderPrompt({
+      result: makeResult({ failures: [], child_job_analyses: [] }),
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+  })
+
+  it('includes child job failures in the all-reviewed check', async () => {
+    const result = makeResult({
+      failures: [
+        {
+          test_name: 'parent-test',
+          error: 'err',
+          analysis: { classification: 'PRODUCT BUG', affected_tests: ['parent-test'], details: '', artifacts_evidence: '' },
+          error_signature: 'sig-p',
+        },
+      ],
+      child_job_analyses: [
+        {
+          job_name: 'child-job',
+          build_number: 42,
+          jenkins_url: null,
+          summary: null,
+          failures: [
+            {
+              test_name: 'child-test',
+              error: 'err',
+              analysis: { classification: 'CODE ISSUE', affected_tests: ['child-test'], details: '', artifacts_evidence: '' },
+              error_signature: 'sig-c',
+            },
+          ],
+          failed_children: [],
+          note: null,
+        },
+      ],
+    })
+
+    // Only review parent test — should NOT trigger
+    const { unmount } = renderPrompt({
+      result,
+      additionalReviews: {
+        'parent-test': makeReview(true),
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+    unmount()
+
+    // Review both parent and child — should trigger
+    renderPrompt({
+      result,
+      additionalReviews: {
+        'parent-test': makeReview(true),
+        'child-job#42::child-test': makeReview(true),
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+  })
+
+  it('dialog closes after API error (best-effort)', async () => {
+    mockPost.mockRejectedValueOnce(new Error('Network error'))
+
+    renderPrompt({
+      additionalReviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+    })
+  })
+})

--- a/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
+++ b/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { useEffect } from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { useEffect, useImperativeHandle, forwardRef, createRef } from 'react'
 import { AllReviewedPrompt } from '../AllReviewedPrompt'
 import { ReportProvider, useReportDispatch } from '../ReportContext'
 import type { AnalysisResult, ReviewState } from '@/types'
@@ -79,12 +79,16 @@ function Injector({
     dispatch({ type: 'SET_COMMENTS_AND_REVIEWS', payload: { comments: [], reviews } })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Dispatch additional reviews on second render cycle to simulate user action
+  // Dispatch additional reviews after a tick to simulate a real user action
+  // (must happen in a separate render cycle from the initial data load)
   useEffect(() => {
     if (additionalReviews) {
-      for (const [key, state] of Object.entries(additionalReviews)) {
-        dispatch({ type: 'SET_REVIEW', payload: { key, state } })
-      }
+      const id = setTimeout(() => {
+        for (const [key, state] of Object.entries(additionalReviews)) {
+          dispatch({ type: 'SET_REVIEW', payload: { key, state } })
+        }
+      }, 0)
+      return () => clearTimeout(id)
     }
   }, [additionalReviews]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -108,6 +112,37 @@ function renderPrompt(opts: {
     </ReportProvider>,
   )
 }
+
+/** Imperative handle exposed by DynamicInjector for dispatching reviews on demand. */
+interface DynamicInjectorHandle {
+  setReviews: (reviews: Record<string, ReviewState>) => void
+}
+
+const DynamicInjector = forwardRef<DynamicInjectorHandle, {
+  result: AnalysisResult
+  reviews: Record<string, ReviewState>
+  reportportalAvailable: boolean
+}>(function DynamicInjector({ result, reviews, reportportalAvailable }, ref) {
+  const dispatch = useReportDispatch()
+  useEffect(() => {
+    dispatch({
+      type: 'SET_RESULT',
+      payload: { result, createdAt: '', completedAt: '', analysisStartedAt: '' },
+    })
+    dispatch({ type: 'SET_REPORTPORTAL_AVAILABLE', payload: reportportalAvailable })
+    dispatch({ type: 'SET_COMMENTS_AND_REVIEWS', payload: { comments: [], reviews } })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useImperativeHandle(ref, () => ({
+    setReviews(newReviews: Record<string, ReviewState>) {
+      for (const [key, state] of Object.entries(newReviews)) {
+        dispatch({ type: 'SET_REVIEW', payload: { key, state } })
+      }
+    },
+  }))
+
+  return <AllReviewedPrompt jobId="job-1" />
+})
 
 /* ------------------------------------------------------------------ */
 /*  Tests                                                              */
@@ -256,6 +291,73 @@ describe('AllReviewedPrompt', () => {
         'parent-test': makeReview(true),
         'child-job#42::child-test': makeReview(true),
       },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+  })
+
+  it('does not show dialog when report loads with all failures already reviewed', async () => {
+    renderPrompt({
+      reviews: {
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+  })
+
+  it('re-triggers dialog after cycle: all-reviewed → one unreviewed → all-reviewed', async () => {
+    const injectorRef = createRef<DynamicInjectorHandle>()
+
+    render(
+      <ReportProvider>
+        <DynamicInjector
+          ref={injectorRef}
+          result={makeResult()}
+          reviews={{}}
+          reportportalAvailable={true}
+        />
+      </ReportProvider>,
+    )
+
+    // Step 1: Mark all as reviewed → dialog should open
+    await act(async () => {
+      injectorRef.current!.setReviews({
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('All failures reviewed. Update Report Portal?')).toBeDefined()
+    })
+
+    // Dismiss dialog
+    fireEvent.click(screen.getByRole('button', { name: 'No' }))
+    await waitFor(() => {
+      expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+    })
+
+    // Step 2: Un-review one failure
+    await act(async () => {
+      injectorRef.current!.setReviews({
+        'test-a': makeReview(false),
+      })
+    })
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(screen.queryByText('All failures reviewed. Update Report Portal?')).toBeNull()
+
+    // Step 3: Mark all reviewed again → dialog should re-open
+    await act(async () => {
+      injectorRef.current!.setReviews({
+        'test-a': makeReview(true),
+        'test-b': makeReview(true),
+      })
     })
 
     await waitFor(() => {

--- a/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
+++ b/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
@@ -87,7 +87,8 @@ function Injector({
         for (const [key, state] of Object.entries(additionalReviews)) {
           dispatch({ type: 'SET_REVIEW', payload: { key, state } })
         }
-        window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId: 'job-1' } }))
+        // Fire event in a separate tick so React processes the SET_REVIEW state updates first
+        setTimeout(() => window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId: 'job-1' } })), 0)
       }, 0)
       return () => clearTimeout(id)
     }

--- a/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
+++ b/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
@@ -87,6 +87,7 @@ function Injector({
         for (const [key, state] of Object.entries(additionalReviews)) {
           dispatch({ type: 'SET_REVIEW', payload: { key, state } })
         }
+        window.dispatchEvent(new Event('jji:review-changed'))
       }, 0)
       return () => clearTimeout(id)
     }
@@ -138,6 +139,7 @@ const DynamicInjector = forwardRef<DynamicInjectorHandle, {
       for (const [key, state] of Object.entries(newReviews)) {
         dispatch({ type: 'SET_REVIEW', payload: { key, state } })
       }
+      window.dispatchEvent(new Event('jji:review-changed'))
     },
   }))
 

--- a/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
+++ b/frontend/src/pages/report/__tests__/AllReviewedPrompt.test.tsx
@@ -87,7 +87,7 @@ function Injector({
         for (const [key, state] of Object.entries(additionalReviews)) {
           dispatch({ type: 'SET_REVIEW', payload: { key, state } })
         }
-        window.dispatchEvent(new Event('jji:review-changed'))
+        window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId: 'job-1' } }))
       }, 0)
       return () => clearTimeout(id)
     }
@@ -139,7 +139,7 @@ const DynamicInjector = forwardRef<DynamicInjectorHandle, {
       for (const [key, state] of Object.entries(newReviews)) {
         dispatch({ type: 'SET_REVIEW', payload: { key, state } })
       }
-      window.dispatchEvent(new Event('jji:review-changed'))
+      window.dispatchEvent(new CustomEvent('jji:review-changed', { detail: { jobId: 'job-1' } }))
     },
   }))
 


### PR DESCRIPTION
Closes #193

## Changes
- Add AllReviewedPrompt component that detects all-reviewed transition
- Show confirmation popup with Yes/No when all failures become reviewed
- Re-triggers on reviewed state cycles (reviewed → unreviewed → reviewed)
- Only shows when Report Portal is enabled
- Extract shared `failureKeys` utility for recursive failure key collection

## Done
- [x] Frontend detects when all failures transition to reviewed state
- [x] Confirmation popup shown to user (Yes/No)
- [x] Yes triggers Report Portal update API call
- [x] No dismisses without action
- [x] Popup re-triggers if reviewed state cycles
- [x] Popup only appears when Report Portal is enabled
- [x] Frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialog prompts users to push results to Report Portal when all test failures (including nested child-job failures) are marked reviewed; shown on report pages only when Report Portal is available.

* **Refactor**
  * Centralized logic for aggregating/counting nested failures and consistent review-key generation.

* **Behavior**
  * Review actions now emit a global review-changed event to coordinate UI updates.

* **Tests**
  * Added tests covering the all-reviewed flow, dialog interactions, nested failures, and Report Portal push.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->