### PR TITLE
fix: render actual newlines in code fix snippets instead of literal \n

### DIFF
--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -41,6 +41,18 @@ describe('unescapeCodeContent', () => {
   it('handles empty string', () => {
     expect(unescapeCodeContent('')).toBe('')
   })
+
+  it('preserves double-escaped \\\\n as literal backslash-n', () => {
+    expect(unescapeCodeContent('\\\\n')).toBe('\\n')
+  })
+
+  it('preserves double-escaped \\\\t as literal backslash-t', () => {
+    expect(unescapeCodeContent('\\\\t')).toBe('\\t')
+  })
+
+  it('handles mixed single and double-escaped sequences', () => {
+    expect(unescapeCodeContent('line1\\nline2\\\\nstill-line2')).toBe('line1\nline2\\nstill-line2')
+  })
 })
 
 describe('formatCost', () => {

--- a/frontend/src/lib/__tests__/format.test.ts
+++ b/frontend/src/lib/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatCompactNumber, formatCost } from '../format'
+import { formatCompactNumber, formatCost, unescapeCodeContent } from '../format'
 
 describe('formatCompactNumber', () => {
   it('returns plain number below 1000', () => {
@@ -17,6 +17,29 @@ describe('formatCompactNumber', () => {
     expect(formatCompactNumber(1_000_000)).toBe('1M')
     expect(formatCompactNumber(1_500_000)).toBe('1.5M')
     expect(formatCompactNumber(10_000_000)).toBe('10M')
+  })
+})
+
+describe('unescapeCodeContent', () => {
+  it('replaces literal \\n with actual newlines', () => {
+    expect(unescapeCodeContent('line1\\nline2\\nline3')).toBe('line1\nline2\nline3')
+  })
+
+  it('replaces literal \\t with actual tabs', () => {
+    expect(unescapeCodeContent('col1\\tcol2')).toBe('col1\tcol2')
+  })
+
+  it('handles mixed \\n and \\t', () => {
+    expect(unescapeCodeContent('if x:\\n\\treturn y')).toBe('if x:\n\treturn y')
+  })
+
+  it('returns unchanged text when no escape sequences present', () => {
+    const text = 'normal text with\nreal newlines'
+    expect(unescapeCodeContent(text)).toBe(text)
+  })
+
+  it('handles empty string', () => {
+    expect(unescapeCodeContent('')).toBe('')
   })
 })
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -11,6 +11,14 @@ export function formatCompactNumber(n: number): string {
   return String(n)
 }
 
+/**
+ * Unescape literal `\n` and `\t` sequences that backends sometimes embed
+ * in code-snippet strings, turning them into real newline / tab characters.
+ */
+export function unescapeCodeContent(text: string): string {
+  return text.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+}
+
 /** Format USD cost for display. Returns '$0.00' for null/zero/undefined. */
 export function formatCost(value: number | null | undefined): string {
   if (value == null || value === 0) return '$0.00'

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -16,7 +16,13 @@ export function formatCompactNumber(n: number): string {
  * in code-snippet strings, turning them into real newline / tab characters.
  */
 export function unescapeCodeContent(text: string): string {
-  return text.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+  return text.replace(/\\\\[nt]|\\[nt]/g, (match) => {
+    if (match === '\\n') return '\n'
+    if (match === '\\t') return '\t'
+    if (match === '\\\\n') return '\\n'
+    if (match === '\\\\t') return '\\t'
+    return match
+  })
 }
 
 /** Format USD cost for display. Returns '$0.00' for null/zero/undefined. */

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -7,6 +7,7 @@ import { isCommentInScope } from '@/lib/grouping'
 import { api } from '@/lib/api'
 import { getUsername } from '@/lib/cookies'
 import { useSessionState } from '@/lib/useSessionState'
+import { unescapeCodeContent } from '@/lib/format'
 import { useReportState, useReportDispatch, reviewKey } from './ReportContext'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -61,7 +62,7 @@ function CopyableSectionHeader({ title, content, sectionId, copiedSection, onCop
   )
 }
 
-function CodeFixLiteralBlock({
+export function CodeFixLiteralBlock({
   title,
   content,
   className,
@@ -70,11 +71,12 @@ function CodeFixLiteralBlock({
   content: string
   className: string
 }) {
+  const unescaped = unescapeCodeContent(content)
   return (
     <div className="mt-2">
       <p className="text-xs font-display uppercase tracking-widest text-text-tertiary mb-1">{title}</p>
       <pre className={`overflow-x-auto max-h-96 overflow-y-auto rounded bg-surface-elevated p-2 text-xs font-mono whitespace-pre-wrap ${className}`}>
-        {content}
+        {unescaped}
       </pre>
     </div>
   )
@@ -340,8 +342,8 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   content={[
                     analysis.code_fix?.file ? `${analysis.code_fix.file}${analysis.code_fix.line ? `:${analysis.code_fix.line}` : ''}` : '',
                     analysis.code_fix?.change ?? '',
-                    analysis.code_fix.original_code != null ? `Original Code:\n${analysis.code_fix.original_code}` : '',
-                    analysis.code_fix.suggested_code != null ? `Suggested Code:\n${analysis.code_fix.suggested_code}` : '',
+                    analysis.code_fix.original_code != null ? `Original Code:\n${unescapeCodeContent(analysis.code_fix.original_code)}` : '',
+                    analysis.code_fix.suggested_code != null ? `Suggested Code:\n${unescapeCodeContent(analysis.code_fix.suggested_code)}` : '',
                   ].filter(Boolean).join('\n\n')}
                   sectionId="suggested_fix"
                   copiedSection={copiedSection}

--- a/frontend/src/pages/report/__tests__/CodeFixLiteralBlock.test.tsx
+++ b/frontend/src/pages/report/__tests__/CodeFixLiteralBlock.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CodeFixLiteralBlock } from '../FailureCard'
+
+describe('CodeFixLiteralBlock', () => {
+  it('renders actual newlines from literal \\n sequences', () => {
+    render(
+      <CodeFixLiteralBlock
+        title="Test Code"
+        content={'line1\\nline2\\nline3'}
+        className="text-green"
+      />,
+    )
+    const pre = screen.getByText(/line1/)
+    expect(pre.textContent).toBe('line1\nline2\nline3')
+  })
+
+  it('renders actual tabs from literal \\t sequences', () => {
+    render(
+      <CodeFixLiteralBlock
+        title="Test Code"
+        content={'if x:\\n\\treturn y'}
+        className="text-green"
+      />,
+    )
+    const pre = screen.getByText(/if x:/)
+    expect(pre.textContent).toBe('if x:\n\treturn y')
+  })
+
+  it('renders content unchanged when no escape sequences', () => {
+    const content = 'normal code content'
+    render(
+      <CodeFixLiteralBlock
+        title="Test Code"
+        content={content}
+        className="text-green"
+      />,
+    )
+    expect(screen.getByText(content)).toBeTruthy()
+  })
+
+  it('renders section title', () => {
+    render(
+      <CodeFixLiteralBlock
+        title="Original Code"
+        content="some code"
+        className="text-green"
+      />,
+    )
+    expect(screen.getByText('Original Code')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes #202

## Problem
The "Suggested Fix" section's "Original Code" and "Suggested Code" snippets displayed `\n` as literal text instead of rendering actual line breaks, making multi-line code unreadable.

## Fix
- Added `unescapeCodeContent()` utility to convert escaped `\n` and `\t` sequences to actual characters
- Applied unescaping in `CodeFixLiteralBlock` rendering and clipboard copy
- Added unit and component tests

## Done
- [x] Investigated where `\n` escaping occurs
- [x] Fixed rendering so newlines display as actual line breaks
- [x] Both "Original Code" and "Suggested Code" blocks render correctly
- [x] Clipboard copy also unescapes content
- [x] Frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code snippets in failure reports now display with proper formatting, converting escape sequences into actual line breaks and indentation.
  * Copy-to-clipboard for suggested fixes now preserves that formatting when pasted.

* **Tests**
  * New unit tests verify unescaping behavior for literal escape sequences, plain text, and mixed cases to ensure displayed and copied output match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->