### PR TITLE
feat: replace Report Bug with AI-powered feedback dialog

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,6 +8,7 @@ useDefault = true
 [allowlist]
 # Allowlist test files that contain fake/mock credentials for unit tests
 paths = [
+    '''\.secrets\.baseline''',
     '''tests/test_config\.py''',
     '''tests/test_main\.py''',
     '''tests/conftest\.py''',
@@ -15,4 +16,5 @@ paths = [
     '''tests/test_cli_client\.py''',
     '''tests/test_auth\.py''',
     '''tests/test_debug_request_logging\.py''',
+    '''tests/test_feedback\.py''',
 ]

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -78,10 +78,20 @@ export function NavBar() {
 
   // Fetch server capabilities to check if feedback is enabled
   useEffect(() => {
-    api.get<{ feedback_enabled?: boolean }>('/api/capabilities')
-      .then((caps) => setFeedbackEnabled(caps.feedback_enabled ?? false))
-      .catch(() => {})
-  }, [])
+    let cancelled = false
+    async function loadCapabilities() {
+      try {
+        const caps = await api.get<{ feedback_enabled?: boolean }>('/api/capabilities')
+        if (!cancelled) setFeedbackEnabled(caps.feedback_enabled ?? false)
+      } catch {
+        if (!cancelled) setFeedbackEnabled(false)
+      }
+    }
+    void loadCapabilities()
+    return () => {
+      cancelled = true
+    }
+  }, [username])
 
   const baseNavLinks = username
     ? [...BASE_NAV_LINKS, { to: '/mentions', label: 'Mentions' }]

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -79,19 +79,23 @@ export function NavBar() {
   // Fetch server capabilities to check if feedback is enabled
   useEffect(() => {
     let cancelled = false
-    async function loadCapabilities() {
+    async function loadCapabilities(retry = true) {
       try {
         const caps = await api.get<{ feedback_enabled?: boolean }>('/api/capabilities')
         if (!cancelled) setFeedbackEnabled(caps.feedback_enabled ?? false)
       } catch {
-        if (!cancelled) setFeedbackEnabled(false)
+        if (!cancelled && retry) {
+          setTimeout(() => { if (!cancelled) void loadCapabilities(false) }, 5000)
+        } else if (!cancelled) {
+          setFeedbackEnabled(false)
+        }
       }
     }
     void loadCapabilities()
     return () => {
       cancelled = true
     }
-  }, [username])
+  }, [])
 
   const baseNavLinks = username
     ? [...BASE_NAV_LINKS, { to: '/mentions', label: 'Mentions' }]

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { BookOpen, Bug, type LucideIcon } from 'lucide-react'
+import { BookOpen, MessageSquarePlus, type LucideIcon } from 'lucide-react'
 import { UserBadge } from './UserBadge'
+import { FeedbackDialog } from '@/components/shared/FeedbackDialog'
 import { useAuth } from '@/lib/auth'
 import { api } from '@/lib/api'
-import { GITHUB_REPO_URL } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 
 interface ExternalNavLink {
@@ -16,7 +16,6 @@ interface ExternalNavLink {
 
 const EXTERNAL_NAV_LINKS: ExternalNavLink[] = [
   { href: 'https://myk-org.github.io/jenkins-job-insight/', label: 'User Guide', title: 'User Guide', icon: BookOpen },
-  { href: `${GITHUB_REPO_URL}/issues/new`, label: 'Report Bug', title: 'Report a bug on GitHub', icon: Bug },
 ]
 
 const BASE_NAV_LINKS = [
@@ -30,6 +29,8 @@ export function NavBar() {
   const location = useLocation()
   const { isAdmin, username } = useAuth()
   const [unreadCount, setUnreadCount] = useState(0)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
+  const [feedbackEnabled, setFeedbackEnabled] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const fetchUnread = useCallback(async () => {
@@ -74,6 +75,13 @@ export function NavBar() {
   useEffect(() => {
     if (!username) setUnreadCount(0)
   }, [username])
+
+  // Fetch server capabilities to check if feedback is enabled
+  useEffect(() => {
+    api.get<{ feedback_enabled?: boolean }>('/api/capabilities')
+      .then((caps) => setFeedbackEnabled(caps.feedback_enabled ?? false))
+      .catch(() => {})
+  }, [])
 
   const baseNavLinks = username
     ? [...BASE_NAV_LINKS, { to: '/mentions', label: 'Mentions' }]
@@ -129,7 +137,21 @@ export function NavBar() {
               {label}
             </a>
           ))}
+          {feedbackEnabled && (
+            <button
+              type="button"
+              onClick={() => setFeedbackOpen(true)}
+              title="Send feedback"
+              className="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
+            >
+              <MessageSquarePlus className="h-4 w-4 shrink-0" />
+              Feedback
+            </button>
+          )}
           <UserBadge />
+          {feedbackEnabled && (
+            <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+          )}
         </div>
       </div>
     </header>

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react'
+import { api } from '@/lib/api'
+import { getRecentFailedCalls } from '@/lib/api'
+import { getRecentErrors } from '@/lib/errorCapture'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
+import { CheckCircle2, ExternalLink, Bug, Lightbulb } from 'lucide-react'
+import type { FeedbackRequest, FeedbackResponse } from '@/types'
+
+type FeedbackType = 'bug' | 'feature'
+type Phase = 'form' | 'submitting' | 'success' | 'error'
+
+interface FeedbackDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+  const [feedbackType, setFeedbackType] = useState<FeedbackType>('bug')
+  const [description, setDescription] = useState('')
+  const [phase, setPhase] = useState<Phase>('form')
+  const [issueUrl, setIssueUrl] = useState('')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  function collectPageState(): FeedbackRequest['page_state'] {
+    const state: FeedbackRequest['page_state'] = {
+      url: window.location.href,
+    }
+    // Extract report_id from URL if on a report page
+    const reportMatch = window.location.pathname.match(/\/results\/([^/]+)/)
+    if (reportMatch) {
+      state.report_id = reportMatch[1]
+    }
+    // Capture active filters from URL search params
+    const params = new URLSearchParams(window.location.search)
+    const filters = params.toString()
+    if (filters) {
+      state.active_filters = filters
+    }
+    return state
+  }
+
+  async function handleSubmit() {
+    if (!description.trim()) return
+
+    setPhase('submitting')
+    try {
+      const failedCalls = getRecentFailedCalls()
+      const payload: FeedbackRequest = {
+        feedback_type: feedbackType,
+        description: description.trim(),
+        console_errors: getRecentErrors(),
+        failed_api_calls: failedCalls.map(({ status, endpoint, error }) => ({
+          status,
+          endpoint,
+          error,
+        })),
+        page_state: collectPageState(),
+        user_agent: navigator.userAgent,
+      }
+
+      const res = await api.post<FeedbackResponse>('/api/feedback', payload)
+      setIssueUrl(res.issue_url)
+      setPhase('success')
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to submit feedback')
+      setPhase('error')
+    }
+  }
+
+  function handleClose(nextOpen: boolean) {
+    if (nextOpen) return
+    onOpenChange(false)
+    setTimeout(() => {
+      setPhase('form')
+      setFeedbackType('bug')
+      setDescription('')
+      setIssueUrl('')
+      setErrorMsg('')
+    }, 200)
+  }
+
+  const typeOptions: { value: FeedbackType; label: string; icon: typeof Bug }[] = [
+    { value: 'bug', label: 'Bug Report', icon: Bug },
+    { value: 'feature', label: 'Feature Request', icon: Lightbulb },
+  ]
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{phase === 'success' ? 'Feedback Submitted' : 'Send Feedback'}</DialogTitle>
+          {phase === 'form' && (
+            <DialogDescription>
+              Report a bug or suggest a feature. Browser context is attached automatically.
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {/* Form */}
+        {phase === 'form' && (
+          <div className="space-y-4">
+            {/* Type selector */}
+            <div className="flex gap-2">
+              {typeOptions.map(({ value, label, icon: Icon }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFeedbackType(value)}
+                  className={`flex flex-1 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                    feedbackType === value
+                      ? 'border-border-accent bg-surface-elevated text-text-primary'
+                      : 'border-border-default text-text-tertiary hover:bg-surface-hover hover:text-text-secondary'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {/* Description */}
+            <div className="space-y-2">
+              <label htmlFor="feedback-description" className="text-xs font-display uppercase tracking-widest text-text-tertiary">
+                Description
+              </label>
+              <Textarea
+                id="feedback-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder={
+                  feedbackType === 'bug'
+                    ? 'Describe the bug: what happened vs. what you expected...'
+                    : 'Describe the feature you\'d like to see...'
+                }
+                rows={6}
+              />
+            </div>
+
+            <p className="text-xs text-text-tertiary">
+              Console errors, recent failed API calls, and page context will be included automatically.
+            </p>
+          </div>
+        )}
+
+        {/* Submitting */}
+        {phase === 'submitting' && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <LoadingSpinner size="lg" />
+            <p className="text-sm text-text-secondary">Submitting feedback...</p>
+          </div>
+        )}
+
+        {/* Success */}
+        {phase === 'success' && (
+          <div className="flex flex-col items-center gap-4 py-8 animate-scale-in">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-signal-green/15">
+              <CheckCircle2 className="h-8 w-8 text-signal-green" />
+            </div>
+            <p className="text-sm text-text-secondary">Thank you for your feedback!</p>
+            {issueUrl && (
+              <a
+                href={issueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-sm text-text-link hover:underline"
+              >
+                View issue <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </div>
+        )}
+
+        {/* Error */}
+        {phase === 'error' && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <p className="text-sm text-signal-red">{errorMsg}</p>
+          </div>
+        )}
+
+        <DialogFooter className="flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end">
+          {phase === 'form' && (
+            <div className="flex gap-2 sm:ml-auto">
+              <Button variant="ghost" onClick={() => handleClose(false)}>Cancel</Button>
+              <Button onClick={handleSubmit} disabled={!description.trim()}>Submit</Button>
+            </div>
+          )}
+          {phase === 'error' && (
+            <div className="flex gap-2 sm:ml-auto">
+              <Button variant="ghost" onClick={() => handleClose(false)}>Close</Button>
+              <Button onClick={() => setPhase('form')}>Try Again</Button>
+            </div>
+          )}
+          {phase === 'success' && (
+            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -11,13 +11,19 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { CheckCircle2, ExternalLink, Bug, Lightbulb } from 'lucide-react'
-import type { FeedbackRequest, FeedbackResponse } from '@/types'
+import type {
+  FeedbackRequest,
+  FeedbackPreviewResponse,
+  FeedbackCreateRequest,
+  FeedbackCreateResponse,
+} from '@/types'
 
 type FeedbackType = 'bug' | 'feature'
-type Phase = 'form' | 'submitting' | 'success' | 'error'
+type Phase = 'form' | 'previewing' | 'preview' | 'creating' | 'success' | 'error'
 
 interface FeedbackDialogProps {
   open: boolean
@@ -30,7 +36,13 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [phase, setPhase] = useState<Phase>('form')
   const [issueUrl, setIssueUrl] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
+  const [errorSource, setErrorSource] = useState<'preview' | 'create'>('preview')
   const cancelledRef = useRef(false)
+
+  // Preview state
+  const [previewTitle, setPreviewTitle] = useState('')
+  const [previewBody, setPreviewBody] = useState('')
+  const [previewLabels, setPreviewLabels] = useState<string[]>([])
 
   // Track dialog open/close to guard async setState
   useEffect(() => {
@@ -59,10 +71,10 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     return state
   }
 
-  async function handleSubmit() {
+  async function handlePreview() {
     if (!description.trim()) return
 
-    setPhase('submitting')
+    setPhase('previewing')
     try {
       const failedCalls = getRecentFailedCalls()
       const payload: FeedbackRequest = {
@@ -78,17 +90,47 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
         user_agent: navigator.userAgent,
       }
 
-      const res = await api.post<FeedbackResponse>('/api/feedback', payload)
+      const res = await api.post<FeedbackPreviewResponse>('/api/feedback/preview', payload)
+      if (!cancelledRef.current) {
+        setPreviewTitle(res.title)
+        setPreviewBody(res.body)
+        setPreviewLabels(res.labels)
+        setPhase('preview')
+      }
+    } catch (err) {
+      if (!cancelledRef.current) {
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to generate preview')
+        setErrorSource('preview')
+        setPhase('error')
+      }
+    }
+  }
+
+  async function handleCreate() {
+    setPhase('creating')
+    try {
+      const payload: FeedbackCreateRequest = {
+        title: previewTitle,
+        body: previewBody,
+        labels: previewLabels,
+      }
+
+      const res = await api.post<FeedbackCreateResponse>('/api/feedback/create', payload)
       if (!cancelledRef.current) {
         setIssueUrl(res.issue_url)
         setPhase('success')
       }
     } catch (err) {
       if (!cancelledRef.current) {
-        setErrorMsg(err instanceof Error ? err.message : 'Failed to submit feedback')
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to create issue')
+        setErrorSource('create')
         setPhase('error')
       }
     }
+  }
+
+  function handleBack() {
+    setPhase('form')
   }
 
   function handleClose(nextOpen: boolean) {
@@ -100,6 +142,9 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       setDescription('')
       setIssueUrl('')
       setErrorMsg('')
+      setPreviewTitle('')
+      setPreviewBody('')
+      setPreviewLabels([])
     }, 200)
   }
 
@@ -108,19 +153,31 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     { value: 'feature', label: 'Feature Request', icon: Lightbulb },
   ]
 
+  const dialogTitle =
+    phase === 'success'
+      ? 'Feedback Submitted'
+      : phase === 'preview' || phase === 'creating'
+        ? 'Preview Issue'
+        : 'Send Feedback'
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>{phase === 'success' ? 'Feedback Submitted' : 'Send Feedback'}</DialogTitle>
+          <DialogTitle>{dialogTitle}</DialogTitle>
           {phase === 'form' && (
             <DialogDescription>
               Report a bug or suggest a feature. Browser context is attached automatically.
             </DialogDescription>
           )}
+          {phase === 'preview' && (
+            <DialogDescription>
+              Review and edit the generated issue before creating it.
+            </DialogDescription>
+          )}
         </DialogHeader>
 
-        {/* Form */}
+        {/* Phase 1: Form */}
         {phase === 'form' && (
           <div className="space-y-4">
             {/* Type selector */}
@@ -166,15 +223,50 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           </div>
         )}
 
-        {/* Submitting */}
-        {phase === 'submitting' && (
+        {/* Previewing (loading) */}
+        {phase === 'previewing' && (
           <div className="flex flex-col items-center gap-4 py-8">
             <LoadingSpinner size="lg" />
-            <p className="text-sm text-text-secondary">Submitting feedback...</p>
+            <p className="text-sm text-text-secondary">Generating preview...</p>
           </div>
         )}
 
-        {/* Success */}
+        {/* Phase 2: Preview */}
+        {phase === 'preview' && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="preview-title" className="text-xs font-display uppercase tracking-widest text-text-tertiary">
+                Title
+              </label>
+              <Input
+                id="preview-title"
+                value={previewTitle}
+                onChange={(e) => setPreviewTitle(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="preview-body" className="text-xs font-display uppercase tracking-widest text-text-tertiary">
+                Body
+              </label>
+              <Textarea
+                id="preview-body"
+                value={previewBody}
+                onChange={(e) => setPreviewBody(e.target.value)}
+                rows={10}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Creating (loading) */}
+        {phase === 'creating' && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <LoadingSpinner size="lg" />
+            <p className="text-sm text-text-secondary">Creating issue...</p>
+          </div>
+        )}
+
+        {/* Phase 3: Success */}
         {phase === 'success' && (
           <div className="flex flex-col items-center gap-4 py-8 animate-scale-in">
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-signal-green/15">
@@ -205,13 +297,19 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           {phase === 'form' && (
             <div className="flex gap-2 sm:ml-auto">
               <Button variant="ghost" onClick={() => handleClose(false)}>Cancel</Button>
-              <Button onClick={handleSubmit} disabled={!description.trim()}>Submit</Button>
+              <Button onClick={handlePreview} disabled={!description.trim()}>Preview</Button>
+            </div>
+          )}
+          {phase === 'preview' && (
+            <div className="flex gap-2 sm:ml-auto">
+              <Button variant="ghost" onClick={handleBack}>Back</Button>
+              <Button onClick={handleCreate} disabled={!previewTitle.trim()}>Create Issue</Button>
             </div>
           )}
           {phase === 'error' && (
             <div className="flex gap-2 sm:ml-auto">
               <Button variant="ghost" onClick={() => handleClose(false)}>Close</Button>
-              <Button onClick={() => setPhase('form')}>Try Again</Button>
+              <Button onClick={() => setPhase(errorSource === 'preview' ? 'form' : 'preview')}>Try Again</Button>
             </div>
           )}
           {phase === 'success' && (

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -171,7 +171,10 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
         : 'Send Feedback'
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
+    <Dialog open={open} onOpenChange={(nextOpen) => {
+      if (!nextOpen && (phase === 'previewing' || phase === 'creating' || phase === 'preview')) return
+      handleClose(nextOpen)
+    }}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>{dialogTitle}</DialogTitle>

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
-import { CheckCircle2, ExternalLink, Bug, Lightbulb } from 'lucide-react'
+import { CheckCircle2, ExternalLink } from 'lucide-react'
 import type {
   FeedbackRequest,
   FeedbackPreviewResponse,
@@ -22,8 +22,7 @@ import type {
   FeedbackCreateResponse,
 } from '@/types'
 
-type FeedbackType = 'bug' | 'feature'
-type Phase = 'form' | 'previewing' | 'preview' | 'creating' | 'success' | 'error'
+type Phase = 'form' | 'previewing' | 'preview' | 'creating' | 'success' | 'error' | 'ai-not-configured'
 
 interface FeedbackDialogProps {
   open: boolean
@@ -31,7 +30,6 @@ interface FeedbackDialogProps {
 }
 
 export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
-  const [feedbackType, setFeedbackType] = useState<FeedbackType>('bug')
   const [description, setDescription] = useState('')
   const [phase, setPhase] = useState<Phase>('form')
   const [issueUrl, setIssueUrl] = useState('')
@@ -93,7 +91,6 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     try {
       const failedCalls = getRecentFailedCalls()
       const payload: FeedbackRequest = {
-        feedback_type: feedbackType,
         description: description.trim(),
         console_errors: getRecentErrors(),
         failed_api_calls: failedCalls.map(({ status, endpoint, error }) => ({
@@ -113,9 +110,14 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       setPhase('preview')
     } catch (err) {
       if (gen !== generationRef.current) return
-      setErrorMsg(err instanceof Error ? err.message : 'Failed to generate preview')
-      setErrorSource('preview')
-      setPhase('error')
+      const msg = err instanceof Error ? err.message : 'Failed to generate preview'
+      if (/ai\s*(is)?\s*not\s*configured/i.test(msg)) {
+        setPhase('ai-not-configured')
+      } else {
+        setErrorMsg(msg)
+        setErrorSource('preview')
+        setPhase('error')
+      }
     }
   }
 
@@ -154,7 +156,6 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     resetTimerRef.current = setTimeout(() => {
       resetTimerRef.current = null
       setPhase('form')
-      setFeedbackType('bug')
       setDescription('')
       setIssueUrl('')
       setErrorMsg('')
@@ -163,11 +164,6 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       setPreviewLabels([])
     }, 200)
   }
-
-  const typeOptions: { value: FeedbackType; label: string; icon: typeof Bug }[] = [
-    { value: 'bug', label: 'Bug Report', icon: Bug },
-    { value: 'feature', label: 'Feature Request', icon: Lightbulb },
-  ]
 
   const dialogTitle =
     phase === 'success'
@@ -183,7 +179,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           <DialogTitle>{dialogTitle}</DialogTitle>
           {phase === 'form' && (
             <DialogDescription>
-              Report a bug or suggest a feature. Browser context is attached automatically.
+              Describe your issue or idea. Browser context is attached automatically.
             </DialogDescription>
           )}
           {phase === 'preview' && (
@@ -196,25 +192,6 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
         {/* Phase 1: Form */}
         {phase === 'form' && (
           <div className="space-y-4">
-            {/* Type selector */}
-            <div className="flex gap-2">
-              {typeOptions.map(({ value, label, icon: Icon }) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setFeedbackType(value)}
-                  className={`flex flex-1 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
-                    feedbackType === value
-                      ? 'border-border-accent bg-surface-elevated text-text-primary'
-                      : 'border-border-default text-text-tertiary hover:bg-surface-hover hover:text-text-secondary'
-                  }`}
-                >
-                  <Icon className="h-4 w-4" />
-                  {label}
-                </button>
-              ))}
-            </div>
-
             {/* Description */}
             <div className="space-y-2">
               <label htmlFor="feedback-description" className="text-xs font-display uppercase tracking-widest text-text-tertiary">
@@ -224,11 +201,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
                 id="feedback-description"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder={
-                  feedbackType === 'bug'
-                    ? 'Describe the bug: what happened vs. what you expected...'
-                    : 'Describe the feature you\'d like to see...'
-                }
+                placeholder="Describe your issue or suggestion..."
                 rows={6}
               />
             </div>
@@ -302,6 +275,21 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           </div>
         )}
 
+        {/* AI not configured */}
+        {phase === 'ai-not-configured' && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <p className="text-sm text-text-secondary">AI is not configured on this server. You can open an issue manually:</p>
+            <a
+              href="https://github.com/myk-org/jenkins-job-insight/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm text-text-link hover:underline"
+            >
+              Open a new issue <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+
         {/* Error */}
         {phase === 'error' && (
           <div className="flex flex-col items-center gap-4 py-8">
@@ -330,6 +318,9 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
               <Button variant="ghost" onClick={() => handleClose(false)}>Close</Button>
               <Button onClick={() => setPhase(errorSource === 'preview' ? 'form' : 'preview')}>Try Again</Button>
             </div>
+          )}
+          {phase === 'ai-not-configured' && (
+            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
           )}
           {phase === 'success' && (
             <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -66,9 +66,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   }, [])
 
   function collectPageState(): FeedbackRequest['page_state'] {
-    const state: FeedbackRequest['page_state'] = {
-      url: window.location.href,
-    }
+    const state: FeedbackRequest['page_state'] = {}
     // Extract report_id from URL if on a report page
     const reportMatch = window.location.pathname.match(/\/results\/([^/]+)/)
     if (reportMatch) {

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -319,7 +319,10 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           {phase === 'preview' && (
             <div className="flex gap-2 sm:ml-auto">
               <Button variant="ghost" onClick={handleBack}>Back</Button>
-              <Button onClick={handleCreate} disabled={!previewTitle.trim()}>Create Issue</Button>
+              <Button
+                onClick={handleCreate}
+                disabled={!previewTitle.trim() || !previewBody.trim()}
+              >Create Issue</Button>
             </div>
           )}
           {phase === 'error' && (

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -37,7 +37,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [issueUrl, setIssueUrl] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
   const [errorSource, setErrorSource] = useState<'preview' | 'create'>('preview')
-  const cancelledRef = useRef(false)
+  const generationRef = useRef(0)
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Preview state
@@ -48,13 +48,13 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   // Track dialog open/close to guard async setState
   useEffect(() => {
     if (open) {
-      cancelledRef.current = false
+      generationRef.current += 1
       if (resetTimerRef.current) {
         clearTimeout(resetTimerRef.current)
         resetTimerRef.current = null
       }
     } else {
-      cancelledRef.current = true
+      generationRef.current += 1
     }
   }, [open])
 
@@ -88,6 +88,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   async function handlePreview() {
     if (!description.trim()) return
 
+    const gen = generationRef.current
     setPhase('previewing')
     try {
       const failedCalls = getRecentFailedCalls()
@@ -105,22 +106,21 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       }
 
       const res = await api.post<FeedbackPreviewResponse>('/api/feedback/preview', payload)
-      if (!cancelledRef.current) {
-        setPreviewTitle(res.title)
-        setPreviewBody(res.body)
-        setPreviewLabels(res.labels)
-        setPhase('preview')
-      }
+      if (gen !== generationRef.current) return
+      setPreviewTitle(res.title)
+      setPreviewBody(res.body)
+      setPreviewLabels(res.labels)
+      setPhase('preview')
     } catch (err) {
-      if (!cancelledRef.current) {
-        setErrorMsg(err instanceof Error ? err.message : 'Failed to generate preview')
-        setErrorSource('preview')
-        setPhase('error')
-      }
+      if (gen !== generationRef.current) return
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to generate preview')
+      setErrorSource('preview')
+      setPhase('error')
     }
   }
 
   async function handleCreate() {
+    const gen = generationRef.current
     setPhase('creating')
     try {
       const payload: FeedbackCreateRequest = {
@@ -130,16 +130,14 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       }
 
       const res = await api.post<FeedbackCreateResponse>('/api/feedback/create', payload)
-      if (!cancelledRef.current) {
-        setIssueUrl(res.issue_url)
-        setPhase('success')
-      }
+      if (gen !== generationRef.current) return
+      setIssueUrl(res.issue_url)
+      setPhase('success')
     } catch (err) {
-      if (!cancelledRef.current) {
-        setErrorMsg(err instanceof Error ? err.message : 'Failed to create issue')
-        setErrorSource('create')
-        setPhase('error')
-      }
+      if (gen !== generationRef.current) return
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to create issue')
+      setErrorSource('create')
+      setPhase('error')
     }
   }
 

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -175,7 +175,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       if (!nextOpen && (phase === 'previewing' || phase === 'creating' || phase === 'preview')) return
       handleClose(nextOpen)
     }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" hideCloseButton={phase === 'preview' || phase === 'previewing' || phase === 'creating'}>
         <DialogHeader>
           <DialogTitle>{dialogTitle}</DialogTitle>
           {phase === 'form' && (
@@ -301,13 +301,14 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
         <DialogFooter className="flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end">
           {phase === 'form' && (
             <div className="flex gap-2 sm:ml-auto">
-              <Button variant="ghost" onClick={() => handleClose(false)}>Cancel</Button>
+              <Button variant="outline" onClick={() => handleClose(false)}>Cancel</Button>
               <Button onClick={handlePreview} disabled={!description.trim()}>Preview</Button>
             </div>
           )}
           {phase === 'preview' && (
             <div className="flex gap-2 sm:ml-auto">
-              <Button variant="ghost" onClick={handleBack}>Back</Button>
+              <Button variant="outline" onClick={handleBack}>Back</Button>
+              <Button variant="outline" onClick={() => handleClose(false)}>Cancel</Button>
               <Button
                 onClick={handleCreate}
                 disabled={!previewTitle.trim() || !previewBody.trim()}
@@ -316,15 +317,15 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           )}
           {phase === 'error' && (
             <div className="flex gap-2 sm:ml-auto">
-              <Button variant="ghost" onClick={() => handleClose(false)}>Close</Button>
+              <Button variant="outline" onClick={() => handleClose(false)}>Close</Button>
               <Button onClick={() => setPhase(errorSource === 'preview' ? 'form' : 'preview')}>Try Again</Button>
             </div>
           )}
           {phase === 'ai-not-configured' && (
-            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
+            <Button variant="outline" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
           )}
           {phase === 'success' && (
-            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
+            <Button variant="outline" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { api } from '@/lib/api'
 import { getRecentFailedCalls } from '@/lib/api'
 import { getRecentErrors } from '@/lib/errorCapture'
@@ -30,6 +30,16 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [phase, setPhase] = useState<Phase>('form')
   const [issueUrl, setIssueUrl] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
+  const cancelledRef = useRef(false)
+
+  // Track dialog open/close to guard async setState
+  useEffect(() => {
+    if (open) {
+      cancelledRef.current = false
+    } else {
+      cancelledRef.current = true
+    }
+  }, [open])
 
   function collectPageState(): FeedbackRequest['page_state'] {
     const state: FeedbackRequest['page_state'] = {
@@ -69,11 +79,15 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
       }
 
       const res = await api.post<FeedbackResponse>('/api/feedback', payload)
-      setIssueUrl(res.issue_url)
-      setPhase('success')
+      if (!cancelledRef.current) {
+        setIssueUrl(res.issue_url)
+        setPhase('success')
+      }
     } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : 'Failed to submit feedback')
-      setPhase('error')
+      if (!cancelledRef.current) {
+        setErrorMsg(err instanceof Error ? err.message : 'Failed to submit feedback')
+        setPhase('error')
+      }
     }
   }
 

--- a/frontend/src/components/shared/FeedbackDialog.tsx
+++ b/frontend/src/components/shared/FeedbackDialog.tsx
@@ -38,6 +38,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [errorMsg, setErrorMsg] = useState('')
   const [errorSource, setErrorSource] = useState<'preview' | 'create'>('preview')
   const cancelledRef = useRef(false)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Preview state
   const [previewTitle, setPreviewTitle] = useState('')
@@ -48,10 +49,23 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   useEffect(() => {
     if (open) {
       cancelledRef.current = false
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current)
+        resetTimerRef.current = null
+      }
     } else {
       cancelledRef.current = true
     }
   }, [open])
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current)
+      }
+    }
+  }, [])
 
   function collectPageState(): FeedbackRequest['page_state'] {
     const state: FeedbackRequest['page_state'] = {
@@ -136,7 +150,11 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   function handleClose(nextOpen: boolean) {
     if (nextOpen) return
     onOpenChange(false)
-    setTimeout(() => {
+    if (resetTimerRef.current) {
+      clearTimeout(resetTimerRef.current)
+    }
+    resetTimerRef.current = setTimeout(() => {
+      resetTimerRef.current = null
       setPhase('form')
       setFeedbackType('bug')
       setDescription('')

--- a/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FeedbackDialog } from '../FeedbackDialog'
+
+// Mock the api module
+vi.mock('@/lib/api', () => ({
+  api: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+  getRecentFailedCalls: vi.fn(() => []),
+  ApiError: class extends Error {
+    status: number
+    statusText: string
+    body: unknown
+    constructor(status: number, statusText: string, body: unknown) {
+      super(`API error ${status}: ${statusText}`)
+      this.status = status
+      this.statusText = statusText
+      this.body = body
+    }
+  },
+}))
+
+// Mock errorCapture
+vi.mock('@/lib/errorCapture', () => ({
+  getRecentErrors: vi.fn(() => ['error1', 'error2']),
+}))
+
+import { api, getRecentFailedCalls } from '@/lib/api'
+
+const mockPost = api.post as ReturnType<typeof vi.fn>
+const mockGetFailedCalls = getRecentFailedCalls as ReturnType<typeof vi.fn>
+
+describe('FeedbackDialog', () => {
+  const onOpenChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders form with type selector and textarea when open', () => {
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    expect(screen.getByText('Send Feedback')).toBeInTheDocument()
+    expect(screen.getByText('Bug Report')).toBeInTheDocument()
+    expect(screen.getByText('Feature Request')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+  })
+
+  it('disables submit when description is empty', () => {
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+  })
+
+  it('enables submit when description is provided', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Something broke')
+    expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled()
+  })
+
+  it('switches feedback type when toggled', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    const featureBtn = screen.getByText('Feature Request')
+    await user.click(featureBtn)
+    // The placeholder should change
+    expect(screen.getByPlaceholderText(/feature you'd like to see/i)).toBeInTheDocument()
+  })
+
+  it('submits feedback and shows success', async () => {
+    mockPost.mockResolvedValue({ issue_url: 'https://github.com/org/repo/issues/42', issue_key: '#42' })
+    mockGetFailedCalls.mockReturnValue([])
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Page crashes on load')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(screen.getByText('Thank you for your feedback!')).toBeInTheDocument())
+    expect(screen.getByText('View issue')).toHaveAttribute('href', 'https://github.com/org/repo/issues/42')
+    expect(mockPost).toHaveBeenCalledWith('/api/feedback', expect.objectContaining({
+      feedback_type: 'bug',
+      description: 'Page crashes on load',
+      user_agent: expect.any(String),
+      console_errors: ['error1', 'error2'],
+    }))
+  })
+
+  it('shows error message on submit failure', async () => {
+    mockPost.mockRejectedValue(new Error('API error 500: Internal Server Error'))
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(screen.getByText(/API error 500/)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+  })
+
+  it('Try Again returns to form state', async () => {
+    mockPost.mockRejectedValue(new Error('Network error'))
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(screen.getByText(/Network error/)).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+    expect(screen.getByText('Send Feedback')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+  })
+
+  it('includes failed API calls in the payload', async () => {
+    mockPost.mockResolvedValue({ issue_url: '', issue_key: '' })
+    mockGetFailedCalls.mockReturnValue([
+      { status: 500, endpoint: '/api/test', error: 'server error', timestamp: 123 },
+    ])
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Bug report')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(mockPost).toHaveBeenCalled())
+    const payload = mockPost.mock.calls[0][1]
+    expect(payload.failed_api_calls).toEqual([
+      { status: 500, endpoint: '/api/test', error: 'server error' },
+    ])
+  })
+})

--- a/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
@@ -40,12 +40,12 @@ describe('FeedbackDialog', () => {
     vi.clearAllMocks()
   })
 
-  it('renders form with type selector and textarea when open', () => {
+  it('renders form with description textarea when open', () => {
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     expect(screen.getByText('Send Feedback')).toBeInTheDocument()
-    expect(screen.getByText('Bug Report')).toBeInTheDocument()
-    expect(screen.getByText('Feature Request')).toBeInTheDocument()
+    expect(screen.getByText(/Describe your issue or idea/)).toBeInTheDocument()
     expect(screen.getByLabelText('Description')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Describe your issue or suggestion...')).toBeInTheDocument()
   })
 
   it('disables Preview when description is empty', () => {
@@ -58,15 +58,6 @@ describe('FeedbackDialog', () => {
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Something broke')
     expect(screen.getByRole('button', { name: /preview/i })).toBeEnabled()
-  })
-
-  it('switches feedback type when toggled', async () => {
-    const user = userEvent.setup()
-    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
-    const featureBtn = screen.getByText('Feature Request')
-    await user.click(featureBtn)
-    // The placeholder should change
-    expect(screen.getByPlaceholderText(/feature you'd like to see/i)).toBeInTheDocument()
   })
 
   it('calls preview endpoint and shows editable preview', async () => {
@@ -85,7 +76,6 @@ describe('FeedbackDialog', () => {
     expect(screen.getByLabelText('Title')).toHaveValue('AI generated title')
     expect(screen.getByLabelText('Body')).toHaveValue('AI generated body')
     expect(mockPost).toHaveBeenCalledWith('/api/feedback/preview', expect.objectContaining({
-      feedback_type: 'bug',
       description: 'Page crashes on load',
       user_agent: expect.any(String),
       console_errors: ['error1', 'error2'],
@@ -278,5 +268,36 @@ describe('FeedbackDialog', () => {
       body: 'Edited body',
       labels: ['feature'],
     })
+  })
+
+  it('shows AI-not-configured state with manual issue link when AI is not configured', async () => {
+    mockPost.mockRejectedValue(new Error('AI is not configured'))
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/AI is not configured on this server/)).toBeInTheDocument()
+    )
+    const link = screen.getByRole('link', { name: /open a new issue/i })
+    expect(link).toHaveAttribute('href', 'https://github.com/myk-org/jenkins-job-insight/issues/new')
+    expect(link).toHaveAttribute('target', '_blank')
+    // Should show Close button in footer, not Try Again
+    const closeButtons = screen.getAllByRole('button', { name: /close/i })
+    expect(closeButtons.length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it('handles "ai not configured" error with varied casing', async () => {
+    mockPost.mockRejectedValue(new Error('AI Not Configured on this instance'))
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Feedback')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/AI is not configured on this server/)).toBeInTheDocument()
+    )
   })
 })

--- a/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
@@ -48,16 +48,16 @@ describe('FeedbackDialog', () => {
     expect(screen.getByLabelText('Description')).toBeInTheDocument()
   })
 
-  it('disables submit when description is empty', () => {
+  it('disables Preview when description is empty', () => {
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
-    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /preview/i })).toBeDisabled()
   })
 
-  it('enables submit when description is provided', async () => {
+  it('enables Preview when description is provided', async () => {
     const user = userEvent.setup()
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Something broke')
-    expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /preview/i })).toBeEnabled()
   })
 
   it('switches feedback type when toggled', async () => {
@@ -69,16 +69,22 @@ describe('FeedbackDialog', () => {
     expect(screen.getByPlaceholderText(/feature you'd like to see/i)).toBeInTheDocument()
   })
 
-  it('submits feedback and shows success', async () => {
-    mockPost.mockResolvedValue({ issue_url: 'https://github.com/org/repo/issues/42', issue_key: '#42' })
+  it('calls preview endpoint and shows editable preview', async () => {
+    mockPost.mockResolvedValue({
+      title: 'AI generated title',
+      body: 'AI generated body',
+      labels: ['bug'],
+    })
     mockGetFailedCalls.mockReturnValue([])
     const user = userEvent.setup()
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Page crashes on load')
-    await user.click(screen.getByRole('button', { name: /submit/i }))
-    await waitFor(() => expect(screen.getByText('Thank you for your feedback!')).toBeInTheDocument())
-    expect(screen.getByText('View issue')).toHaveAttribute('href', 'https://github.com/org/repo/issues/42')
-    expect(mockPost).toHaveBeenCalledWith('/api/feedback', expect.objectContaining({
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() => expect(screen.getByText('Preview Issue')).toBeInTheDocument())
+    expect(screen.getByLabelText('Title')).toHaveValue('AI generated title')
+    expect(screen.getByLabelText('Body')).toHaveValue('AI generated body')
+    expect(mockPost).toHaveBeenCalledWith('/api/feedback/preview', expect.objectContaining({
       feedback_type: 'bug',
       description: 'Page crashes on load',
       user_agent: expect.any(String),
@@ -86,41 +92,191 @@ describe('FeedbackDialog', () => {
     }))
   })
 
-  it('shows error message on submit failure', async () => {
+  it('allows editing preview title and body', async () => {
+    mockPost.mockResolvedValue({
+      title: 'Original title',
+      body: 'Original body',
+      labels: ['bug'],
+    })
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some bug')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+
+    const titleInput = screen.getByLabelText('Title')
+    await user.clear(titleInput)
+    await user.type(titleInput, 'Edited title')
+    expect(titleInput).toHaveValue('Edited title')
+
+    const bodyInput = screen.getByLabelText('Body')
+    await user.clear(bodyInput)
+    await user.type(bodyInput, 'Edited body')
+    expect(bodyInput).toHaveValue('Edited body')
+  })
+
+  it('creates issue from preview and shows success', async () => {
+    // First call: preview
+    mockPost.mockResolvedValueOnce({
+      title: 'AI title',
+      body: 'AI body',
+      labels: ['bug'],
+    })
+    // Second call: create
+    mockPost.mockResolvedValueOnce({
+      issue_url: 'https://github.com/org/repo/issues/42',
+      issue_number: 42,
+      title: 'AI title',
+    })
+
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Page crashes')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /create issue/i }))
+
+    await waitFor(() => expect(screen.getByText('Thank you for your feedback!')).toBeInTheDocument())
+    expect(screen.getByText('View issue')).toHaveAttribute('href', 'https://github.com/org/repo/issues/42')
+    expect(mockPost).toHaveBeenCalledWith('/api/feedback/create', {
+      title: 'AI title',
+      body: 'AI body',
+      labels: ['bug'],
+    })
+  })
+
+  it('Back button returns to form from preview', async () => {
+    mockPost.mockResolvedValue({
+      title: 'AI title',
+      body: 'AI body',
+      labels: ['bug'],
+    })
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /back/i }))
+
+    expect(screen.getByText('Send Feedback')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+  })
+
+  it('shows error message on preview failure', async () => {
     mockPost.mockRejectedValue(new Error('API error 500: Internal Server Error'))
     const user = userEvent.setup()
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Some feedback')
-    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await user.click(screen.getByRole('button', { name: /preview/i }))
     await waitFor(() => expect(screen.getByText(/API error 500/)).toBeInTheDocument())
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
   })
 
-  it('Try Again returns to form state', async () => {
+  it('shows error message on create failure', async () => {
+    mockPost.mockResolvedValueOnce({
+      title: 'AI title',
+      body: 'AI body',
+      labels: ['bug'],
+    })
+    mockPost.mockRejectedValueOnce(new Error('API error 500: Internal Server Error'))
+
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /create issue/i }))
+
+    await waitFor(() => expect(screen.getByText(/API error 500/)).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+  })
+
+  it('Try Again from preview error returns to form', async () => {
     mockPost.mockRejectedValue(new Error('Network error'))
     const user = userEvent.setup()
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Some feedback')
-    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await user.click(screen.getByRole('button', { name: /preview/i }))
     await waitFor(() => expect(screen.getByText(/Network error/)).toBeInTheDocument())
     await user.click(screen.getByRole('button', { name: /try again/i }))
     expect(screen.getByText('Send Feedback')).toBeInTheDocument()
     expect(screen.getByLabelText('Description')).toBeInTheDocument()
   })
 
-  it('includes failed API calls in the payload', async () => {
-    mockPost.mockResolvedValue({ issue_url: '', issue_key: '' })
+  it('Try Again from create error returns to preview', async () => {
+    mockPost.mockResolvedValueOnce({
+      title: 'AI title',
+      body: 'AI body',
+      labels: ['bug'],
+    })
+    mockPost.mockRejectedValueOnce(new Error('Create failed'))
+
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'Some feedback')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /create issue/i }))
+    await waitFor(() => expect(screen.getByText(/Create failed/)).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+    // Should return to preview phase with title/body still intact
+    expect(screen.getByText('Preview Issue')).toBeInTheDocument()
+    expect(screen.getByLabelText('Title')).toHaveValue('AI title')
+  })
+
+  it('includes failed API calls in the preview payload', async () => {
+    mockPost.mockResolvedValue({ title: 'T', body: 'B', labels: [] })
     mockGetFailedCalls.mockReturnValue([
       { status: 500, endpoint: '/api/test', error: 'server error', timestamp: 123 },
     ])
     const user = userEvent.setup()
     render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
     await user.type(screen.getByLabelText('Description'), 'Bug report')
-    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await user.click(screen.getByRole('button', { name: /preview/i }))
     await waitFor(() => expect(mockPost).toHaveBeenCalled())
     const payload = mockPost.mock.calls[0][1]
     expect(payload.failed_api_calls).toEqual([
       { status: 500, endpoint: '/api/test', error: 'server error' },
     ])
+  })
+
+  it('sends edited title and body when creating issue', async () => {
+    mockPost.mockResolvedValueOnce({
+      title: 'Original title',
+      body: 'Original body',
+      labels: ['feature'],
+    })
+    mockPost.mockResolvedValueOnce({
+      issue_url: 'https://github.com/org/repo/issues/99',
+      issue_number: 99,
+      title: 'Edited title',
+    })
+
+    const user = userEvent.setup()
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />)
+    await user.type(screen.getByLabelText('Description'), 'A feature idea')
+    await user.click(screen.getByRole('button', { name: /preview/i }))
+
+    await waitFor(() => expect(screen.getByLabelText('Title')).toBeInTheDocument())
+
+    const titleInput = screen.getByLabelText('Title')
+    await user.clear(titleInput)
+    await user.type(titleInput, 'Edited title')
+
+    const bodyInput = screen.getByLabelText('Body')
+    await user.clear(bodyInput)
+    await user.type(bodyInput, 'Edited body')
+
+    await user.click(screen.getByRole('button', { name: /create issue/i }))
+
+    await waitFor(() => expect(screen.getByText('Thank you for your feedback!')).toBeInTheDocument())
+    expect(mockPost).toHaveBeenCalledWith('/api/feedback/create', {
+      title: 'Edited title',
+      body: 'Edited body',
+      labels: ['feature'],
+    })
   })
 })

--- a/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
+++ b/frontend/src/components/shared/__tests__/FeedbackDialog.test.tsx
@@ -237,7 +237,7 @@ describe('FeedbackDialog', () => {
     mockPost.mockResolvedValueOnce({
       title: 'Original title',
       body: 'Original body',
-      labels: ['feature'],
+      labels: ['enhancement'],
     })
     mockPost.mockResolvedValueOnce({
       issue_url: 'https://github.com/org/repo/issues/99',
@@ -266,7 +266,7 @@ describe('FeedbackDialog', () => {
     expect(mockPost).toHaveBeenCalledWith('/api/feedback/create', {
       title: 'Edited title',
       body: 'Edited body',
-      labels: ['feature'],
+      labels: ['enhancement'],
     })
   })
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { api, ApiError } from '../api'
+import { api, ApiError, getRecentFailedCalls } from '../api'
 
 describe('api', () => {
   beforeEach(() => {
@@ -47,5 +47,30 @@ describe('api', () => {
     const [, options] = fetchSpy.mock.calls[0]
     expect(options?.method).toBe('POST')
     expect(options?.body).toBe(JSON.stringify({ name: 'test' }))
+  })
+
+  it('tracks failed API calls (status >= 400)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'bad request' }), {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const beforeCount = getRecentFailedCalls().length
+    await expect(api.get('/bad-endpoint')).rejects.toThrow(ApiError)
+    const after = getRecentFailedCalls()
+    expect(after.length).toBe(beforeCount + 1)
+    const last = after[after.length - 1]
+    expect(last.status).toBe(400)
+    expect(last.endpoint).toBe('/bad-endpoint')
+    expect(last.timestamp).toBeGreaterThan(0)
+  })
+
+  it('getRecentFailedCalls returns a copy', () => {
+    const a = getRecentFailedCalls()
+    const b = getRecentFailedCalls()
+    expect(a).not.toBe(b)
+    expect(a).toEqual(b)
   })
 })

--- a/frontend/src/lib/__tests__/errorCapture.test.ts
+++ b/frontend/src/lib/__tests__/errorCapture.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getRecentErrors } from '../errorCapture'
+
+describe('errorCapture', () => {
+  // The module is already imported and listeners installed as a side effect.
+  // We can trigger errors and verify they're captured.
+
+  beforeEach(() => {
+    // Flush any errors captured from other tests by reading them.
+    // The module keeps state across tests within the same import.
+    // We need a fresh start, so we'll verify behavior additively.
+  })
+
+  it('captures window.onerror events', () => {
+    const before = getRecentErrors().length
+    // Simulate a global error by calling window.onerror directly
+    if (typeof window.onerror === 'function') {
+      window.onerror('Test error message', 'test.js', 10, 5, new Error('test'))
+    }
+    const after = getRecentErrors()
+    expect(after.length).toBeGreaterThan(before)
+    expect(after[after.length - 1]).toContain('Test error message')
+  })
+
+  it('captures unhandled rejection events', () => {
+    const before = getRecentErrors().length
+    // Dispatch an unhandledrejection event
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent
+    Object.defineProperty(event, 'reason', { value: new Error('rejection reason') })
+    window.dispatchEvent(event)
+    const after = getRecentErrors()
+    expect(after.length).toBeGreaterThan(before)
+    expect(after[after.length - 1]).toContain('rejection reason')
+  })
+
+  it('returns a copy of the errors array', () => {
+    const a = getRecentErrors()
+    const b = getRecentErrors()
+    expect(a).not.toBe(b)
+    expect(a).toEqual(b)
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,31 @@
 /** Centralized fetch wrapper for the JJI API. */
 
+// -- Failed API call tracking ------------------------------------
+
+interface FailedApiCall {
+  status: number
+  endpoint: string
+  error: string
+  timestamp: number
+}
+
+const MAX_FAILED_CALLS = 10
+const recentFailedCalls: FailedApiCall[] = []
+
+function trackFailedCall(entry: FailedApiCall) {
+  if (recentFailedCalls.length >= MAX_FAILED_CALLS) {
+    recentFailedCalls.shift()
+  }
+  recentFailedCalls.push(entry)
+}
+
+/** Return a snapshot of the recent failed API calls (status >= 400). */
+export function getRecentFailedCalls(): FailedApiCall[] {
+  return [...recentFailedCalls]
+}
+
+// ----------------------------------------------------------------
+
 class ApiError extends Error {
   status: number
   statusText: string
@@ -35,6 +61,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     } catch {
       body = null
     }
+    trackFailedCall({
+      status: res.status,
+      endpoint: path,
+      error: typeof body === 'string' ? body : JSON.stringify(body ?? ''),
+      timestamp: Date.now(),
+    })
     throw new ApiError(res.status, res.statusText, body)
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -64,7 +64,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     trackFailedCall({
       status: res.status,
       endpoint: path,
-      error: typeof body === 'string' ? body : JSON.stringify(body ?? ''),
+      error: typeof body === 'string' ? body : body != null ? JSON.stringify(body) : '',
       timestamp: Date.now(),
     })
     throw new ApiError(res.status, res.statusText, body)

--- a/frontend/src/lib/errorCapture.ts
+++ b/frontend/src/lib/errorCapture.ts
@@ -1,0 +1,43 @@
+/**
+ * Captures console errors and unhandled rejections in a circular buffer.
+ * Side-effect module: initializes listeners on import.
+ */
+
+const MAX_ERRORS = 20
+const recentErrors: string[] = []
+
+function pushError(msg: string) {
+  if (recentErrors.length >= MAX_ERRORS) {
+    recentErrors.shift()
+  }
+  recentErrors.push(msg)
+}
+
+/** Return a snapshot of the recent console errors. */
+export function getRecentErrors(): string[] {
+  return [...recentErrors]
+}
+
+// --- Install global listeners (side-effect) ---
+
+const prevOnError = window.onerror
+window.onerror = (message, source, lineno, colno, error) => {
+  const parts = [String(message)]
+  if (source) parts.push(`at ${source}:${lineno ?? '?'}:${colno ?? '?'}`)
+  if (error?.stack) parts.push(error.stack)
+  pushError(parts.join(' '))
+
+  if (typeof prevOnError === 'function') {
+    return prevOnError(message, source, lineno, colno, error)
+  }
+  return false
+}
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason
+  if (reason instanceof Error) {
+    pushError(reason.stack ?? reason.message)
+  } else {
+    pushError(String(reason))
+  }
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import '@/lib/errorCapture' // Initialize global error capture (side-effect)
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -398,7 +398,20 @@ export interface FeedbackRequest {
   user_agent: string
 }
 
-export interface FeedbackResponse {
+export interface FeedbackPreviewResponse {
+  title: string
+  body: string
+  labels: string[]
+}
+
+export interface FeedbackCreateRequest {
+  title: string
+  body: string
+  labels: string[]
+}
+
+export interface FeedbackCreateResponse {
   issue_url: string
-  issue_key: string
+  issue_number: number
+  title: string
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -291,6 +291,7 @@ export interface ResultResponse {
     server_jira_project_key?: string
     reportportal?: boolean
     reportportal_project?: string
+    feedback_enabled?: boolean
   }
 }
 
@@ -384,4 +385,20 @@ export interface JobMetadata {
 
 export interface DashboardJobWithMetadata extends DashboardJob {
   metadata?: JobMetadata | null
+}
+
+// -- Feedback -----------------------------------------------------
+
+export interface FeedbackRequest {
+  feedback_type: 'bug' | 'feature'
+  description: string
+  console_errors: string[]
+  failed_api_calls: { status: number; endpoint: string; error: string }[]
+  page_state: { url: string; active_filters?: string; report_id?: string }
+  user_agent: string
+}
+
+export interface FeedbackResponse {
+  issue_url: string
+  issue_key: string
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -390,7 +390,6 @@ export interface DashboardJobWithMetadata extends DashboardJob {
 // -- Feedback -----------------------------------------------------
 
 export interface FeedbackRequest {
-  feedback_type: 'bug' | 'feature'
   description: string
   console_errors: string[]
   failed_api_calls: { status: number; endpoint: string; error: string }[]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -393,7 +393,7 @@ export interface FeedbackRequest {
   description: string
   console_errors: string[]
   failed_api_calls: { status: number; endpoint: string; error: string }[]
-  page_state: { url: string; active_filters?: string; report_id?: string }
+  page_state: { url?: string; active_filters?: string; report_id?: string }
   user_agent: string
 }
 

--- a/src/jenkins_job_insight/bug_creation.py
+++ b/src/jenkins_job_insight/bug_creation.py
@@ -23,6 +23,16 @@ from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
+# AI attribution footers appended to all generated issues.
+GITHUB_AI_FOOTER = (
+    "\n\n---\n"
+    "*Generated using AI with [JJI](https://github.com/myk-org/jenkins-job-insight)*"
+)
+JIRA_AI_FOOTER = (
+    "\n\n----\n"
+    "_Generated using AI with [JJI|https://github.com/myk-org/jenkins-job-insight]_"
+)
+
 
 def _build_failure_context(failure: FailureAnalysis) -> dict:
     """Extract structured context from a FailureAnalysis for prompt building.
@@ -348,6 +358,7 @@ Do not wrap in code blocks or JSON. Just the title on the first line, then the b
     if result.success:
         parsed = _parse_ai_issue_response(result.text)
         if parsed:
+            parsed["body"] += GITHUB_AI_FOOTER
             return parsed
         logger.debug(
             "AI returned output but JSON parsing failed for GitHub issue, output=%s",
@@ -359,7 +370,11 @@ Do not wrap in code blocks or JSON. Just the title on the first line, then the b
     logger.warning(
         "AI content generation failed for GitHub issue, using fallback template"
     )
-    return _build_fallback_github_content(ctx, jenkins_url, report_url, include_links)
+    content = _build_fallback_github_content(
+        ctx, jenkins_url, report_url, include_links
+    )
+    content["body"] += GITHUB_AI_FOOTER
+    return content
 
 
 async def generate_jira_bug_content(
@@ -477,6 +492,7 @@ Do not wrap in code blocks or JSON. Just the summary on the first line, then the
     if result.success:
         parsed = _parse_ai_issue_response(result.text)
         if parsed:
+            parsed["body"] += JIRA_AI_FOOTER
             return parsed
         logger.debug(
             "AI returned output but JSON parsing failed for Jira bug, output=%s",
@@ -486,7 +502,9 @@ Do not wrap in code blocks or JSON. Just the summary on the first line, then the
         logger.debug("AI CLI call failed for Jira bug: %s", result.text)
 
     logger.warning("AI content generation failed for Jira bug, using fallback template")
-    return _build_fallback_jira_content(ctx, jenkins_url, report_url, include_links)
+    content = _build_fallback_jira_content(ctx, jenkins_url, report_url, include_links)
+    content["body"] += JIRA_AI_FOOTER
+    return content
 
 
 def _parse_github_repo_url(repo_url: str) -> tuple[str, str]:
@@ -612,6 +630,10 @@ async def create_github_issue(
     """
     owner, repo = _parse_github_repo_url(repo_url)
 
+    # Append AI attribution footer if not already present.
+    if GITHUB_AI_FOOTER.strip() not in body:
+        body += GITHUB_AI_FOOTER
+
     headers = {
         "Accept": "application/vnd.github.v3+json",
         "Authorization": f"Bearer {github_token}",
@@ -678,6 +700,10 @@ async def create_jira_bug(
     effective_issue_type = issue_type.strip() if issue_type else "Bug"
     if not effective_issue_type:
         effective_issue_type = "Bug"
+
+    # Append AI attribution footer if not already present.
+    if JIRA_AI_FOOTER.strip() not in body:
+        body += JIRA_AI_FOOTER
 
     payload: dict = {
         "fields": {

--- a/src/jenkins_job_insight/config.py
+++ b/src/jenkins_job_insight/config.py
@@ -369,6 +369,19 @@ class Settings(BaseSettings):
         return bool(tests_repo_url and github_token)
 
     @property
+    def feedback_enabled(self) -> bool:
+        """Check if feedback submission is enabled.
+
+        Requires ENABLE_GITHUB_ISSUES to not be explicitly False and
+        GITHUB_TOKEN to be configured. Unlike github_issues_enabled,
+        does not require TESTS_REPO_URL since feedback issues go to
+        the hardcoded project repo.
+        """
+        if self.enable_github_issues is False:
+            return False
+        return bool(self.github_token and self.github_token.get_secret_value())
+
+    @property
     def web_push_enabled(self) -> bool:
         """Check if Web Push is enabled (env vars or auto-generated keys)."""
         if hasattr(self, "_vapid_config_cache"):

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -13,7 +13,7 @@ from simple_logger.logger import get_logger
 
 from ai_cli_runner import call_ai_cli
 from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
-from jenkins_job_insight.bug_creation import create_github_issue
+from jenkins_job_insight.bug_creation import GITHUB_AI_FOOTER, create_github_issue
 from jenkins_job_insight.config import Settings
 from jenkins_job_insight.models import (
     FeedbackPreviewResponse,
@@ -302,6 +302,9 @@ async def generate_feedback_preview(
     title, body, labels = await format_feedback_with_ai(
         request, settings, ai_provider=ai_provider, ai_model=ai_model
     )
+    # Append AI attribution footer so the user sees it in preview.
+    if GITHUB_AI_FOOTER.strip() not in body:
+        body += GITHUB_AI_FOOTER
     return FeedbackPreviewResponse(title=title, body=body, labels=labels)
 
 

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -15,7 +15,11 @@ from ai_cli_runner import call_ai_cli
 from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
 from jenkins_job_insight.bug_creation import create_github_issue
 from jenkins_job_insight.config import Settings
-from jenkins_job_insight.models import FeedbackRequest, FeedbackResponse
+from jenkins_job_insight.models import (
+    FeedbackPreviewResponse,
+    FeedbackRequest,
+    FeedbackResponse,
+)
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -258,22 +262,41 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
     return title, body
 
 
-async def create_feedback_issue(
+async def generate_feedback_preview(
     request: FeedbackRequest, settings: Settings
-) -> FeedbackResponse:
-    """Orchestrate feedback submission: scrub, format with AI, create GitHub issue.
+) -> FeedbackPreviewResponse:
+    """Generate an AI-formatted preview of a feedback GitHub issue.
+
+    Calls AI to generate a well-structured title and body, scrubs
+    sensitive data from attached logs, and returns the preview
+    without creating the issue.
 
     Args:
         request: User feedback submission.
+        settings: Application settings.
+
+    Returns:
+        FeedbackPreviewResponse with generated title, body, and labels.
+    """
+    title, body = await format_feedback_with_ai(request, settings)
+    labels = ["bug"] if request.feedback_type == "bug" else ["enhancement"]
+    return FeedbackPreviewResponse(title=title, body=body, labels=labels)
+
+
+async def create_feedback_from_preview(
+    title: str, body: str, labels: list[str], settings: Settings
+) -> FeedbackResponse:
+    """Create a GitHub issue from a previously previewed feedback.
+
+    Args:
+        title: Issue title (from preview).
+        body: Issue body (from preview).
+        labels: Issue labels (from preview).
         settings: Application settings (must have github_token configured).
 
     Returns:
         FeedbackResponse with the created issue details.
     """
-    title, body = await format_feedback_with_ai(request, settings)
-
-    label = "bug" if request.feedback_type == "bug" else "enhancement"
-
     github_token = (
         settings.github_token.get_secret_value() if settings.github_token else ""
     )
@@ -283,11 +306,36 @@ async def create_feedback_issue(
         body=body,
         repo_url=_FEEDBACK_REPO_URL,
         github_token=github_token,
-        labels=[label],
+        labels=labels,
     )
 
     return FeedbackResponse(
         issue_url=result["url"],
         issue_number=result["number"],
         title=result["title"],
+    )
+
+
+async def create_feedback_issue(
+    request: FeedbackRequest, settings: Settings
+) -> FeedbackResponse:
+    """Orchestrate feedback submission: scrub, format with AI, create GitHub issue.
+
+    .. deprecated::
+        Use :func:`generate_feedback_preview` + :func:`create_feedback_from_preview`
+        for the two-step preview/create flow.
+
+    Args:
+        request: User feedback submission.
+        settings: Application settings (must have github_token configured).
+
+    Returns:
+        FeedbackResponse with the created issue details.
+    """
+    preview = await generate_feedback_preview(request, settings)
+    return await create_feedback_from_preview(
+        title=preview.title,
+        body=preview.body,
+        labels=preview.labels,
+        settings=settings,
     )

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -1,0 +1,283 @@
+"""User feedback endpoint: AI-formatted GitHub issue creation.
+
+Accepts user feedback (bug report or feature request), uses AI to
+format it into a well-structured GitHub issue, scrubs sensitive data
+from attached logs, and creates the issue in myk-org/jenkins-job-insight.
+"""
+
+import json
+import os
+import re
+
+from simple_logger.logger import get_logger
+
+from ai_cli_runner import call_ai_cli
+from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
+from jenkins_job_insight.bug_creation import create_github_issue
+from jenkins_job_insight.config import Settings
+from jenkins_job_insight.models import FeedbackRequest, FeedbackResponse
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+_FEEDBACK_REPO_URL = "https://github.com/myk-org/jenkins-job-insight"
+
+# Patterns for sensitive data scrubbing.
+# Order matters: more specific patterns first to avoid partial matches.
+_SENSITIVE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # JWT tokens (three dot-separated base64 segments)
+    (
+        re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+        "[REDACTED_JWT]",
+    ),
+    # Basic auth headers (Base64-encoded credentials)
+    (re.compile(r"(Basic\s+)[A-Za-z0-9+/=]{8,}", re.IGNORECASE), r"\1[REDACTED]"),
+    # Bearer tokens
+    (re.compile(r"(Bearer\s+)\S+", re.IGNORECASE), r"\1[REDACTED]"),
+    # Authorization header values (generic)
+    (
+        re.compile(r"(Authorization[\"']?\s*[:=]\s*[\"']?)\S+", re.IGNORECASE),
+        r"\1[REDACTED]",
+    ),
+    # API keys/tokens in query params or assignments
+    (
+        re.compile(
+            r"((?:api_key|apikey|api_token|access_token|token|secret|auth_token)[\"']?\s*[:=]\s*[\"']?)\S+",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED]",
+    ),
+    # Passwords in query params or assignments
+    (
+        re.compile(
+            r"((?:password|passwd|pwd)[\"']?\s*[:=]\s*[\"']?)\S+", re.IGNORECASE
+        ),
+        r"\1[REDACTED]",
+    ),
+    # GitHub tokens (ghp_, gho_, ghs_, ghr_, github_pat_)
+    (
+        re.compile(r"\b(?:ghp_|gho_|ghs_|ghr_|github_pat_)[A-Za-z0-9_]+\b"),
+        "[REDACTED_GITHUB_TOKEN]",
+    ),
+    # Generic long hex/base64 secrets (40+ chars, likely tokens)
+    (re.compile(r"\b[A-Fa-f0-9]{40,}\b"), "[REDACTED_HEX_TOKEN]"),
+]
+
+
+def scrub_sensitive_data(text: str) -> str:
+    """Remove sensitive patterns from text.
+
+    Scrubs API tokens/keys, passwords, JWT tokens, Basic/Bearer auth
+    headers, and similar credential patterns. Preserves URLs, test
+    names, and other non-sensitive content.
+    """
+    result = text
+    for pattern, replacement in _SENSITIVE_PATTERNS:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+async def format_feedback_with_ai(
+    request: FeedbackRequest, settings: Settings
+) -> tuple[str, str]:
+    """Format user feedback into a GitHub issue title and body using AI.
+
+    Returns:
+        Tuple of (title, body) for the GitHub issue.
+    """
+    ai_provider = settings.ai_provider if hasattr(settings, "ai_provider") else ""
+    ai_model = settings.ai_model if hasattr(settings, "ai_model") else ""
+    ai_cli_timeout = settings.ai_cli_timeout
+
+    context_parts: list[str] = []
+    if request.feedback_type == "bug":
+        context_parts.append("Feedback type: Bug Report")
+        context_parts.append(f"Description: {request.description}")
+        if request.console_errors:
+            scrubbed_errors = [scrub_sensitive_data(e) for e in request.console_errors]
+            context_parts.append(
+                "Console errors:\n" + "\n".join(f"- {e}" for e in scrubbed_errors)
+            )
+        if request.failed_api_calls:
+            scrubbed_calls = []
+            for call in request.failed_api_calls:
+                scrubbed = {k: scrub_sensitive_data(str(v)) for k, v in call.items()}
+                scrubbed_calls.append(scrubbed)
+            context_parts.append(
+                f"Failed API calls:\n{json.dumps(scrubbed_calls, indent=2)}"
+            )
+        if request.page_state:
+            context_parts.append(
+                f"Page state:\n{json.dumps(request.page_state, indent=2)}"
+            )
+        if request.user_agent:
+            context_parts.append(f"User agent: {request.user_agent}")
+    else:
+        context_parts.append("Feedback type: Feature Request")
+        context_parts.append(f"Description: {request.description}")
+
+    context = "\n\n".join(context_parts)
+
+    if request.feedback_type == "bug":
+        prompt = f"""You are formatting a user-submitted bug report into a well-structured GitHub issue
+for the jenkins-job-insight project (https://github.com/myk-org/jenkins-job-insight).
+
+User's feedback:
+{context}
+
+Create a GitHub issue with:
+1. A concise, descriptive title (max 120 chars)
+2. A well-formatted markdown body with appropriate sections
+
+Respond ONLY with valid JSON (no markdown fences) in this exact format:
+{{"title": "...", "body": "..."}}
+
+The body should include:
+- **Description**: Clear summary of the bug
+- **Steps to Reproduce**: Inferred from the context
+- **Console Errors**: If any were provided (already scrubbed of sensitive data)
+- **Failed API Calls**: If any were provided
+- **Environment**: Browser/user agent info if available
+- **Page State**: Current page context if available
+
+Do NOT include any sensitive data (tokens, passwords, etc.) in the output."""
+    else:
+        prompt = f"""You are formatting a user-submitted feature request into a well-structured GitHub issue
+for the jenkins-job-insight project (https://github.com/myk-org/jenkins-job-insight).
+
+User's feedback:
+{context}
+
+Create a GitHub issue with:
+1. A concise, descriptive title (max 120 chars)
+2. A well-formatted markdown body
+
+Respond ONLY with valid JSON (no markdown fences) in this exact format:
+{{"title": "...", "body": "..."}}
+
+The body should include:
+- **Description**: Clear summary of the feature request
+- **Use Case**: Why this feature would be useful
+- **Proposed Solution**: If the user suggested one
+
+Do NOT include any sensitive data in the output."""
+
+    result = await call_ai_cli(
+        prompt,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        ai_cli_timeout=ai_cli_timeout,
+        cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
+    )
+
+    if result.success:
+        parsed = _parse_json_response(result.text)
+        if parsed:
+            return parsed["title"], parsed["body"]
+        logger.debug(
+            "AI response JSON parsing failed, using fallback. Output: %s", result.text
+        )
+    else:
+        logger.debug("AI CLI call failed for feedback formatting: %s", result.text)
+
+    logger.warning("AI formatting failed for feedback, using fallback template")
+    return _build_fallback_feedback(request)
+
+
+def _parse_json_response(text: str) -> dict | None:
+    """Parse JSON from AI response, handling markdown code fences."""
+    text = text.strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        lines = text.split("\n", 1)
+        if len(lines) > 1:
+            text = lines[1]
+        end = text.rfind("```")
+        if end > 0:
+            text = text[:end]
+        text = text.strip()
+
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict) and "title" in data and "body" in data:
+            return data
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return None
+
+
+def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
+    """Build fallback title and body when AI formatting fails."""
+    if request.feedback_type == "bug":
+        title = f"Bug report: {request.description[:100]}"
+        parts = [
+            "## Bug Report",
+            "",
+            f"**Description:** {request.description}",
+        ]
+        if request.console_errors:
+            parts.extend(["", "## Console Errors", "```"])
+            parts.extend(scrub_sensitive_data(e) for e in request.console_errors)
+            parts.append("```")
+        if request.failed_api_calls:
+            scrubbed_calls = [
+                {k: scrub_sensitive_data(str(v)) for k, v in call.items()}
+                for call in request.failed_api_calls
+            ]
+            parts.extend(
+                [
+                    "",
+                    "## Failed API Calls",
+                    f"```json\n{json.dumps(scrubbed_calls, indent=2)}\n```",
+                ]
+            )
+        if request.page_state:
+            parts.extend(
+                [
+                    "",
+                    "## Page State",
+                    f"```json\n{json.dumps(request.page_state, indent=2)}\n```",
+                ]
+            )
+        if request.user_agent:
+            parts.extend(["", f"**User Agent:** {request.user_agent}"])
+        body = "\n".join(parts)
+    else:
+        title = f"Feature request: {request.description[:100]}"
+        body = f"## Feature Request\n\n**Description:** {request.description}"
+    return title, body
+
+
+async def create_feedback_issue(
+    request: FeedbackRequest, settings: Settings
+) -> FeedbackResponse:
+    """Orchestrate feedback submission: scrub, format with AI, create GitHub issue.
+
+    Args:
+        request: User feedback submission.
+        settings: Application settings (must have github_token configured).
+
+    Returns:
+        FeedbackResponse with the created issue details.
+    """
+    title, body = await format_feedback_with_ai(request, settings)
+
+    label = "bug" if request.feedback_type == "bug" else "enhancement"
+
+    github_token = (
+        settings.github_token.get_secret_value() if settings.github_token else ""
+    )
+
+    result = await create_github_issue(
+        title=title,
+        body=body,
+        repo_url=_FEEDBACK_REPO_URL,
+        github_token=github_token,
+        labels=[label],
+    )
+
+    return FeedbackResponse(
+        issue_url=result["url"],
+        issue_number=result["number"],
+        title=result["title"],
+    )

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -129,7 +129,9 @@ async def format_feedback_with_ai(
             }
             context_parts.append(f"Page state:\n{json.dumps(scrubbed_state, indent=2)}")
         if request.user_agent:
-            context_parts.append(f"User agent: {request.user_agent}")
+            context_parts.append(
+                f"User agent: {scrub_sensitive_data(request.user_agent)}"
+            )
     else:
         context_parts.append("Feedback type: Feature Request")
         context_parts.append(
@@ -182,14 +184,18 @@ The body should include:
 
 Do NOT include any sensitive data in the output."""
 
-    result = await call_ai_cli(
-        prompt,
-        ai_provider=ai_provider,
-        ai_model=ai_model,
-        ai_cli_timeout=ai_cli_timeout,
-        cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
-        output_format="json",
-    )
+    try:
+        result = await call_ai_cli(
+            prompt,
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+            ai_cli_timeout=ai_cli_timeout,
+            cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+            output_format="json",
+        )
+    except Exception as exc:  # noqa: BLE001 - feedback formatting should fall back
+        logger.warning("AI CLI call failed for feedback formatting: %s", exc)
+        return _build_fallback_feedback(request)
 
     if result.success:
         parsed = _parse_json_response(result.text)
@@ -278,7 +284,9 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
                 ]
             )
         if request.user_agent:
-            parts.extend(["", f"**User Agent:** {request.user_agent}"])
+            parts.extend(
+                ["", f"**User Agent:** {scrub_sensitive_data(request.user_agent)}"]
+            )
         body = "\n".join(parts)
     else:
         scrubbed_desc = scrub_sensitive_data(request.description)

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -81,68 +81,64 @@ def scrub_sensitive_data(text: str) -> str:
 
 
 async def format_feedback_with_ai(
-    request: FeedbackRequest, settings: Settings
-) -> tuple[str, str]:
-    """Format user feedback into a GitHub issue title and body using AI.
+    request: FeedbackRequest,
+    settings: Settings,
+    ai_provider: str = "",
+    ai_model: str = "",
+) -> tuple[str, str, list[str]]:
+    """Format user feedback into a GitHub issue title, body, and labels using AI.
+
+    Args:
+        request: User feedback submission.
+        settings: Application settings.
+        ai_provider: Resolved AI provider identifier.
+        ai_model: Resolved AI model identifier.
 
     Returns:
-        Tuple of (title, body) for the GitHub issue.
+        Tuple of (title, body, labels) for the GitHub issue.
     """
-    ai_provider = os.getenv("AI_PROVIDER", "").lower()
-    ai_model = os.getenv("AI_MODEL", "")
     ai_cli_timeout = settings.ai_cli_timeout
 
     context_parts: list[str] = []
-    if request.feedback_type == "bug":
-        context_parts.append("Feedback type: Bug Report")
+    context_parts.append(f"Description: {scrub_sensitive_data(request.description)}")
+    if request.console_errors:
+        scrubbed_errors = [scrub_sensitive_data(e) for e in request.console_errors]
         context_parts.append(
-            f"Description: {scrub_sensitive_data(request.description)}"
+            "Console errors:\n" + "\n".join(f"- {e}" for e in scrubbed_errors)
         )
-        if request.console_errors:
-            scrubbed_errors = [scrub_sensitive_data(e) for e in request.console_errors]
-            context_parts.append(
-                "Console errors:\n" + "\n".join(f"- {e}" for e in scrubbed_errors)
-            )
-        if request.failed_api_calls:
-            scrubbed_calls = [
-                {
-                    "status": call.status,
-                    "endpoint": scrub_sensitive_data(call.endpoint),
-                    "error": scrub_sensitive_data(call.error),
-                }
-                for call in request.failed_api_calls
-            ]
-            context_parts.append(
-                f"Failed API calls:\n{json.dumps(scrubbed_calls, indent=2)}"
-            )
-        if (
-            request.page_state.url
-            or request.page_state.active_filters
-            or request.page_state.report_id
-        ):
-            scrubbed_state = {
-                "url": scrub_sensitive_data(request.page_state.url),
-                "active_filters": scrub_sensitive_data(
-                    request.page_state.active_filters
-                ),
-                "report_id": scrub_sensitive_data(request.page_state.report_id),
+    if request.failed_api_calls:
+        scrubbed_calls = [
+            {
+                "status": call.status,
+                "endpoint": scrub_sensitive_data(call.endpoint),
+                "error": scrub_sensitive_data(call.error),
             }
-            context_parts.append(f"Page state:\n{json.dumps(scrubbed_state, indent=2)}")
-        if request.user_agent:
-            context_parts.append(
-                f"User agent: {scrub_sensitive_data(request.user_agent)}"
-            )
-    else:
-        context_parts.append("Feedback type: Feature Request")
+            for call in request.failed_api_calls
+        ]
         context_parts.append(
-            f"Description: {scrub_sensitive_data(request.description)}"
+            f"Failed API calls:\n{json.dumps(scrubbed_calls, indent=2)}"
         )
+    if (
+        request.page_state.url
+        or request.page_state.active_filters
+        or request.page_state.report_id
+    ):
+        scrubbed_state = {
+            "url": scrub_sensitive_data(request.page_state.url),
+            "active_filters": scrub_sensitive_data(request.page_state.active_filters),
+            "report_id": scrub_sensitive_data(request.page_state.report_id),
+        }
+        context_parts.append(f"Page state:\n{json.dumps(scrubbed_state, indent=2)}")
+    if request.user_agent:
+        context_parts.append(f"User agent: {scrub_sensitive_data(request.user_agent)}")
 
     context = "\n\n".join(context_parts)
 
-    if request.feedback_type == "bug":
-        prompt = f"""You are formatting a user-submitted bug report into a well-structured GitHub issue
+    prompt = f"""You are formatting user-submitted feedback into a well-structured GitHub issue
 for the jenkins-job-insight project (https://github.com/myk-org/jenkins-job-insight).
+
+First, determine whether this feedback is a BUG REPORT or a FEATURE REQUEST based on the content.
+Set the "labels" field accordingly: ["bug"] for bug reports, ["enhancement"] for feature requests.
 
 User's feedback:
 {context}
@@ -150,11 +146,12 @@ User's feedback:
 Create a GitHub issue with:
 1. A concise, descriptive title (max 120 chars)
 2. A well-formatted markdown body with appropriate sections
+3. Labels: ["bug"] or ["enhancement"] based on content analysis
 
 Respond ONLY with valid JSON (no markdown fences) in this exact format:
-{{"title": "...", "body": "..."}}
+{{"title": "...", "body": "...", "labels": ["bug"] or ["enhancement"]}}
 
-The body should include:
+For bug reports, the body should include:
 - **Description**: Clear summary of the bug
 - **Steps to Reproduce**: Inferred from the context
 - **Console Errors**: If any were provided (already scrubbed of sensitive data)
@@ -162,27 +159,12 @@ The body should include:
 - **Environment**: Browser/user agent info if available
 - **Page State**: Current page context if available
 
-Do NOT include any sensitive data (tokens, passwords, etc.) in the output."""
-    else:
-        prompt = f"""You are formatting a user-submitted feature request into a well-structured GitHub issue
-for the jenkins-job-insight project (https://github.com/myk-org/jenkins-job-insight).
-
-User's feedback:
-{context}
-
-Create a GitHub issue with:
-1. A concise, descriptive title (max 120 chars)
-2. A well-formatted markdown body
-
-Respond ONLY with valid JSON (no markdown fences) in this exact format:
-{{"title": "...", "body": "..."}}
-
-The body should include:
+For feature requests, the body should include:
 - **Description**: Clear summary of the feature request
 - **Use Case**: Why this feature would be useful
 - **Proposed Solution**: If the user suggested one
 
-Do NOT include any sensitive data in the output."""
+Do NOT include any sensitive data (tokens, passwords, etc.) in the output."""
 
     try:
         result = await call_ai_cli(
@@ -195,12 +177,19 @@ Do NOT include any sensitive data in the output."""
         )
     except Exception as exc:  # noqa: BLE001 - feedback formatting should fall back
         logger.warning("AI CLI call failed for feedback formatting: %s", exc)
-        return _build_fallback_feedback(request)
+        title, body = _build_fallback_feedback(request)
+        return title, body, ["enhancement"]
 
     if result.success:
         parsed = _parse_json_response(result.text)
         if parsed:
-            return parsed["title"], parsed["body"]
+            labels = parsed.get("labels", ["enhancement"])
+            if not isinstance(labels, list):
+                labels = ["enhancement"]
+            labels = [lbl for lbl in labels if lbl in _ALLOWED_LABELS]
+            if not labels:
+                labels = ["enhancement"]
+            return parsed["title"], parsed["body"], labels
         logger.debug(
             "AI response JSON parsing failed, using fallback. Output: %s", result.text
         )
@@ -208,7 +197,8 @@ Do NOT include any sensitive data in the output."""
         logger.debug("AI CLI call failed for feedback formatting: %s", result.text)
 
     logger.warning("AI formatting failed for feedback, using fallback template")
-    return _build_fallback_feedback(request)
+    title, body = _build_fallback_feedback(request)
+    return title, body, ["enhancement"]
 
 
 def _parse_json_response(text: str) -> dict | None:
@@ -236,67 +226,63 @@ def _parse_json_response(text: str) -> dict | None:
 def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
     """Build fallback title and body when AI formatting fails."""
     _FALLBACK_TITLE_MAX = 500  # matches FeedbackCreateRequest.title max_length
-    if request.feedback_type == "bug":
-        scrubbed_desc = scrub_sensitive_data(request.description)
-        title = f"Bug report: {scrubbed_desc}"[:_FALLBACK_TITLE_MAX]
-        parts = [
-            "## Bug Report",
-            "",
-            f"**Description:** {scrubbed_desc}",
-        ]
-        if request.console_errors:
-            parts.extend(["", "## Console Errors", "```"])
-            parts.extend(scrub_sensitive_data(e) for e in request.console_errors)
-            parts.append("```")
-        if request.failed_api_calls:
-            scrubbed_calls = [
-                {
-                    "status": call.status,
-                    "endpoint": scrub_sensitive_data(call.endpoint),
-                    "error": scrub_sensitive_data(call.error),
-                }
-                for call in request.failed_api_calls
-            ]
-            parts.extend(
-                [
-                    "",
-                    "## Failed API Calls",
-                    f"```json\n{json.dumps(scrubbed_calls, indent=2)}\n```",
-                ]
-            )
-        if (
-            request.page_state.url
-            or request.page_state.active_filters
-            or request.page_state.report_id
-        ):
-            scrubbed_state = {
-                "url": scrub_sensitive_data(request.page_state.url),
-                "active_filters": scrub_sensitive_data(
-                    request.page_state.active_filters
-                ),
-                "report_id": scrub_sensitive_data(request.page_state.report_id),
+    scrubbed_desc = scrub_sensitive_data(request.description)
+    title = f"Feedback: {scrubbed_desc}"[:_FALLBACK_TITLE_MAX]
+    parts = [
+        "## Feedback",
+        "",
+        f"**Description:** {scrubbed_desc}",
+    ]
+    if request.console_errors:
+        parts.extend(["", "## Console Errors", "```"])
+        parts.extend(scrub_sensitive_data(e) for e in request.console_errors)
+        parts.append("```")
+    if request.failed_api_calls:
+        scrubbed_calls = [
+            {
+                "status": call.status,
+                "endpoint": scrub_sensitive_data(call.endpoint),
+                "error": scrub_sensitive_data(call.error),
             }
-            parts.extend(
-                [
-                    "",
-                    "## Page State",
-                    f"```json\n{json.dumps(scrubbed_state, indent=2)}\n```",
-                ]
-            )
-        if request.user_agent:
-            parts.extend(
-                ["", f"**User Agent:** {scrub_sensitive_data(request.user_agent)}"]
-            )
-        body = "\n".join(parts)
-    else:
-        scrubbed_desc = scrub_sensitive_data(request.description)
-        title = f"Feature request: {scrubbed_desc}"[:_FALLBACK_TITLE_MAX]
-        body = f"## Feature Request\n\n**Description:** {scrubbed_desc}"
+            for call in request.failed_api_calls
+        ]
+        parts.extend(
+            [
+                "",
+                "## Failed API Calls",
+                f"```json\n{json.dumps(scrubbed_calls, indent=2)}\n```",
+            ]
+        )
+    if (
+        request.page_state.url
+        or request.page_state.active_filters
+        or request.page_state.report_id
+    ):
+        scrubbed_state = {
+            "url": scrub_sensitive_data(request.page_state.url),
+            "active_filters": scrub_sensitive_data(request.page_state.active_filters),
+            "report_id": scrub_sensitive_data(request.page_state.report_id),
+        }
+        parts.extend(
+            [
+                "",
+                "## Page State",
+                f"```json\n{json.dumps(scrubbed_state, indent=2)}\n```",
+            ]
+        )
+    if request.user_agent:
+        parts.extend(
+            ["", f"**User Agent:** {scrub_sensitive_data(request.user_agent)}"]
+        )
+    body = "\n".join(parts)
     return title, body
 
 
 async def generate_feedback_preview(
-    request: FeedbackRequest, settings: Settings
+    request: FeedbackRequest,
+    settings: Settings,
+    ai_provider: str = "",
+    ai_model: str = "",
 ) -> FeedbackPreviewResponse:
     """Generate an AI-formatted preview of a feedback GitHub issue.
 
@@ -307,12 +293,15 @@ async def generate_feedback_preview(
     Args:
         request: User feedback submission.
         settings: Application settings.
+        ai_provider: Resolved AI provider identifier.
+        ai_model: Resolved AI model identifier.
 
     Returns:
         FeedbackPreviewResponse with generated title, body, and labels.
     """
-    title, body = await format_feedback_with_ai(request, settings)
-    labels = ["bug"] if request.feedback_type == "bug" else ["enhancement"]
+    title, body, labels = await format_feedback_with_ai(
+        request, settings, ai_provider=ai_provider, ai_model=ai_model
+    )
     return FeedbackPreviewResponse(title=title, body=body, labels=labels)
 
 

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -84,14 +84,16 @@ async def format_feedback_with_ai(
     Returns:
         Tuple of (title, body) for the GitHub issue.
     """
-    ai_provider = settings.ai_provider if hasattr(settings, "ai_provider") else ""
-    ai_model = settings.ai_model if hasattr(settings, "ai_model") else ""
+    ai_provider = os.getenv("AI_PROVIDER", "").lower()
+    ai_model = os.getenv("AI_MODEL", "")
     ai_cli_timeout = settings.ai_cli_timeout
 
     context_parts: list[str] = []
     if request.feedback_type == "bug":
         context_parts.append("Feedback type: Bug Report")
-        context_parts.append(f"Description: {request.description}")
+        context_parts.append(
+            f"Description: {scrub_sensitive_data(request.description)}"
+        )
         if request.console_errors:
             scrubbed_errors = [scrub_sensitive_data(e) for e in request.console_errors]
             context_parts.append(
@@ -106,14 +108,17 @@ async def format_feedback_with_ai(
                 f"Failed API calls:\n{json.dumps(scrubbed_calls, indent=2)}"
             )
         if request.page_state:
-            context_parts.append(
-                f"Page state:\n{json.dumps(request.page_state, indent=2)}"
-            )
+            scrubbed_state = {
+                k: scrub_sensitive_data(str(v)) for k, v in request.page_state.items()
+            }
+            context_parts.append(f"Page state:\n{json.dumps(scrubbed_state, indent=2)}")
         if request.user_agent:
             context_parts.append(f"User agent: {request.user_agent}")
     else:
         context_parts.append("Feedback type: Feature Request")
-        context_parts.append(f"Description: {request.description}")
+        context_parts.append(
+            f"Description: {scrub_sensitive_data(request.description)}"
+        )
 
     context = "\n\n".join(context_parts)
 
@@ -209,11 +214,12 @@ def _parse_json_response(text: str) -> dict | None:
 def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
     """Build fallback title and body when AI formatting fails."""
     if request.feedback_type == "bug":
-        title = f"Bug report: {request.description[:100]}"
+        scrubbed_desc = scrub_sensitive_data(request.description)
+        title = f"Bug report: {scrubbed_desc}"
         parts = [
             "## Bug Report",
             "",
-            f"**Description:** {request.description}",
+            f"**Description:** {scrubbed_desc}",
         ]
         if request.console_errors:
             parts.extend(["", "## Console Errors", "```"])
@@ -232,19 +238,23 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
                 ]
             )
         if request.page_state:
+            scrubbed_state = {
+                k: scrub_sensitive_data(str(v)) for k, v in request.page_state.items()
+            }
             parts.extend(
                 [
                     "",
                     "## Page State",
-                    f"```json\n{json.dumps(request.page_state, indent=2)}\n```",
+                    f"```json\n{json.dumps(scrubbed_state, indent=2)}\n```",
                 ]
             )
         if request.user_agent:
             parts.extend(["", f"**User Agent:** {request.user_agent}"])
         body = "\n".join(parts)
     else:
-        title = f"Feature request: {request.description[:100]}"
-        body = f"## Feature Request\n\n**Description:** {request.description}"
+        scrubbed_desc = scrub_sensitive_data(request.description)
+        title = f"Feature request: {scrubbed_desc}"
+        body = f"## Feature Request\n\n**Description:** {scrubbed_desc}"
     return title, body
 
 

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -283,6 +283,9 @@ async def generate_feedback_preview(
     return FeedbackPreviewResponse(title=title, body=body, labels=labels)
 
 
+_ALLOWED_LABELS: set[str] = {"bug", "enhancement"}
+
+
 async def create_feedback_from_preview(
     title: str, body: str, labels: list[str], settings: Settings
 ) -> FeedbackResponse:
@@ -297,6 +300,10 @@ async def create_feedback_from_preview(
     Returns:
         FeedbackResponse with the created issue details.
     """
+    title = scrub_sensitive_data(title)
+    body = scrub_sensitive_data(body)
+    labels = [lbl for lbl in labels if lbl in _ALLOWED_LABELS]
+
     github_token = (
         settings.github_token.get_secret_value() if settings.github_token else ""
     )

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -104,16 +104,28 @@ async def format_feedback_with_ai(
                 "Console errors:\n" + "\n".join(f"- {e}" for e in scrubbed_errors)
             )
         if request.failed_api_calls:
-            scrubbed_calls = []
-            for call in request.failed_api_calls:
-                scrubbed = {k: scrub_sensitive_data(str(v)) for k, v in call.items()}
-                scrubbed_calls.append(scrubbed)
+            scrubbed_calls = [
+                {
+                    "status": call.status,
+                    "endpoint": scrub_sensitive_data(call.endpoint),
+                    "error": scrub_sensitive_data(call.error),
+                }
+                for call in request.failed_api_calls
+            ]
             context_parts.append(
                 f"Failed API calls:\n{json.dumps(scrubbed_calls, indent=2)}"
             )
-        if request.page_state:
+        if (
+            request.page_state.url
+            or request.page_state.active_filters
+            or request.page_state.report_id
+        ):
             scrubbed_state = {
-                k: scrub_sensitive_data(str(v)) for k, v in request.page_state.items()
+                "url": scrub_sensitive_data(request.page_state.url),
+                "active_filters": scrub_sensitive_data(
+                    request.page_state.active_filters
+                ),
+                "report_id": scrub_sensitive_data(request.page_state.report_id),
             }
             context_parts.append(f"Page state:\n{json.dumps(scrubbed_state, indent=2)}")
         if request.user_agent:
@@ -217,9 +229,10 @@ def _parse_json_response(text: str) -> dict | None:
 
 def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
     """Build fallback title and body when AI formatting fails."""
+    _FALLBACK_TITLE_MAX = 500  # matches FeedbackCreateRequest.title max_length
     if request.feedback_type == "bug":
         scrubbed_desc = scrub_sensitive_data(request.description)
-        title = f"Bug report: {scrubbed_desc}"
+        title = f"Bug report: {scrubbed_desc}"[:_FALLBACK_TITLE_MAX]
         parts = [
             "## Bug Report",
             "",
@@ -231,7 +244,11 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
             parts.append("```")
         if request.failed_api_calls:
             scrubbed_calls = [
-                {k: scrub_sensitive_data(str(v)) for k, v in call.items()}
+                {
+                    "status": call.status,
+                    "endpoint": scrub_sensitive_data(call.endpoint),
+                    "error": scrub_sensitive_data(call.error),
+                }
                 for call in request.failed_api_calls
             ]
             parts.extend(
@@ -241,9 +258,17 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
                     f"```json\n{json.dumps(scrubbed_calls, indent=2)}\n```",
                 ]
             )
-        if request.page_state:
+        if (
+            request.page_state.url
+            or request.page_state.active_filters
+            or request.page_state.report_id
+        ):
             scrubbed_state = {
-                k: scrub_sensitive_data(str(v)) for k, v in request.page_state.items()
+                "url": scrub_sensitive_data(request.page_state.url),
+                "active_filters": scrub_sensitive_data(
+                    request.page_state.active_filters
+                ),
+                "report_id": scrub_sensitive_data(request.page_state.report_id),
             }
             parts.extend(
                 [
@@ -257,7 +282,7 @@ def _build_fallback_feedback(request: FeedbackRequest) -> tuple[str, str]:
         body = "\n".join(parts)
     else:
         scrubbed_desc = scrub_sensitive_data(request.description)
-        title = f"Feature request: {scrubbed_desc}"
+        title = f"Feature request: {scrubbed_desc}"[:_FALLBACK_TITLE_MAX]
         body = f"## Feature Request\n\n**Description:** {scrubbed_desc}"
     return title, body
 

--- a/src/jenkins_job_insight/feedback.py
+++ b/src/jenkins_job_insight/feedback.py
@@ -178,7 +178,7 @@ Do NOT include any sensitive data (tokens, passwords, etc.) in the output."""
     except Exception as exc:  # noqa: BLE001 - feedback formatting should fall back
         logger.warning("AI CLI call failed for feedback formatting: %s", exc)
         title, body = _build_fallback_feedback(request)
-        return title, body, ["enhancement"]
+        return title, body, _derive_fallback_labels(request)
 
     if result.success:
         parsed = _parse_json_response(result.text)
@@ -198,7 +198,7 @@ Do NOT include any sensitive data (tokens, passwords, etc.) in the output."""
 
     logger.warning("AI formatting failed for feedback, using fallback template")
     title, body = _build_fallback_feedback(request)
-    return title, body, ["enhancement"]
+    return title, body, _derive_fallback_labels(request)
 
 
 def _parse_json_response(text: str) -> dict | None:
@@ -217,6 +217,10 @@ def _parse_json_response(text: str) -> dict | None:
     try:
         data = json.loads(text)
         if isinstance(data, dict) and "title" in data and "body" in data:
+            if not isinstance(data["title"], str) or not data["title"].strip():
+                return None
+            if not isinstance(data["body"], str) or not data["body"].strip():
+                return None
             return data
     except (json.JSONDecodeError, ValueError):
         pass
@@ -309,6 +313,17 @@ async def generate_feedback_preview(
 
 
 _ALLOWED_LABELS: set[str] = {"bug", "enhancement"}
+
+
+def _derive_fallback_labels(request: FeedbackRequest) -> list[str]:
+    """Derive issue labels from request signals when AI is unavailable.
+
+    Returns ["bug"] when error signals (console_errors or failed_api_calls)
+    are present, otherwise ["enhancement"].
+    """
+    if request.console_errors or request.failed_api_calls:
+        return ["bug"]
+    return ["enhancement"]
 
 
 async def create_feedback_from_preview(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2661,9 +2661,7 @@ def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
         "server_jira_project_key": settings.jira_project_key or "",
         "reportportal": settings.reportportal_enabled,
         "reportportal_project": settings.reportportal_project or "",
-        "feedback_enabled": bool(
-            settings.github_token and settings.github_token.get_secret_value()
-        ),
+        "feedback_enabled": settings.feedback_enabled,
     }
 
 
@@ -4796,11 +4794,32 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
     """
     _check_allow_list(request)
     settings = get_settings()
-    if not settings.github_token or not settings.github_token.get_secret_value():
+    if not settings.feedback_enabled:
         raise HTTPException(
-            status_code=503, detail="GitHub token not configured on server"
+            status_code=503, detail="Feedback submission is disabled on this server"
         )
-    return await create_feedback_issue(body, settings)
+    try:
+        return await create_feedback_issue(body, settings)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise HTTPException(
+                status_code=502,
+                detail="GitHub token is invalid or expired",
+            ) from exc
+        raise HTTPException(
+            status_code=502,
+            detail=f"GitHub API error: {exc.response.status_code}",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"GitHub API unreachable: {exc}",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to submit feedback: {exc}",
+        ) from exc
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4817,7 +4817,7 @@ async def preview_feedback(request: Request, body: FeedbackRequest):
         )
     try:
         ai_provider, ai_model = _resolve_ai_config_values(None, None)
-    except HTTPException:
+    except HTTPException as exc:
         raise HTTPException(
             status_code=503,
             detail=(
@@ -4825,7 +4825,7 @@ async def preview_feedback(request: Request, body: FeedbackRequest):
                 "Configure AI_PROVIDER and AI_MODEL environment variables "
                 "to enable AI-powered feedback."
             ),
-        )
+        ) from exc
     try:
         return await generate_feedback_preview(
             body, settings, ai_provider=ai_provider, ai_model=ai_model

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4783,13 +4783,14 @@ Respond with ONLY a JSON object:
 
 
 @app.post("/api/feedback", status_code=201, response_model=FeedbackResponse)
-async def submit_feedback(body: FeedbackRequest):
+async def submit_feedback(request: Request, body: FeedbackRequest):
     """Submit user feedback as a GitHub issue.
 
     Accepts bug reports or feature requests, uses AI to format them
     into well-structured GitHub issues, scrubs sensitive data from
     attached logs, and creates the issue in myk-org/jenkins-job-insight.
     """
+    _check_allow_list(request)
     settings = get_settings()
     if not settings.github_token or not settings.github_token.get_secret_value():
         raise HTTPException(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4821,7 +4821,7 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
             status_code=502,
             detail=f"GitHub API unreachable: {exc}",
         ) from exc
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 — non-fatal feedback submission
         logger.exception("Failed to submit feedback")
         raise HTTPException(
             status_code=500,

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -841,13 +841,14 @@ app.add_middleware(AuthMiddleware)
 app.add_middleware(ErrorTrackingMiddleware)
 
 
+_BODY_LOGGING_SKIP_PATHS = frozenset({"/api/feedback"})
+
+
 class RequestBodyLoggingMiddleware(BaseHTTPMiddleware):
     """Log incoming request bodies at DEBUG level with sensitive data masked."""
 
-    _SKIP_PATHS = frozenset({"/api/feedback"})
-
     async def dispatch(self, request: Request, call_next):
-        if request.url.path in self._SKIP_PATHS:
+        if request.url.path in _BODY_LOGGING_SKIP_PATHS:
             return await call_next(request)
         if logger.isEnabledFor(logging.DEBUG) and request.method in (
             "POST",
@@ -898,6 +899,11 @@ async def _validation_error_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     """Log 422 validation error details at DEBUG level, then return standard response."""
+    if request.url.path in _BODY_LOGGING_SKIP_PATHS:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": jsonable_encoder(exc.errors())},
+        )
     if logger.isEnabledFor(logging.DEBUG):
         masked_body = None
         if exc.body is not None:
@@ -4816,9 +4822,10 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
             detail=f"GitHub API unreachable: {exc}",
         ) from exc
     except Exception as exc:
+        logger.exception("Failed to submit feedback")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to submit feedback: {exc}",
+            detail="Failed to submit feedback",
         ) from exc
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -4814,7 +4814,20 @@ async def preview_feedback(request: Request, body: FeedbackRequest):
             status_code=503, detail="Feedback submission is disabled on this server"
         )
     try:
-        return await generate_feedback_preview(body, settings)
+        ai_provider, ai_model = _resolve_ai_config_values(None, None)
+    except HTTPException:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "AI provider not configured on this server. "
+                "Configure AI_PROVIDER and AI_MODEL environment variables "
+                "to enable AI-powered feedback."
+            ),
+        )
+    try:
+        return await generate_feedback_preview(
+            body, settings, ai_provider=ai_provider, ai_model=ai_model
+        )
     except Exception as exc:  # noqa: BLE001 — non-fatal feedback preview
         logger.exception("Failed to generate feedback preview")
         raise HTTPException(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -65,6 +65,7 @@ from jenkins_job_insight.bug_creation import (
     search_github_duplicates,
     search_jira_duplicates,
 )
+from jenkins_job_insight.feedback import create_feedback_issue
 from jenkins_job_insight.comment_enrichment import detect_mentions
 from jenkins_job_insight.notifications import send_mention_notifications
 from jenkins_job_insight.vapid import get_vapid_config
@@ -82,6 +83,8 @@ from jenkins_job_insight.models import (
     CreateIssueRequest,
     FailureAnalysis,
     FailureAnalysisResult,
+    FeedbackRequest,
+    FeedbackResponse,
     JobMetadataInput,
     OverrideClassificationRequest,
     PreviewIssueRequest,
@@ -2654,6 +2657,9 @@ def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
         "server_jira_project_key": settings.jira_project_key or "",
         "reportportal": settings.reportportal_enabled,
         "reportportal_project": settings.reportportal_project or "",
+        "feedback_enabled": bool(
+            settings.github_token and settings.github_token.get_secret_value()
+        ),
     }
 
 
@@ -4774,6 +4780,22 @@ Respond with ONLY a JSON object:
     except (json.JSONDecodeError, AttributeError):
         logger.debug("Failed to parse AI response for comment intent: %s", result.text)
         return AnalyzeCommentResponse(suggests_reviewed=False)
+
+
+@app.post("/api/feedback", status_code=201, response_model=FeedbackResponse)
+async def submit_feedback(body: FeedbackRequest):
+    """Submit user feedback as a GitHub issue.
+
+    Accepts bug reports or feature requests, uses AI to format them
+    into well-structured GitHub issues, scrubs sensitive data from
+    attached logs, and creates the issue in myk-org/jenkins-job-insight.
+    """
+    settings = get_settings()
+    if not settings.github_token or not settings.github_token.get_secret_value():
+        raise HTTPException(
+            status_code=503, detail="GitHub token not configured on server"
+        )
+    return await create_feedback_issue(body, settings)
 
 
 # SPA catch-all routes — must be AFTER all API routes

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2672,7 +2672,9 @@ def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
         "server_jira_project_key": settings.jira_project_key or "",
         "reportportal": settings.reportportal_enabled,
         "reportportal_project": settings.reportportal_project or "",
-        "feedback_enabled": settings.feedback_enabled and bool(AI_PROVIDER),
+        "feedback_enabled": settings.feedback_enabled
+        and bool(AI_PROVIDER)
+        and bool(AI_MODEL),
     }
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -65,7 +65,10 @@ from jenkins_job_insight.bug_creation import (
     search_github_duplicates,
     search_jira_duplicates,
 )
-from jenkins_job_insight.feedback import create_feedback_issue
+from jenkins_job_insight.feedback import (
+    create_feedback_from_preview,
+    generate_feedback_preview,
+)
 from jenkins_job_insight.comment_enrichment import detect_mentions
 from jenkins_job_insight.notifications import send_mention_notifications
 from jenkins_job_insight.vapid import get_vapid_config
@@ -83,6 +86,8 @@ from jenkins_job_insight.models import (
     CreateIssueRequest,
     FailureAnalysis,
     FailureAnalysisResult,
+    FeedbackCreateRequest,
+    FeedbackPreviewResponse,
     FeedbackRequest,
     FeedbackResponse,
     JobMetadataInput,
@@ -841,7 +846,7 @@ app.add_middleware(AuthMiddleware)
 app.add_middleware(ErrorTrackingMiddleware)
 
 
-_BODY_LOGGING_SKIP_PATHS = frozenset({"/api/feedback"})
+_BODY_LOGGING_SKIP_PATHS = frozenset({"/api/feedback/preview", "/api/feedback/create"})
 
 
 class RequestBodyLoggingMiddleware(BaseHTTPMiddleware):
@@ -4790,13 +4795,17 @@ Respond with ONLY a JSON object:
         return AnalyzeCommentResponse(suggests_reviewed=False)
 
 
-@app.post("/api/feedback", status_code=201, response_model=FeedbackResponse)
-async def submit_feedback(request: Request, body: FeedbackRequest):
-    """Submit user feedback as a GitHub issue.
+@app.post(
+    "/api/feedback/preview",
+    status_code=200,
+    response_model=FeedbackPreviewResponse,
+)
+async def preview_feedback(request: Request, body: FeedbackRequest):
+    """Preview user feedback as a formatted GitHub issue.
 
     Accepts bug reports or feature requests, uses AI to format them
     into well-structured GitHub issues, scrubs sensitive data from
-    attached logs, and creates the issue in myk-org/jenkins-job-insight.
+    attached logs, and returns the preview without creating the issue.
     """
     _check_allow_list(request)
     settings = get_settings()
@@ -4805,7 +4814,35 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
             status_code=503, detail="Feedback submission is disabled on this server"
         )
     try:
-        return await create_feedback_issue(body, settings)
+        return await generate_feedback_preview(body, settings)
+    except Exception as exc:  # noqa: BLE001 — non-fatal feedback preview
+        logger.exception("Failed to generate feedback preview")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to generate feedback preview",
+        ) from exc
+
+
+@app.post("/api/feedback/create", status_code=201, response_model=FeedbackResponse)
+async def create_feedback(request: Request, body: FeedbackCreateRequest):
+    """Create a GitHub issue from a previewed feedback.
+
+    Takes a title, body, and labels (typically from the preview endpoint)
+    and creates the GitHub issue.
+    """
+    _check_allow_list(request)
+    settings = get_settings()
+    if not settings.feedback_enabled:
+        raise HTTPException(
+            status_code=503, detail="Feedback submission is disabled on this server"
+        )
+    try:
+        return await create_feedback_from_preview(
+            title=body.title,
+            body=body.body,
+            labels=body.labels,
+            settings=settings,
+        )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code in (401, 403):
             raise HTTPException(
@@ -4822,10 +4859,10 @@ async def submit_feedback(request: Request, body: FeedbackRequest):
             detail=f"GitHub API unreachable: {exc}",
         ) from exc
     except Exception as exc:  # noqa: BLE001 — non-fatal feedback submission
-        logger.exception("Failed to submit feedback")
+        logger.exception("Failed to create feedback issue")
         raise HTTPException(
             status_code=500,
-            detail="Failed to submit feedback",
+            detail="Failed to create feedback issue",
         ) from exc
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2672,7 +2672,7 @@ def _build_capabilities(settings: Settings) -> dict[str, bool | str]:
         "server_jira_project_key": settings.jira_project_key or "",
         "reportportal": settings.reportportal_enabled,
         "reportportal_project": settings.reportportal_project or "",
-        "feedback_enabled": settings.feedback_enabled,
+        "feedback_enabled": settings.feedback_enabled and bool(AI_PROVIDER),
     }
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -844,7 +844,11 @@ app.add_middleware(ErrorTrackingMiddleware)
 class RequestBodyLoggingMiddleware(BaseHTTPMiddleware):
     """Log incoming request bodies at DEBUG level with sensitive data masked."""
 
+    _SKIP_PATHS = frozenset({"/api/feedback"})
+
     async def dispatch(self, request: Request, call_next):
+        if request.url.path in self._SKIP_PATHS:
+            return await call_next(request)
         if logger.isEnabledFor(logging.DEBUG) and request.method in (
             "POST",
             "PUT",

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -858,8 +858,9 @@ class PageState(BaseModel):
 class FeedbackRequest(BaseModel):
     """User feedback submission (bug or feature request)."""
 
-    feedback_type: Literal["bug", "feature"] = Field(
-        description="Type of feedback: 'bug' or 'feature'"
+    feedback_type: str = Field(
+        default="feedback",
+        description="Type of feedback (auto-determined by AI if not specified)",
     )
     description: str = Field(
         min_length=1, max_length=10000, description="Natural language description"

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -839,6 +839,22 @@ class AnalyzeCommentResponse(BaseModel):
     reason: str = ""
 
 
+class FailedApiCall(BaseModel):
+    """A single failed API call captured by the frontend."""
+
+    status: int = Field(default=0, description="HTTP status code")
+    endpoint: str = Field(default="", description="API endpoint path")
+    error: str = Field(default="", description="Error message or response body")
+
+
+class PageState(BaseModel):
+    """Current page state when feedback was submitted."""
+
+    url: str = Field(default="", description="Current page URL")
+    active_filters: str = Field(default="", description="Active filter selections")
+    report_id: str = Field(default="", description="Current report ID")
+
+
 class FeedbackRequest(BaseModel):
     """User feedback submission (bug or feature request)."""
 
@@ -851,13 +867,13 @@ class FeedbackRequest(BaseModel):
     console_errors: list[str] = Field(
         default_factory=list, description="Browser console errors"
     )
-    failed_api_calls: list[dict] = Field(
+    failed_api_calls: list[FailedApiCall] = Field(
         default_factory=list,
-        description="Recent failed API responses: {status, endpoint, error}",
+        description="Recent failed API responses",
     )
-    page_state: dict = Field(
-        default_factory=dict,
-        description="Current page state: {url, active_filters, report_id}",
+    page_state: PageState = Field(
+        default_factory=PageState,
+        description="Current page state when feedback was submitted",
     )
     user_agent: str = Field(default="", description="Browser user agent string")
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -837,3 +837,32 @@ class AnalyzeCommentResponse(BaseModel):
 
     suggests_reviewed: bool
     reason: str = ""
+
+
+class FeedbackRequest(BaseModel):
+    """User feedback submission (bug or feature request)."""
+
+    feedback_type: Literal["bug", "feature"] = Field(
+        description="Type of feedback: 'bug' or 'feature'"
+    )
+    description: str = Field(description="Natural language description")
+    console_errors: list[str] = Field(
+        default_factory=list, description="Browser console errors"
+    )
+    failed_api_calls: list[dict] = Field(
+        default_factory=list,
+        description="Recent failed API responses: {status, endpoint, error}",
+    )
+    page_state: dict = Field(
+        default_factory=dict,
+        description="Current page state: {url, active_filters, report_id}",
+    )
+    user_agent: str = Field(default="", description="Browser user agent string")
+
+
+class FeedbackResponse(BaseModel):
+    """Response from feedback submission."""
+
+    issue_url: str = Field(description="URL to the created GitHub issue")
+    issue_number: int = Field(description="GitHub issue number")
+    title: str = Field(description="Issue title as created")

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -843,16 +843,20 @@ class FailedApiCall(BaseModel):
     """A single failed API call captured by the frontend."""
 
     status: int = Field(default=0, description="HTTP status code")
-    endpoint: str = Field(default="", description="API endpoint path")
-    error: str = Field(default="", description="Error message or response body")
+    endpoint: str = Field(default="", max_length=500, description="API endpoint path")
+    error: str = Field(
+        default="", max_length=2000, description="Error message or response body"
+    )
 
 
 class PageState(BaseModel):
     """Current page state when feedback was submitted."""
 
-    url: str = Field(default="", description="Current page URL")
-    active_filters: str = Field(default="", description="Active filter selections")
-    report_id: str = Field(default="", description="Current report ID")
+    url: str = Field(default="", max_length=500, description="Current page URL")
+    active_filters: str = Field(
+        default="", max_length=1000, description="Active filter selections"
+    )
+    report_id: str = Field(default="", max_length=200, description="Current report ID")
 
 
 class FeedbackRequest(BaseModel):
@@ -865,8 +869,8 @@ class FeedbackRequest(BaseModel):
     description: str = Field(
         min_length=1, max_length=10000, description="Natural language description"
     )
-    console_errors: list[str] = Field(
-        default_factory=list, description="Browser console errors"
+    console_errors: list[Annotated[str, Field(max_length=5000)]] = Field(
+        default_factory=list, max_length=50, description="Browser console errors"
     )
     failed_api_calls: list[FailedApiCall] = Field(
         default_factory=list,
@@ -876,7 +880,9 @@ class FeedbackRequest(BaseModel):
         default_factory=PageState,
         description="Current page state when feedback was submitted",
     )
-    user_agent: str = Field(default="", description="Browser user agent string")
+    user_agent: str = Field(
+        default="", max_length=500, description="Browser user agent string"
+    )
 
 
 class FeedbackPreviewResponse(BaseModel):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -860,6 +860,22 @@ class FeedbackRequest(BaseModel):
     user_agent: str = Field(default="", description="Browser user agent string")
 
 
+class FeedbackPreviewResponse(BaseModel):
+    """Response from feedback preview (AI-generated title + body)."""
+
+    title: str = Field(description="Generated issue title")
+    body: str = Field(description="Generated issue body (markdown)")
+    labels: list[str] = Field(default_factory=list, description="Issue labels")
+
+
+class FeedbackCreateRequest(BaseModel):
+    """Request to create a GitHub issue from a previewed feedback."""
+
+    title: str = Field(description="Issue title")
+    body: str = Field(description="Issue body (markdown)")
+    labels: list[str] = Field(default_factory=list, description="Issue labels")
+
+
 class FeedbackResponse(BaseModel):
     """Response from feedback submission."""
 

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -845,7 +845,9 @@ class FeedbackRequest(BaseModel):
     feedback_type: Literal["bug", "feature"] = Field(
         description="Type of feedback: 'bug' or 'feature'"
     )
-    description: str = Field(description="Natural language description")
+    description: str = Field(
+        min_length=1, max_length=10000, description="Natural language description"
+    )
     console_errors: list[str] = Field(
         default_factory=list, description="Browser console errors"
     )
@@ -871,8 +873,10 @@ class FeedbackPreviewResponse(BaseModel):
 class FeedbackCreateRequest(BaseModel):
     """Request to create a GitHub issue from a previewed feedback."""
 
-    title: str = Field(description="Issue title")
-    body: str = Field(description="Issue body (markdown)")
+    title: str = Field(min_length=1, max_length=500, description="Issue title")
+    body: str = Field(
+        min_length=1, max_length=50000, description="Issue body (markdown)"
+    )
     labels: list[str] = Field(default_factory=list, description="Issue labels")
 
 

--- a/tests/test_bug_creation.py
+++ b/tests/test_bug_creation.py
@@ -16,6 +16,14 @@ from jenkins_job_insight.models import (
 
 _TEST_GITHUB_TOKEN = "ghp_test"  # noqa: S105
 
+# Expected footer substrings for assertion checks.
+_GITHUB_FOOTER_MARKER = (
+    "Generated using AI with [JJI](https://github.com/myk-org/jenkins-job-insight)"
+)
+_JIRA_FOOTER_MARKER = (
+    "Generated using AI with [JJI|https://github.com/myk-org/jenkins-job-insight]"
+)
+
 
 @pytest.fixture
 def code_issue_failure() -> FailureAnalysis:
@@ -88,6 +96,7 @@ class TestGenerateGithubIssueContent:
             assert result["title"]
             assert result["body"]
             assert "test_valid_credentials" in result["body"]
+            assert _GITHUB_FOOTER_MARKER in result["body"]
 
     async def test_fallback_on_ai_failure(self, code_issue_failure):
         from jenkins_job_insight.bug_creation import generate_github_issue_content
@@ -105,6 +114,7 @@ class TestGenerateGithubIssueContent:
             assert result["title"]
             assert result["body"]
             assert "test_valid_credentials" in result["body"]
+            assert _GITHUB_FOOTER_MARKER in result["body"]
 
     async def test_fallback_includes_code_fix(self, code_issue_failure):
         from jenkins_job_insight.bug_creation import generate_github_issue_content
@@ -120,6 +130,7 @@ class TestGenerateGithubIssueContent:
             )
             assert "src/auth/handlers.py" in result["body"]
             assert "Suggested Fix" in result["body"]
+            assert _GITHUB_FOOTER_MARKER in result["body"]
 
 
 class TestGenerateJiraBugContent:
@@ -144,6 +155,7 @@ class TestGenerateJiraBugContent:
             )
             assert result["title"]
             assert result["body"]
+            assert _JIRA_FOOTER_MARKER in result["body"]
 
     async def test_fallback_on_ai_failure(self, product_bug_failure):
         from jenkins_job_insight.bug_creation import generate_jira_bug_content
@@ -159,6 +171,7 @@ class TestGenerateJiraBugContent:
             )
             assert result["title"] == "DNS resolution timeout on internal resolver"
             assert "test_resolve" in result["body"]
+            assert _JIRA_FOOTER_MARKER in result["body"]
 
 
 class TestSearchGithubDuplicates:
@@ -256,6 +269,10 @@ class TestCreateGithubIssue:
             assert result["url"] == "https://github.com/org/repo/issues/99"
             assert result["number"] == 99
 
+            # Verify footer was appended to the body sent to GitHub API
+            posted_body = mock_client.post.call_args.kwargs["json"]["body"]
+            assert _GITHUB_FOOTER_MARKER in posted_body
+
     async def test_creates_issue_with_labels(self):
         from jenkins_job_insight.bug_creation import create_github_issue
 
@@ -283,6 +300,10 @@ class TestCreateGithubIssue:
                 labels=["bug", "test-failure"],
             )
             assert result["number"] == 100
+
+            # Verify footer was appended to the body sent to GitHub API
+            posted_body = mock_client.post.call_args.kwargs["json"]["body"]
+            assert _GITHUB_FOOTER_MARKER in posted_body
 
 
 class TestCreateJiraBug:
@@ -320,6 +341,12 @@ class TestCreateJiraBug:
             )
             assert result["key"] == "PROJ-456"
             assert "jira.example.com" in result["url"]
+
+            # Verify Jira-format footer was appended
+            posted_body = mock_client.post.call_args.kwargs["json"]["fields"][
+                "description"
+            ]
+            assert _JIRA_FOOTER_MARKER in posted_body
 
     async def test_creates_bug_server_dc(self):
         """Test Jira Server/DC auth (Bearer PAT, no email)."""
@@ -428,6 +455,12 @@ class TestCreateJiraBug:
             payload = call_args.kwargs.get("json") or call_args[1].get("json")
             assert payload["fields"]["issuetype"] == {"name": "Bug"}
 
+            # Verify Jira-format footer was appended
+            posted_body = mock_client.post.call_args.kwargs["json"]["fields"][
+                "description"
+            ]
+            assert _JIRA_FOOTER_MARKER in posted_body
+
 
 class TestParseGithubRepoUrl:
     def test_standard_url(self):
@@ -531,3 +564,76 @@ class TestCreateIssueRequestJiraIssueType:
             jira_issue_type="Task",
         )
         assert req.jira_issue_type == "Task"
+
+
+class TestAiFooterNotDoubled:
+    """Verify footer deduplication: content that already has the footer is not doubled."""
+
+    async def test_github_footer_not_doubled(self):
+        from jenkins_job_insight.bug_creation import (
+            GITHUB_AI_FOOTER,
+            create_github_issue,
+        )
+
+        body_with_footer = "## Details\nSome content" + GITHUB_AI_FOOTER
+
+        mock_response = httpx.Response(
+            201,
+            json={
+                "number": 200,
+                "title": "Test",
+                "html_url": "https://github.com/org/repo/issues/200",
+            },
+            request=_mock_request(),
+        )
+        with patch("jenkins_job_insight.bug_creation.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            await create_github_issue(
+                title="Test",
+                body=body_with_footer,
+                repo_url="https://github.com/org/repo",
+                github_token=_TEST_GITHUB_TOKEN,
+            )
+            posted_body = mock_client.post.call_args.kwargs["json"]["body"]
+            assert posted_body.count(_GITHUB_FOOTER_MARKER) == 1
+
+    async def test_jira_footer_not_doubled(self):
+        from jenkins_job_insight.bug_creation import JIRA_AI_FOOTER, create_jira_bug
+
+        body_with_footer = "h2. Details\nSome content" + JIRA_AI_FOOTER
+
+        mock_settings = MagicMock()
+        mock_settings.jira_url = "https://jira.example.com"
+        mock_settings.jira_project_key = "PROJ"
+        mock_settings.jira_email = "test@example.com"
+        mock_settings.jira_api_token = MagicMock()
+        mock_settings.jira_api_token.get_secret_value.return_value = "token"
+        mock_settings.jira_pat = None
+        mock_settings.jira_ssl_verify = True
+
+        mock_response = httpx.Response(
+            201,
+            json={"key": "PROJ-999"},
+            request=_mock_request(),
+        )
+        with patch("jenkins_job_insight.bug_creation.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            await create_jira_bug(
+                title="Test",
+                body=body_with_footer,
+                settings=mock_settings,
+            )
+            posted_body = mock_client.post.call_args.kwargs["json"]["fields"][
+                "description"
+            ]
+            assert posted_body.count(_JIRA_FOOTER_MARKER) == 1

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,483 @@
+"""Tests for user feedback endpoint and scrubbing logic."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from ai_cli_runner import AIResult
+from fastapi.testclient import TestClient
+
+from jenkins_job_insight import storage
+from jenkins_job_insight.config import get_settings
+from jenkins_job_insight.feedback import (
+    _FEEDBACK_REPO_URL,
+    _build_fallback_feedback,
+    create_feedback_issue,
+    format_feedback_with_ai,
+    scrub_sensitive_data,
+)
+from jenkins_job_insight.models import FeedbackRequest, FeedbackResponse
+
+
+# ---------------------------------------------------------------------------
+# scrub_sensitive_data tests
+# ---------------------------------------------------------------------------
+
+
+class TestScrubSensitiveData:
+    def test_bearer_token(self):
+        text = "Authorization: Bearer ghp_abc123XYZ"
+        result = scrub_sensitive_data(text)
+        assert "ghp_abc123XYZ" not in result
+        assert "[REDACTED]" in result
+
+    def test_basic_auth_header(self):
+        text = "Authorization: Basic dXNlcjpwYXNz"
+        result = scrub_sensitive_data(text)
+        assert "dXNlcjpwYXNz" not in result
+        assert "[REDACTED]" in result
+
+    def test_api_key_param(self):
+        text = "api_key=test-key-placeholder"  # pragma: allowlist secret
+        result = scrub_sensitive_data(text)
+        assert "test-key-placeholder" not in result
+        assert "[REDACTED]" in result
+
+    def test_token_param(self):
+        text = "token=mySecretToken123"
+        result = scrub_sensitive_data(text)
+        assert "mySecretToken123" not in result
+        assert "[REDACTED]" in result
+
+    def test_password_param(self):
+        text = "password=SuperS3cret!"
+        result = scrub_sensitive_data(text)
+        assert "SuperS3cret!" not in result
+        assert "[REDACTED]" in result
+
+    def test_jwt_token(self):
+        jwt = "eyJhbGci.eyJzdWIi.dummy-test-sig"  # pragma: allowlist secret
+        # JWT embedded in a sentence (not preceded by a key= pattern)
+        text = f"The auth header contained {jwt} which expired"
+        result = scrub_sensitive_data(text)
+        assert jwt not in result
+        assert "[REDACTED_JWT]" in result
+
+    def test_jwt_token_after_key(self):
+        jwt = "eyJhbGci.eyJzdWIi.dummy-test-sig"  # pragma: allowlist secret
+        text = f"Token: {jwt}"
+        result = scrub_sensitive_data(text)
+        assert jwt not in result
+        assert "[REDACTED]" in result
+
+    def test_github_token_patterns(self):
+        for prefix in ("ghp_", "gho_", "ghs_", "ghr_", "github_pat_"):
+            text = f"token={prefix}abcdefghij1234567890"
+            result = scrub_sensitive_data(text)
+            assert f"{prefix}abcdefghij1234567890" not in result
+
+    def test_preserves_normal_text(self):
+        text = "Test test_login_flow failed with AssertionError at line 42"
+        result = scrub_sensitive_data(text)
+        assert result == text
+
+    def test_preserves_urls(self):
+        text = "Failed request to https://api.example.com/v1/users"
+        result = scrub_sensitive_data(text)
+        assert "https://api.example.com/v1/users" in result
+
+    def test_preserves_test_names(self):
+        text = "tests.auth.test_login.TestLogin.test_valid_credentials"
+        result = scrub_sensitive_data(text)
+        assert result == text
+
+    def test_multiple_sensitive_patterns(self):
+        text = "Bearer fake-token-abc password=fake-pass api_key=mykey"
+        result = scrub_sensitive_data(text)
+        assert "fake-token-abc" not in result
+        assert "fake-pass" not in result
+        assert "mykey" not in result
+
+    def test_empty_string(self):
+        assert scrub_sensitive_data("") == ""
+
+    def test_authorization_header_json(self):
+        text = """{"Authorization": "Bearer super-secret-token"}"""
+        result = scrub_sensitive_data(text)
+        assert "super-secret-token" not in result
+
+
+# ---------------------------------------------------------------------------
+# fallback formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFallbackFeedback:
+    def test_bug_fallback(self):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Button does not work",
+            console_errors=["TypeError: undefined is not a function"],
+            failed_api_calls=[
+                {
+                    "status": 500,
+                    "endpoint": "/api/analyze",
+                    "error": "Internal Server Error",
+                }
+            ],
+            page_state={"url": "/report/123"},
+            user_agent="Mozilla/5.0",
+        )
+        title, body = _build_fallback_feedback(req)
+        assert "Bug report:" in title
+        assert "## Bug Report" in body
+        assert "Button does not work" in body
+        assert "TypeError" in body
+        assert "/api/analyze" in body
+        assert "Mozilla/5.0" in body
+
+    def test_feature_fallback(self):
+        req = FeedbackRequest(
+            feedback_type="feature",
+            description="Add dark mode support",
+        )
+        title, body = _build_fallback_feedback(req)
+        assert "Feature request:" in title
+        assert "## Feature Request" in body
+        assert "Add dark mode support" in body
+
+    def test_bug_fallback_scrubs_console_errors(self):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Auth error",
+            console_errors=["Bearer my-secret-token leaked"],
+        )
+        _, body = _build_fallback_feedback(req)
+        assert "my-secret-token" not in body
+        assert "[REDACTED]" in body
+
+
+# ---------------------------------------------------------------------------
+# format_feedback_with_ai tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFeedbackWithAi:
+    @pytest.fixture
+    def settings(self):
+        env = {
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JENKINS_USER": "user",
+            "JENKINS_PASSWORD": "pass",  # pragma: allowlist secret
+        }
+        with patch.dict(os.environ, env, clear=True):
+            get_settings.cache_clear()
+            s = get_settings()
+            get_settings.cache_clear()
+            return s
+
+    async def test_ai_success(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="The analyze button is broken",
+        )
+        ai_response = json.dumps(
+            {
+                "title": "Analyze button not responding",
+                "body": "## Description\n\nThe analyze button fails to trigger analysis.",
+            }
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text=ai_response)
+            title, body = await format_feedback_with_ai(req, settings)
+        assert title == "Analyze button not responding"
+        assert "## Description" in body
+
+    async def test_ai_failure_uses_fallback(self, settings):
+        req = FeedbackRequest(
+            feedback_type="feature",
+            description="Add export to CSV",
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=False, text="CLI error")
+            title, body = await format_feedback_with_ai(req, settings)
+        assert "Feature request:" in title
+        assert "Add export to CSV" in body
+
+    async def test_ai_returns_invalid_json_uses_fallback(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Something broke",
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text="not json at all")
+            title, body = await format_feedback_with_ai(req, settings)
+        assert "Bug report:" in title
+
+    async def test_ai_response_with_markdown_fences(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Error on page load",
+        )
+        ai_response = (
+            "```json\n"
+            + json.dumps(
+                {
+                    "title": "Page load error",
+                    "body": "## Bug\n\nPage fails to load.",
+                }
+            )
+            + "\n```"
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text=ai_response)
+            title, body = await format_feedback_with_ai(req, settings)
+        assert title == "Page load error"
+
+    async def test_scrubs_sensitive_data_in_context(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Auth failed",
+            console_errors=["Bearer my-secret-token-123"],
+            failed_api_calls=[{"error": "password=hunter2"}],
+        )
+        captured_prompt = None
+
+        async def capture_call(prompt, **kwargs):
+            nonlocal captured_prompt
+            captured_prompt = prompt
+            return AIResult(success=False, text="fail")
+
+        with patch(
+            "jenkins_job_insight.feedback.call_ai_cli", side_effect=capture_call
+        ):
+            await format_feedback_with_ai(req, settings)
+
+        # Verify sensitive data was scrubbed in the prompt sent to AI
+        assert "my-secret-token-123" not in captured_prompt
+        assert "hunter2" not in captured_prompt
+
+
+# ---------------------------------------------------------------------------
+# create_feedback_issue tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFeedbackIssue:
+    @pytest.fixture
+    def settings(self):
+        env = {
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JENKINS_USER": "user",
+            "JENKINS_PASSWORD": "pass",  # pragma: allowlist secret
+            "GITHUB_TOKEN": "test-token-placeholder",  # pragma: allowlist secret
+        }
+        with patch.dict(os.environ, env, clear=True):
+            get_settings.cache_clear()
+            s = get_settings()
+            get_settings.cache_clear()
+            return s
+
+    async def test_creates_bug_issue(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Dashboard crashes",
+        )
+        with (
+            patch(
+                "jenkins_job_insight.feedback.format_feedback_with_ai"
+            ) as mock_format,
+            patch("jenkins_job_insight.feedback.create_github_issue") as mock_create,
+        ):
+            mock_format.return_value = (
+                "Dashboard crash on load",
+                "## Bug\n\nDetails...",
+            )
+            mock_create.return_value = {
+                "url": "https://github.com/myk-org/jenkins-job-insight/issues/42",
+                "number": 42,
+                "title": "Dashboard crash on load",
+            }
+            result = await create_feedback_issue(req, settings)
+
+        assert isinstance(result, FeedbackResponse)
+        assert result.issue_number == 42
+        assert result.title == "Dashboard crash on load"
+        assert "issues/42" in result.issue_url
+
+        # Verify correct label
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs.get("labels") == ["bug"] or call_kwargs[1].get(
+            "labels"
+        ) == ["bug"]
+
+    async def test_creates_feature_issue_with_enhancement_label(self, settings):
+        req = FeedbackRequest(
+            feedback_type="feature",
+            description="Add dark mode",
+        )
+        with (
+            patch(
+                "jenkins_job_insight.feedback.format_feedback_with_ai"
+            ) as mock_format,
+            patch("jenkins_job_insight.feedback.create_github_issue") as mock_create,
+        ):
+            mock_format.return_value = (
+                "Add dark mode support",
+                "## Feature\n\nDark mode...",
+            )
+            mock_create.return_value = {
+                "url": "https://github.com/myk-org/jenkins-job-insight/issues/99",
+                "number": 99,
+                "title": "Add dark mode support",
+            }
+            result = await create_feedback_issue(req, settings)
+
+        assert result.issue_number == 99
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs.get("labels") == ["enhancement"] or call_kwargs[
+            1
+        ].get("labels") == ["enhancement"]
+
+    async def test_uses_correct_repo_url(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="test",
+        )
+        with (
+            patch(
+                "jenkins_job_insight.feedback.format_feedback_with_ai"
+            ) as mock_format,
+            patch("jenkins_job_insight.feedback.create_github_issue") as mock_create,
+        ):
+            mock_format.return_value = ("Title", "Body")
+            mock_create.return_value = {
+                "url": "https://github.com/x/y/issues/1",
+                "number": 1,
+                "title": "Title",
+            }
+            await create_feedback_issue(req, settings)
+
+        call_kwargs = mock_create.call_args
+        assert (
+            call_kwargs.kwargs.get("repo_url") == _FEEDBACK_REPO_URL
+            or call_kwargs[1].get("repo_url") == _FEEDBACK_REPO_URL
+        )
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackEndpoint:
+    @pytest.fixture
+    def _init_db(self, temp_db_path):
+        """Initialize an empty database for endpoint tests."""
+        import asyncio
+
+        with patch.object(storage, "DB_PATH", temp_db_path):
+            asyncio.run(storage.init_db())
+            yield
+
+    def _make_client(self, temp_db_path, github_token: str = ""):
+        """Create a TestClient with optional GITHUB_TOKEN."""
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in {
+                "GITHUB_TOKEN",
+                "ADMIN_KEY",
+                "JJI_ENCRYPTION_KEY",
+                "ALLOWED_USERS",
+            }
+        }
+        env["SECURE_COOKIES"] = "false"
+        env["DB_PATH"] = str(temp_db_path)
+        if github_token:
+            env["GITHUB_TOKEN"] = github_token
+        with patch.dict(os.environ, env, clear=True):
+            get_settings.cache_clear()
+            with patch.object(storage, "DB_PATH", temp_db_path):
+                from jenkins_job_insight.main import app
+
+                with TestClient(app) as c:
+                    yield c
+            get_settings.cache_clear()
+
+    def test_missing_github_token_returns_503(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=""):
+            resp = client.post(
+                "/api/feedback",
+                json={
+                    "feedback_type": "bug",
+                    "description": "Something broke",
+                },
+            )
+            assert resp.status_code == 503
+            assert "GitHub token not configured" in resp.json()["detail"]
+
+    def test_successful_feedback_submission(self, _init_db, temp_db_path):
+        for client in self._make_client(
+            temp_db_path, github_token="ghp_test"
+        ):  # pragma: allowlist secret
+            with (
+                patch(
+                    "jenkins_job_insight.feedback.format_feedback_with_ai"
+                ) as mock_format,
+                patch(
+                    "jenkins_job_insight.feedback.create_github_issue"
+                ) as mock_create,
+            ):
+                mock_format.return_value = ("Test title", "Test body")
+                mock_create.return_value = {
+                    "url": "https://github.com/myk-org/jenkins-job-insight/issues/10",
+                    "number": 10,
+                    "title": "Test title",
+                }
+                resp = client.post(
+                    "/api/feedback",
+                    json={
+                        "feedback_type": "bug",
+                        "description": "The button is broken",
+                        "console_errors": ["TypeError: x is not a function"],
+                    },
+                )
+            assert resp.status_code == 201
+            data = resp.json()
+            assert data["issue_number"] == 10
+            assert data["title"] == "Test title"
+            assert "issues/10" in data["issue_url"]
+
+    def test_invalid_feedback_type_returns_422(self, _init_db, temp_db_path):
+        for client in self._make_client(
+            temp_db_path, github_token="ghp_test"
+        ):  # pragma: allowlist secret
+            resp = client.post(
+                "/api/feedback",
+                json={
+                    "feedback_type": "invalid",
+                    "description": "Something",
+                },
+            )
+            assert resp.status_code == 422
+
+    def test_capabilities_includes_feedback_enabled(self, _init_db, temp_db_path):
+        for client in self._make_client(
+            temp_db_path, github_token="ghp_test"
+        ):  # pragma: allowlist secret
+            resp = client.get("/api/capabilities")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "feedback_enabled" in data
+            assert data["feedback_enabled"] is True
+
+    def test_capabilities_feedback_disabled_without_token(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=""):
+            resp = client.get("/api/capabilities")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["feedback_enabled"] is False

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -13,11 +13,17 @@ from jenkins_job_insight.config import get_settings
 from jenkins_job_insight.feedback import (
     _FEEDBACK_REPO_URL,
     _build_fallback_feedback,
+    create_feedback_from_preview,
     create_feedback_issue,
     format_feedback_with_ai,
+    generate_feedback_preview,
     scrub_sensitive_data,
 )
-from jenkins_job_insight.models import FeedbackRequest, FeedbackResponse
+from jenkins_job_insight.models import (
+    FeedbackPreviewResponse,
+    FeedbackRequest,
+    FeedbackResponse,
+)
 
 _TEST_GITHUB_TOKEN = "test-token-placeholder"  # noqa: S105
 
@@ -262,7 +268,126 @@ class TestFormatFeedbackWithAi:
 
 
 # ---------------------------------------------------------------------------
-# create_feedback_issue tests
+# generate_feedback_preview tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateFeedbackPreview:
+    @pytest.fixture
+    def settings(self):
+        env = {
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JENKINS_USER": "user",
+            "JENKINS_PASSWORD": "pass",  # pragma: allowlist secret
+        }
+        with patch.dict(os.environ, env, clear=True):
+            get_settings.cache_clear()
+            s = get_settings()
+            get_settings.cache_clear()
+            return s
+
+    async def test_bug_preview_returns_correct_labels(self, settings):
+        req = FeedbackRequest(
+            feedback_type="bug",
+            description="Dashboard crashes",
+        )
+        with patch(
+            "jenkins_job_insight.feedback.format_feedback_with_ai"
+        ) as mock_format:
+            mock_format.return_value = (
+                "Dashboard crash on load",
+                "## Bug\n\nDetails...",
+            )
+            result = await generate_feedback_preview(req, settings)
+
+        assert isinstance(result, FeedbackPreviewResponse)
+        assert result.title == "Dashboard crash on load"
+        assert result.body == "## Bug\n\nDetails..."
+        assert result.labels == ["bug"]
+
+    async def test_feature_preview_returns_correct_labels(self, settings):
+        req = FeedbackRequest(
+            feedback_type="feature",
+            description="Add dark mode",
+        )
+        with patch(
+            "jenkins_job_insight.feedback.format_feedback_with_ai"
+        ) as mock_format:
+            mock_format.return_value = (
+                "Add dark mode support",
+                "## Feature\n\nDark mode...",
+            )
+            result = await generate_feedback_preview(req, settings)
+
+        assert isinstance(result, FeedbackPreviewResponse)
+        assert result.title == "Add dark mode support"
+        assert result.labels == ["enhancement"]
+
+
+# ---------------------------------------------------------------------------
+# create_feedback_from_preview tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFeedbackFromPreview:
+    @pytest.fixture
+    def settings(self):
+        env = {
+            "JENKINS_URL": "https://jenkins.example.com",
+            "JENKINS_USER": "user",
+            "JENKINS_PASSWORD": "pass",  # pragma: allowlist secret
+            "GITHUB_TOKEN": _TEST_GITHUB_TOKEN,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            get_settings.cache_clear()
+            s = get_settings()
+            get_settings.cache_clear()
+            return s
+
+    async def test_creates_issue_with_labels(self, settings):
+        with patch("jenkins_job_insight.feedback.create_github_issue") as mock_create:
+            mock_create.return_value = {
+                "url": "https://github.com/myk-org/jenkins-job-insight/issues/42",
+                "number": 42,
+                "title": "Dashboard crash on load",
+            }
+            result = await create_feedback_from_preview(
+                title="Dashboard crash on load",
+                body="## Bug\n\nDetails...",
+                labels=["bug"],
+                settings=settings,
+            )
+
+        assert isinstance(result, FeedbackResponse)
+        assert result.issue_number == 42
+        assert result.title == "Dashboard crash on load"
+        assert "issues/42" in result.issue_url
+
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["repo_url"] == _FEEDBACK_REPO_URL
+        assert call_kwargs["labels"] == ["bug"]
+
+    async def test_uses_correct_repo_url(self, settings):
+        with patch("jenkins_job_insight.feedback.create_github_issue") as mock_create:
+            mock_create.return_value = {
+                "url": "https://github.com/x/y/issues/1",
+                "number": 1,
+                "title": "Title",
+            }
+            await create_feedback_from_preview(
+                title="Title",
+                body="Body",
+                labels=["enhancement"],
+                settings=settings,
+            )
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["repo_url"] == _FEEDBACK_REPO_URL
+
+
+# ---------------------------------------------------------------------------
+# create_feedback_issue (legacy) tests
 # ---------------------------------------------------------------------------
 
 
@@ -417,10 +542,12 @@ class TestFeedbackEndpoint:
                     yield c
             get_settings.cache_clear()
 
-    def test_missing_github_token_returns_503(self, _init_db, temp_db_path):
+    # -- Preview endpoint tests -----------------------------------------------
+
+    def test_preview_missing_github_token_returns_503(self, _init_db, temp_db_path):
         for client in self._make_client(temp_db_path, github_token=""):
             resp = client.post(
-                "/api/feedback",
+                "/api/feedback/preview",
                 json={
                     "feedback_type": "bug",
                     "description": "Something broke",
@@ -429,28 +556,85 @@ class TestFeedbackEndpoint:
             assert resp.status_code == 503
             assert "disabled" in resp.json()["detail"]
 
-    def test_successful_feedback_submission(self, _init_db, temp_db_path):
+    def test_preview_successful(self, _init_db, temp_db_path):
         for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
-            with (
-                patch(
-                    "jenkins_job_insight.feedback.format_feedback_with_ai"
-                ) as mock_format,
-                patch(
-                    "jenkins_job_insight.feedback.create_github_issue"
-                ) as mock_create,
-            ):
+            with patch(
+                "jenkins_job_insight.feedback.format_feedback_with_ai"
+            ) as mock_format:
                 mock_format.return_value = ("Test title", "Test body")
+                resp = client.post(
+                    "/api/feedback/preview",
+                    json={
+                        "feedback_type": "bug",
+                        "description": "The button is broken",
+                        "console_errors": ["TypeError: x is not a function"],
+                    },
+                )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["title"] == "Test title"
+            assert data["body"] == "Test body"
+            assert data["labels"] == ["bug"]
+
+    def test_preview_feature_returns_enhancement_label(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
+            with patch(
+                "jenkins_job_insight.feedback.format_feedback_with_ai"
+            ) as mock_format:
+                mock_format.return_value = ("Feature title", "Feature body")
+                resp = client.post(
+                    "/api/feedback/preview",
+                    json={
+                        "feedback_type": "feature",
+                        "description": "Add dark mode",
+                    },
+                )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["labels"] == ["enhancement"]
+
+    def test_preview_invalid_feedback_type_returns_422(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
+            resp = client.post(
+                "/api/feedback/preview",
+                json={
+                    "feedback_type": "invalid",
+                    "description": "Something",
+                },
+            )
+            assert resp.status_code == 422
+
+    # -- Create endpoint tests ------------------------------------------------
+
+    def test_create_missing_github_token_returns_503(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=""):
+            resp = client.post(
+                "/api/feedback/create",
+                json={
+                    "title": "Test title",
+                    "body": "Test body",
+                    "labels": ["bug"],
+                },
+            )
+            assert resp.status_code == 503
+            assert "disabled" in resp.json()["detail"]
+
+    def test_create_successful(self, _init_db, temp_db_path):
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
+            with patch(
+                "jenkins_job_insight.feedback.create_github_issue"
+            ) as mock_create:
                 mock_create.return_value = {
                     "url": "https://github.com/myk-org/jenkins-job-insight/issues/10",
                     "number": 10,
                     "title": "Test title",
                 }
                 resp = client.post(
-                    "/api/feedback",
+                    "/api/feedback/create",
                     json={
-                        "feedback_type": "bug",
-                        "description": "The button is broken",
-                        "console_errors": ["TypeError: x is not a function"],
+                        "title": "Test title",
+                        "body": "Test body",
+                        "labels": ["bug"],
                     },
                 )
             assert resp.status_code == 201
@@ -459,16 +643,29 @@ class TestFeedbackEndpoint:
             assert data["title"] == "Test title"
             assert "issues/10" in data["issue_url"]
 
-    def test_invalid_feedback_type_returns_422(self, _init_db, temp_db_path):
+    def test_create_with_empty_labels(self, _init_db, temp_db_path):
         for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
-            resp = client.post(
-                "/api/feedback",
-                json={
-                    "feedback_type": "invalid",
-                    "description": "Something",
-                },
-            )
-            assert resp.status_code == 422
+            with patch(
+                "jenkins_job_insight.feedback.create_github_issue"
+            ) as mock_create:
+                mock_create.return_value = {
+                    "url": "https://github.com/myk-org/jenkins-job-insight/issues/11",
+                    "number": 11,
+                    "title": "No labels",
+                }
+                resp = client.post(
+                    "/api/feedback/create",
+                    json={
+                        "title": "No labels",
+                        "body": "Test body",
+                    },
+                )
+            assert resp.status_code == 201
+            # Verify create_github_issue was called with empty labels
+            mock_create.assert_called_once()
+            assert mock_create.call_args.kwargs["labels"] == []
+
+    # -- Capabilities tests ---------------------------------------------------
 
     def test_capabilities_includes_feedback_enabled(self, _init_db, temp_db_path):
         for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
@@ -494,10 +691,29 @@ class TestFeedbackEndpoint:
             enable_github_issues="false",
         ):
             resp = client.post(
-                "/api/feedback",
+                "/api/feedback/preview",
                 json={
                     "feedback_type": "bug",
                     "description": "Something broke",
+                },
+            )
+            assert resp.status_code == 503
+            assert "disabled" in resp.json()["detail"]
+
+    def test_create_disabled_when_enable_github_issues_false(
+        self, _init_db, temp_db_path
+    ):
+        for client in self._make_client(
+            temp_db_path,
+            github_token=_TEST_GITHUB_TOKEN,
+            enable_github_issues="false",
+        ):
+            resp = client.post(
+                "/api/feedback/create",
+                json={
+                    "title": "Test title",
+                    "body": "Test body",
+                    "labels": ["bug"],
                 },
             )
             assert resp.status_code == 503

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -382,7 +382,12 @@ class TestFeedbackEndpoint:
             asyncio.run(storage.init_db())
             yield
 
-    def _make_client(self, temp_db_path, github_token: str = ""):
+    def _make_client(
+        self,
+        temp_db_path,
+        github_token: str = "",
+        enable_github_issues: str = "",
+    ):
         """Create a TestClient with optional GITHUB_TOKEN."""
         env = {
             k: v
@@ -393,12 +398,15 @@ class TestFeedbackEndpoint:
                 "ADMIN_KEY",
                 "JJI_ENCRYPTION_KEY",
                 "ALLOWED_USERS",
+                "ENABLE_GITHUB_ISSUES",
             }
         }
         env["SECURE_COOKIES"] = "false"
         env["DB_PATH"] = str(temp_db_path)
         if github_token:
             env["GITHUB_TOKEN"] = github_token
+        if enable_github_issues:
+            env["ENABLE_GITHUB_ISSUES"] = enable_github_issues
         with patch.dict(os.environ, env, clear=True):
             get_settings.cache_clear()
             with patch.object(storage, "DB_PATH", temp_db_path):
@@ -418,7 +426,7 @@ class TestFeedbackEndpoint:
                 },
             )
             assert resp.status_code == 503
-            assert "GitHub token not configured" in resp.json()["detail"]
+            assert "disabled" in resp.json()["detail"]
 
     def test_successful_feedback_submission(self, _init_db, temp_db_path):
         for client in self._make_client(
@@ -481,3 +489,33 @@ class TestFeedbackEndpoint:
             assert resp.status_code == 200
             data = resp.json()
             assert data["feedback_enabled"] is False
+
+    def test_feedback_disabled_when_enable_github_issues_false(
+        self, _init_db, temp_db_path
+    ):
+        for client in self._make_client(
+            temp_db_path,
+            github_token="ghp_test",  # pragma: allowlist secret
+            enable_github_issues="false",
+        ):
+            resp = client.post(
+                "/api/feedback",
+                json={
+                    "feedback_type": "bug",
+                    "description": "Something broke",
+                },
+            )
+            assert resp.status_code == 503
+            assert "disabled" in resp.json()["detail"]
+
+    def test_capabilities_feedback_disabled_when_github_issues_false(
+        self, _init_db, temp_db_path
+    ):
+        for client in self._make_client(
+            temp_db_path,
+            github_token="ghp_test",  # pragma: allowlist secret
+            enable_github_issues="false",
+        ):
+            resp = client.get("/api/capabilities")
+            assert resp.status_code == 200
+            assert resp.json()["feedback_enabled"] is False

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -126,7 +126,6 @@ class TestScrubSensitiveData:
 class TestBuildFallbackFeedback:
     def test_bug_fallback(self):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Button does not work",
             console_errors=["TypeError: undefined is not a function"],
             failed_api_calls=[
@@ -140,8 +139,8 @@ class TestBuildFallbackFeedback:
             user_agent="Mozilla/5.0",
         )
         title, body = _build_fallback_feedback(req)
-        assert "Bug report:" in title
-        assert "## Bug Report" in body
+        assert "Feedback:" in title
+        assert "## Feedback" in body
         assert "Button does not work" in body
         assert "TypeError" in body
         assert "/api/analyze" in body
@@ -149,17 +148,15 @@ class TestBuildFallbackFeedback:
 
     def test_feature_fallback(self):
         req = FeedbackRequest(
-            feedback_type="feature",
             description="Add dark mode support",
         )
         title, body = _build_fallback_feedback(req)
-        assert "Feature request:" in title
-        assert "## Feature Request" in body
+        assert "Feedback:" in title
+        assert "## Feedback" in body
         assert "Add dark mode support" in body
 
-    def test_bug_fallback_scrubs_console_errors(self):
+    def test_fallback_scrubs_console_errors(self):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Auth error",
             console_errors=["Bearer my-secret-token leaked"],
         )
@@ -189,45 +186,70 @@ class TestFormatFeedbackWithAi:
 
     async def test_ai_success(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="The analyze button is broken",
         )
         ai_response = json.dumps(
             {
                 "title": "Analyze button not responding",
                 "body": "## Description\n\nThe analyze button fails to trigger analysis.",
+                "labels": ["bug"],
             }
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text=ai_response)
-            title, body = await format_feedback_with_ai(req, settings)
+            title, body, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
         assert title == "Analyze button not responding"
         assert "## Description" in body
+        assert labels == ["bug"]
+
+    async def test_ai_success_with_enhancement_label(self, settings):
+        req = FeedbackRequest(
+            description="Add export to CSV",
+        )
+        ai_response = json.dumps(
+            {
+                "title": "Add CSV export feature",
+                "body": "## Feature\n\nExport support.",
+                "labels": ["enhancement"],
+            }
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text=ai_response)
+            title, body, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert title == "Add CSV export feature"
+        assert labels == ["enhancement"]
 
     async def test_ai_failure_uses_fallback(self, settings):
         req = FeedbackRequest(
-            feedback_type="feature",
             description="Add export to CSV",
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=False, text="CLI error")
-            title, body = await format_feedback_with_ai(req, settings)
-        assert "Feature request:" in title
+            title, body, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert "Feedback:" in title
         assert "Add export to CSV" in body
+        assert labels == ["enhancement"]
 
     async def test_ai_returns_invalid_json_uses_fallback(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Something broke",
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text="not json at all")
-            title, _ = await format_feedback_with_ai(req, settings)
-        assert "Bug report:" in title
+            title, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert "Feedback:" in title
+        assert labels == ["enhancement"]
 
     async def test_ai_response_with_markdown_fences(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Error on page load",
         )
         ai_response = (
@@ -236,18 +258,21 @@ class TestFormatFeedbackWithAi:
                 {
                     "title": "Page load error",
                     "body": "## Bug\n\nPage fails to load.",
+                    "labels": ["bug"],
                 }
             )
             + "\n```"
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text=ai_response)
-            title, _ = await format_feedback_with_ai(req, settings)
+            title, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
         assert title == "Page load error"
+        assert labels == ["bug"]
 
     async def test_scrubs_sensitive_data_in_context(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Auth failed",
             console_errors=["Bearer my-secret-token-123"],
             failed_api_calls=[FailedApiCall(error="password=hunter2")],
@@ -262,11 +287,42 @@ class TestFormatFeedbackWithAi:
         with patch(
             "jenkins_job_insight.feedback.call_ai_cli", side_effect=capture_call
         ):
-            await format_feedback_with_ai(req, settings)
+            await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
 
         # Verify sensitive data was scrubbed in the prompt sent to AI
         assert "my-secret-token-123" not in captured_prompt
         assert "hunter2" not in captured_prompt
+
+    async def test_ai_returns_no_labels_defaults_to_enhancement(self, settings):
+        req = FeedbackRequest(
+            description="Some feedback",
+        )
+        ai_response = json.dumps(
+            {
+                "title": "Some title",
+                "body": "Some body",
+            }
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text=ai_response)
+            _, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert labels == ["enhancement"]
+
+    async def test_ai_exception_uses_fallback(self, settings):
+        req = FeedbackRequest(
+            description="Something broke",
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.side_effect = RuntimeError("AI down")
+            title, body, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert "Feedback:" in title
+        assert labels == ["enhancement"]
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +346,6 @@ class TestGenerateFeedbackPreview:
 
     async def test_bug_preview_returns_correct_labels(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Dashboard crashes",
         )
         with patch(
@@ -299,8 +354,11 @@ class TestGenerateFeedbackPreview:
             mock_format.return_value = (
                 "Dashboard crash on load",
                 "## Bug\n\nDetails...",
+                ["bug"],
             )
-            result = await generate_feedback_preview(req, settings)
+            result = await generate_feedback_preview(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
 
         assert isinstance(result, FeedbackPreviewResponse)
         assert result.title == "Dashboard crash on load"
@@ -309,7 +367,6 @@ class TestGenerateFeedbackPreview:
 
     async def test_feature_preview_returns_correct_labels(self, settings):
         req = FeedbackRequest(
-            feedback_type="feature",
             description="Add dark mode",
         )
         with patch(
@@ -318,8 +375,11 @@ class TestGenerateFeedbackPreview:
             mock_format.return_value = (
                 "Add dark mode support",
                 "## Feature\n\nDark mode...",
+                ["enhancement"],
             )
-            result = await generate_feedback_preview(req, settings)
+            result = await generate_feedback_preview(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
 
         assert isinstance(result, FeedbackPreviewResponse)
         assert result.title == "Add dark mode support"
@@ -421,7 +481,6 @@ class TestCreateFeedbackIssue:
 
     async def test_creates_bug_issue(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="Dashboard crashes",
         )
         with (
@@ -433,6 +492,7 @@ class TestCreateFeedbackIssue:
             mock_format.return_value = (
                 "Dashboard crash on load",
                 "## Bug\n\nDetails...",
+                ["bug"],
             )
             mock_create.return_value = {
                 "url": "https://github.com/myk-org/jenkins-job-insight/issues/42",
@@ -450,7 +510,6 @@ class TestCreateFeedbackIssue:
 
     async def test_creates_feature_issue_with_enhancement_label(self, settings):
         req = FeedbackRequest(
-            feedback_type="feature",
             description="Add dark mode",
         )
         with (
@@ -462,6 +521,7 @@ class TestCreateFeedbackIssue:
             mock_format.return_value = (
                 "Add dark mode support",
                 "## Feature\n\nDark mode...",
+                ["enhancement"],
             )
             mock_create.return_value = {
                 "url": "https://github.com/myk-org/jenkins-job-insight/issues/99",
@@ -475,7 +535,6 @@ class TestCreateFeedbackIssue:
 
     async def test_uses_correct_repo_url(self, settings):
         req = FeedbackRequest(
-            feedback_type="bug",
             description="test",
         )
         with (
@@ -484,7 +543,7 @@ class TestCreateFeedbackIssue:
             ) as mock_format,
             patch("jenkins_job_insight.feedback.create_github_issue") as mock_create,
         ):
-            mock_format.return_value = ("Title", "Body")
+            mock_format.return_value = ("Title", "Body", ["enhancement"])
             mock_create.return_value = {
                 "url": "https://github.com/x/y/issues/1",
                 "number": 1,
@@ -515,6 +574,8 @@ class TestFeedbackEndpoint:
         temp_db_path,
         github_token: str = "",
         enable_github_issues: str = "",
+        ai_provider: str = "claude",
+        ai_model: str = "test-model",
     ):
         """Create a TestClient with optional GITHUB_TOKEN."""
         env = {
@@ -527,6 +588,8 @@ class TestFeedbackEndpoint:
                 "JJI_ENCRYPTION_KEY",
                 "ALLOWED_USERS",
                 "ENABLE_GITHUB_ISSUES",
+                "AI_PROVIDER",
+                "AI_MODEL",
             }
         }
         env["SECURE_COOKIES"] = "false"
@@ -535,9 +598,19 @@ class TestFeedbackEndpoint:
             env["GITHUB_TOKEN"] = github_token
         if enable_github_issues:
             env["ENABLE_GITHUB_ISSUES"] = enable_github_issues
+        if ai_provider:
+            env["AI_PROVIDER"] = ai_provider
+        if ai_model:
+            env["AI_MODEL"] = ai_model
         with patch.dict(os.environ, env, clear=True):
             get_settings.cache_clear()
-            with patch.object(storage, "DB_PATH", temp_db_path):
+            import jenkins_job_insight.main as _main_mod
+
+            with (
+                patch.object(storage, "DB_PATH", temp_db_path),
+                patch.object(_main_mod, "AI_PROVIDER", ai_provider),
+                patch.object(_main_mod, "AI_MODEL", ai_model),
+            ):
                 from jenkins_job_insight.main import app
 
                 with TestClient(app) as c:
@@ -551,23 +624,37 @@ class TestFeedbackEndpoint:
             resp = client.post(
                 "/api/feedback/preview",
                 json={
-                    "feedback_type": "bug",
                     "description": "Something broke",
                 },
             )
             assert resp.status_code == 503
             assert "disabled" in resp.json()["detail"]
 
+    def test_preview_missing_ai_provider_returns_503(self, _init_db, temp_db_path):
+        for client in self._make_client(
+            temp_db_path,
+            github_token=_TEST_GITHUB_TOKEN,
+            ai_provider="",
+            ai_model="",
+        ):
+            resp = client.post(
+                "/api/feedback/preview",
+                json={
+                    "description": "Something broke",
+                },
+            )
+            assert resp.status_code == 503
+            assert "AI provider not configured" in resp.json()["detail"]
+
     def test_preview_successful(self, _init_db, temp_db_path):
         for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
             with patch(
                 "jenkins_job_insight.feedback.format_feedback_with_ai"
             ) as mock_format:
-                mock_format.return_value = ("Test title", "Test body")
+                mock_format.return_value = ("Test title", "Test body", ["bug"])
                 resp = client.post(
                     "/api/feedback/preview",
                     json={
-                        "feedback_type": "bug",
                         "description": "The button is broken",
                         "console_errors": ["TypeError: x is not a function"],
                     },
@@ -583,28 +670,20 @@ class TestFeedbackEndpoint:
             with patch(
                 "jenkins_job_insight.feedback.format_feedback_with_ai"
             ) as mock_format:
-                mock_format.return_value = ("Feature title", "Feature body")
+                mock_format.return_value = (
+                    "Feature title",
+                    "Feature body",
+                    ["enhancement"],
+                )
                 resp = client.post(
                     "/api/feedback/preview",
                     json={
-                        "feedback_type": "feature",
                         "description": "Add dark mode",
                     },
                 )
             assert resp.status_code == 200
             data = resp.json()
             assert data["labels"] == ["enhancement"]
-
-    def test_preview_invalid_feedback_type_returns_422(self, _init_db, temp_db_path):
-        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
-            resp = client.post(
-                "/api/feedback/preview",
-                json={
-                    "feedback_type": "invalid",
-                    "description": "Something",
-                },
-            )
-            assert resp.status_code == 422
 
     # -- Create endpoint tests ------------------------------------------------
 
@@ -695,7 +774,6 @@ class TestFeedbackEndpoint:
             resp = client.post(
                 "/api/feedback/preview",
                 json={
-                    "feedback_type": "bug",
                     "description": "Something broke",
                 },
             )

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -19,6 +19,8 @@ from jenkins_job_insight.feedback import (
 )
 from jenkins_job_insight.models import FeedbackRequest, FeedbackResponse
 
+_TEST_GITHUB_TOKEN = "test-token-placeholder"  # noqa: S105
+
 
 # ---------------------------------------------------------------------------
 # scrub_sensitive_data tests
@@ -212,7 +214,7 @@ class TestFormatFeedbackWithAi:
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text="not json at all")
-            title, body = await format_feedback_with_ai(req, settings)
+            title, _ = await format_feedback_with_ai(req, settings)
         assert "Bug report:" in title
 
     async def test_ai_response_with_markdown_fences(self, settings):
@@ -232,7 +234,7 @@ class TestFormatFeedbackWithAi:
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text=ai_response)
-            title, body = await format_feedback_with_ai(req, settings)
+            title, _ = await format_feedback_with_ai(req, settings)
         assert title == "Page load error"
 
     async def test_scrubs_sensitive_data_in_context(self, settings):
@@ -271,13 +273,24 @@ class TestCreateFeedbackIssue:
             "JENKINS_URL": "https://jenkins.example.com",
             "JENKINS_USER": "user",
             "JENKINS_PASSWORD": "pass",  # pragma: allowlist secret
-            "GITHUB_TOKEN": "test-token-placeholder",  # pragma: allowlist secret
+            "GITHUB_TOKEN": _TEST_GITHUB_TOKEN,
         }
         with patch.dict(os.environ, env, clear=True):
             get_settings.cache_clear()
             s = get_settings()
             get_settings.cache_clear()
             return s
+
+    @staticmethod
+    def _assert_create_issue_kwargs(mock_create, *, expected_labels=None):
+        """Extract and validate common call_args from create_github_issue mock."""
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs.get("repo_url") == _FEEDBACK_REPO_URL
+        assert call_kwargs.get("github_token") is not None
+        if expected_labels is not None:
+            assert call_kwargs.get("labels") == expected_labels
+        return call_kwargs
 
     async def test_creates_bug_issue(self, settings):
         req = FeedbackRequest(
@@ -306,12 +319,7 @@ class TestCreateFeedbackIssue:
         assert result.title == "Dashboard crash on load"
         assert "issues/42" in result.issue_url
 
-        # Verify correct label
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args
-        assert call_kwargs.kwargs.get("labels") == ["bug"] or call_kwargs[1].get(
-            "labels"
-        ) == ["bug"]
+        self._assert_create_issue_kwargs(mock_create, expected_labels=["bug"])
 
     async def test_creates_feature_issue_with_enhancement_label(self, settings):
         req = FeedbackRequest(
@@ -336,10 +344,7 @@ class TestCreateFeedbackIssue:
             result = await create_feedback_issue(req, settings)
 
         assert result.issue_number == 99
-        call_kwargs = mock_create.call_args
-        assert call_kwargs.kwargs.get("labels") == ["enhancement"] or call_kwargs[
-            1
-        ].get("labels") == ["enhancement"]
+        self._assert_create_issue_kwargs(mock_create, expected_labels=["enhancement"])
 
     async def test_uses_correct_repo_url(self, settings):
         req = FeedbackRequest(
@@ -360,11 +365,7 @@ class TestCreateFeedbackIssue:
             }
             await create_feedback_issue(req, settings)
 
-        call_kwargs = mock_create.call_args
-        assert (
-            call_kwargs.kwargs.get("repo_url") == _FEEDBACK_REPO_URL
-            or call_kwargs[1].get("repo_url") == _FEEDBACK_REPO_URL
-        )
+        self._assert_create_issue_kwargs(mock_create)
 
 
 # ---------------------------------------------------------------------------
@@ -429,9 +430,7 @@ class TestFeedbackEndpoint:
             assert "disabled" in resp.json()["detail"]
 
     def test_successful_feedback_submission(self, _init_db, temp_db_path):
-        for client in self._make_client(
-            temp_db_path, github_token="ghp_test"
-        ):  # pragma: allowlist secret
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
             with (
                 patch(
                     "jenkins_job_insight.feedback.format_feedback_with_ai"
@@ -461,9 +460,7 @@ class TestFeedbackEndpoint:
             assert "issues/10" in data["issue_url"]
 
     def test_invalid_feedback_type_returns_422(self, _init_db, temp_db_path):
-        for client in self._make_client(
-            temp_db_path, github_token="ghp_test"
-        ):  # pragma: allowlist secret
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
             resp = client.post(
                 "/api/feedback",
                 json={
@@ -474,9 +471,7 @@ class TestFeedbackEndpoint:
             assert resp.status_code == 422
 
     def test_capabilities_includes_feedback_enabled(self, _init_db, temp_db_path):
-        for client in self._make_client(
-            temp_db_path, github_token="ghp_test"
-        ):  # pragma: allowlist secret
+        for client in self._make_client(temp_db_path, github_token=_TEST_GITHUB_TOKEN):
             resp = client.get("/api/capabilities")
             assert resp.status_code == 200
             data = resp.json()
@@ -495,7 +490,7 @@ class TestFeedbackEndpoint:
     ):
         for client in self._make_client(
             temp_db_path,
-            github_token="ghp_test",  # pragma: allowlist secret
+            github_token=_TEST_GITHUB_TOKEN,
             enable_github_issues="false",
         ):
             resp = client.post(
@@ -513,7 +508,7 @@ class TestFeedbackEndpoint:
     ):
         for client in self._make_client(
             temp_db_path,
-            github_token="ghp_test",  # pragma: allowlist secret
+            github_token=_TEST_GITHUB_TOKEN,
             enable_github_issues="false",
         ):
             resp = client.get("/api/capabilities")

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -29,6 +29,10 @@ from jenkins_job_insight.models import (
 
 _TEST_GITHUB_TOKEN = "test-token-placeholder"  # noqa: S105
 
+_GITHUB_FOOTER_MARKER = (
+    "Generated using AI with [JJI](https://github.com/myk-org/jenkins-job-insight)"
+)
+
 
 # ---------------------------------------------------------------------------
 # scrub_sensitive_data tests
@@ -362,7 +366,7 @@ class TestGenerateFeedbackPreview:
 
         assert isinstance(result, FeedbackPreviewResponse)
         assert result.title == "Dashboard crash on load"
-        assert result.body == "## Bug\n\nDetails..."
+        assert _GITHUB_FOOTER_MARKER in result.body
         assert result.labels == ["bug"]
 
     async def test_feature_preview_returns_correct_labels(self, settings):
@@ -383,6 +387,7 @@ class TestGenerateFeedbackPreview:
 
         assert isinstance(result, FeedbackPreviewResponse)
         assert result.title == "Add dark mode support"
+        assert _GITHUB_FOOTER_MARKER in result.body
         assert result.labels == ["enhancement"]
 
 
@@ -662,7 +667,8 @@ class TestFeedbackEndpoint:
             assert resp.status_code == 200
             data = resp.json()
             assert data["title"] == "Test title"
-            assert data["body"] == "Test body"
+            assert "Test body" in data["body"]
+            assert _GITHUB_FOOTER_MARKER in data["body"]
             assert data["labels"] == ["bug"]
 
     def test_preview_feature_returns_enhancement_label(self, _init_db, temp_db_path):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -20,9 +20,11 @@ from jenkins_job_insight.feedback import (
     scrub_sensitive_data,
 )
 from jenkins_job_insight.models import (
+    FailedApiCall,
     FeedbackPreviewResponse,
     FeedbackRequest,
     FeedbackResponse,
+    PageState,
 )
 
 _TEST_GITHUB_TOKEN = "test-token-placeholder"  # noqa: S105
@@ -128,13 +130,13 @@ class TestBuildFallbackFeedback:
             description="Button does not work",
             console_errors=["TypeError: undefined is not a function"],
             failed_api_calls=[
-                {
-                    "status": 500,
-                    "endpoint": "/api/analyze",
-                    "error": "Internal Server Error",
-                }
+                FailedApiCall(
+                    status=500,
+                    endpoint="/api/analyze",
+                    error="Internal Server Error",
+                )
             ],
-            page_state={"url": "/report/123"},
+            page_state=PageState(url="/report/123"),
             user_agent="Mozilla/5.0",
         )
         title, body = _build_fallback_feedback(req)
@@ -248,7 +250,7 @@ class TestFormatFeedbackWithAi:
             feedback_type="bug",
             description="Auth failed",
             console_errors=["Bearer my-secret-token-123"],
-            failed_api_calls=[{"error": "password=hunter2"}],
+            failed_api_calls=[FailedApiCall(error="password=hunter2")],
         )
         captured_prompt = None
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -13,6 +13,8 @@ from jenkins_job_insight.config import get_settings
 from jenkins_job_insight.feedback import (
     _FEEDBACK_REPO_URL,
     _build_fallback_feedback,
+    _derive_fallback_labels,
+    _parse_json_response,
     create_feedback_from_preview,
     create_feedback_issue,
     format_feedback_with_ai,
@@ -170,6 +172,94 @@ class TestBuildFallbackFeedback:
 
 
 # ---------------------------------------------------------------------------
+# _derive_fallback_labels tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveFallbackLabels:
+    def test_enhancement_when_no_errors(self):
+        req = FeedbackRequest(description="Add dark mode")
+        assert _derive_fallback_labels(req) == ["enhancement"]
+
+    def test_bug_when_console_errors(self):
+        req = FeedbackRequest(
+            description="Page crashed",
+            console_errors=["TypeError: x is not a function"],
+        )
+        assert _derive_fallback_labels(req) == ["bug"]
+
+    def test_bug_when_failed_api_calls(self):
+        req = FeedbackRequest(
+            description="API broken",
+            failed_api_calls=[
+                FailedApiCall(status=500, endpoint="/api/x", error="err")
+            ],
+        )
+        assert _derive_fallback_labels(req) == ["bug"]
+
+    def test_bug_when_both_errors(self):
+        req = FeedbackRequest(
+            description="Everything broke",
+            console_errors=["err"],
+            failed_api_calls=[
+                FailedApiCall(status=500, endpoint="/api/x", error="err")
+            ],
+        )
+        assert _derive_fallback_labels(req) == ["bug"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_json_response tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonResponse:
+    def test_valid_response(self):
+        text = json.dumps({"title": "Bug report", "body": "Details here"})
+        result = _parse_json_response(text)
+        assert result == {"title": "Bug report", "body": "Details here"}
+
+    def test_empty_title_rejected(self):
+        text = json.dumps({"title": "", "body": "Details here"})
+        assert _parse_json_response(text) is None
+
+    def test_whitespace_title_rejected(self):
+        text = json.dumps({"title": "   ", "body": "Details here"})
+        assert _parse_json_response(text) is None
+
+    def test_empty_body_rejected(self):
+        text = json.dumps({"title": "Bug report", "body": ""})
+        assert _parse_json_response(text) is None
+
+    def test_whitespace_body_rejected(self):
+        text = json.dumps({"title": "Bug report", "body": "  \n  "})
+        assert _parse_json_response(text) is None
+
+    def test_non_string_title_rejected(self):
+        text = json.dumps({"title": 123, "body": "Details"})
+        assert _parse_json_response(text) is None
+
+    def test_non_string_body_rejected(self):
+        text = json.dumps({"title": "Bug", "body": ["line1"]})
+        assert _parse_json_response(text) is None
+
+    def test_null_title_rejected(self):
+        text = json.dumps({"title": None, "body": "Details"})
+        assert _parse_json_response(text) is None
+
+    def test_markdown_fences_stripped(self):
+        text = "```json\n" + json.dumps({"title": "T", "body": "B"}) + "\n```"
+        result = _parse_json_response(text)
+        assert result == {"title": "T", "body": "B"}
+
+    def test_invalid_json(self):
+        assert _parse_json_response("not json") is None
+
+    def test_missing_keys(self):
+        assert _parse_json_response(json.dumps({"title": "only title"})) is None
+
+
+# ---------------------------------------------------------------------------
 # format_feedback_with_ai tests
 # ---------------------------------------------------------------------------
 
@@ -221,7 +311,7 @@ class TestFormatFeedbackWithAi:
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.return_value = AIResult(success=True, text=ai_response)
-            title, body, labels = await format_feedback_with_ai(
+            title, _, labels = await format_feedback_with_ai(
                 req, settings, ai_provider="claude", ai_model="test-model"
             )
         assert title == "Add CSV export feature"
@@ -322,7 +412,44 @@ class TestFormatFeedbackWithAi:
         )
         with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
             mock_ai.side_effect = RuntimeError("AI down")
-            title, body, labels = await format_feedback_with_ai(
+            title, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert "Feedback:" in title
+        assert labels == ["enhancement"]
+
+    async def test_fallback_labels_bug_when_console_errors(self, settings):
+        req = FeedbackRequest(
+            description="Page crashed",
+            console_errors=["TypeError: x is not a function"],
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=False, text="fail")
+            _, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert labels == ["bug"]
+
+    async def test_fallback_labels_bug_when_failed_api_calls(self, settings):
+        req = FeedbackRequest(
+            description="API error",
+            failed_api_calls=[
+                FailedApiCall(status=500, endpoint="/api/x", error="err")
+            ],
+        )
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.side_effect = RuntimeError("AI down")
+            _, _, labels = await format_feedback_with_ai(
+                req, settings, ai_provider="claude", ai_model="test-model"
+            )
+        assert labels == ["bug"]
+
+    async def test_ai_returns_blank_title_uses_fallback(self, settings):
+        req = FeedbackRequest(description="Some feedback")
+        ai_response = json.dumps({"title": "", "body": "Details", "labels": ["bug"]})
+        with patch("jenkins_job_insight.feedback.call_ai_cli") as mock_ai:
+            mock_ai.return_value = AIResult(success=True, text=ai_response)
+            title, _, labels = await format_feedback_with_ai(
                 req, settings, ai_provider="claude", ai_model="test-model"
             )
         assert "Feedback:" in title
@@ -812,6 +939,18 @@ class TestFeedbackEndpoint:
             temp_db_path,
             github_token=_TEST_GITHUB_TOKEN,
             enable_github_issues="false",
+        ):
+            resp = client.get("/api/capabilities")
+            assert resp.status_code == 200
+            assert resp.json()["feedback_enabled"] is False
+
+    def test_capabilities_feedback_disabled_without_ai_provider(
+        self, _init_db, temp_db_path
+    ):
+        for client in self._make_client(
+            temp_db_path,
+            github_token=_TEST_GITHUB_TOKEN,
+            ai_provider="",
         ):
             resp = client.get("/api/capabilities")
             assert resp.status_code == 200

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 from jenkins_job_insight import storage
 from jenkins_job_insight.config import get_settings
 from jenkins_job_insight.feedback import (
-    _FEEDBACK_REPO_URL,
     _build_fallback_feedback,
     _derive_fallback_labels,
     _parse_json_response,
@@ -559,7 +558,9 @@ class TestCreateFeedbackFromPreview:
 
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs["repo_url"] == _FEEDBACK_REPO_URL
+        assert (
+            call_kwargs["repo_url"] == "https://github.com/myk-org/jenkins-job-insight"
+        )
         assert call_kwargs["labels"] == ["bug"]
 
     async def test_uses_correct_repo_url(self, settings):
@@ -577,7 +578,10 @@ class TestCreateFeedbackFromPreview:
             )
 
         mock_create.assert_called_once()
-        assert mock_create.call_args.kwargs["repo_url"] == _FEEDBACK_REPO_URL
+        assert (
+            mock_create.call_args.kwargs["repo_url"]
+            == "https://github.com/myk-org/jenkins-job-insight"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -605,7 +609,10 @@ class TestCreateFeedbackIssue:
         """Extract and validate common call_args from create_github_issue mock."""
         mock_create.assert_called_once()
         call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs.get("repo_url") == _FEEDBACK_REPO_URL
+        assert (
+            call_kwargs.get("repo_url")
+            == "https://github.com/myk-org/jenkins-job-insight"
+        )
         assert call_kwargs.get("github_token") is not None
         if expected_labels is not None:
             assert call_kwargs.get("labels") == expected_labels
@@ -951,6 +958,18 @@ class TestFeedbackEndpoint:
             temp_db_path,
             github_token=_TEST_GITHUB_TOKEN,
             ai_provider="",
+        ):
+            resp = client.get("/api/capabilities")
+            assert resp.status_code == 200
+            assert resp.json()["feedback_enabled"] is False
+
+    def test_capabilities_feedback_disabled_without_ai_model(
+        self, _init_db, temp_db_path
+    ):
+        for client in self._make_client(
+            temp_db_path,
+            github_token=_TEST_GITHUB_TOKEN,
+            ai_model="",
         ):
             resp = client.get("/api/capabilities")
             assert resp.status_code == 200


### PR DESCRIPTION
Closes #195

## Changes

### Backend
- New `feedback.py` module with sensitive data scrubbing and AI-powered issue formatting
- `POST /api/feedback` endpoint creates GitHub issues from user feedback
- `feedback_enabled` capability flag based on GITHUB_TOKEN availability
- Supports bug reports (with scrubbed logs) and feature requests

### Frontend
- New `FeedbackDialog` component with bug/feature request toggle
- Browser console error capture (`errorCapture.ts`)
- Failed API call tracking in `api.ts`
- Automatic page state, user agent collection
- Renamed NavBar button from "Report Bug" to "Feedback"

## Done
- [x] Button renamed to generic label covering bugs and feature requests
- [x] Popup dialog for natural language input (replaces GitHub redirect)
- [x] User can indicate bug vs feature request
- [x] AI processes input and creates formatted GitHub issue
- [x] Logs automatically attached for bug reports
- [x] Logs scrubbed for sensitive data before attachment
- [x] Frontend and backend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app feedback: capability‑gated "Feedback" button in the navbar opens a multi‑step dialog (preview, edit, create) and shows a "View issue" link on success.
  * Backend endpoints for feedback preview/create and a capability flag exposing feedback availability.
  * Global error capture and recent failed‑API tracking feed into previews; created issues include AI attribution footer.

* **Tests**
  * Extensive tests covering feedback flows, AI preview/create, error capture, and failed‑call tracking.

* **Chores**
  * Security allowlist updated to ignore two additional test/fixture files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->