### PR TITLE
feat: allow choosing Jira issue type and rename to Jira Ticket

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -25,8 +25,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideCloseButton?: boolean }
+>(({ className, children, hideCloseButton, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -38,10 +38,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-surface-card transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-border-accent focus:ring-offset-2 disabled:pointer-events-none">
-        <X className="h-4 w-4 text-text-secondary" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-surface-card transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-border-accent focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4 text-text-secondary" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -180,9 +180,9 @@ export function BugCreationDialog({
     }
   }
 
-  function handleClose(nextOpen: boolean) {
-    if (nextOpen) return
-    onOpenChange(false)
+  const isBusy = phase === 'loading' || phase === 'preview' || phase === 'creating'
+
+  function resetState() {
     setTimeout(() => {
       setPhase('idle')
       setTitle('')
@@ -203,9 +203,21 @@ export function BugCreationDialog({
     }, 200)
   }
 
+  function handleCancel() {
+    onOpenChange(false)
+    resetState()
+  }
+
+  function handleClose(nextOpen: boolean) {
+    if (!nextOpen && isBusy) return
+    if (nextOpen) return
+    onOpenChange(false)
+    resetState()
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+      <DialogContent hideCloseButton={isBusy} className="max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{phase === 'success' ? `${label} Created` : `Create ${label}`}</DialogTitle>
           {phase === 'preview' && <DialogDescription>Review and edit before creating.</DialogDescription>}
@@ -431,13 +443,13 @@ export function BugCreationDialog({
                 <p className="text-xs text-text-tertiary">Add a {target === 'github' ? 'GitHub' : 'Jira'} token in <a href="/settings" className="text-text-link hover:underline">settings</a> to create directly.</p>
               )}
               <div className="flex gap-2 sm:ml-auto">
-                <Button variant="ghost" onClick={() => handleClose(false)}>Cancel</Button>
+                <Button variant="outline" onClick={() => handleCancel()}>Cancel</Button>
                 <Button onClick={handleCreate} disabled={!title.trim() || !hasToken} title={!hasToken ? `Add a ${target === 'github' ? 'GitHub' : 'Jira'} token to create issues` : undefined}>Create {label}</Button>
               </div>
             </>
           )}
           {(phase === 'success' || phase === 'error') && (
-            <Button variant="ghost" onClick={() => handleClose(false)} className="sm:ml-auto">Close</Button>
+            <Button variant="outline" onClick={() => handleCancel()} className="sm:ml-auto">Close</Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -444,7 +444,7 @@ export function BugCreationDialog({
               )}
               <div className="flex gap-2 sm:ml-auto">
                 <Button variant="outline" onClick={() => handleCancel()}>Cancel</Button>
-                <Button onClick={handleCreate} disabled={!title.trim() || !hasToken} title={!hasToken ? `Add a ${target === 'github' ? 'GitHub' : 'Jira'} token to create issues` : undefined}>Create {label}</Button>
+                <Button onClick={handleCreate} disabled={!title.trim() || !hasToken || (target === 'jira' && jiraIssueType === '__custom__' && !customIssueType.trim())} title={!hasToken ? `Add a ${target === 'github' ? 'GitHub' : 'Jira'} token to create issues` : undefined}>Create {label}</Button>
               </div>
             </>
           )}

--- a/frontend/src/pages/report/BugCreationDialog.tsx
+++ b/frontend/src/pages/report/BugCreationDialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { CheckCircle2, ExternalLink, AlertTriangle } from 'lucide-react'
 import type { PreviewIssueResponse, CreateIssueResponse, SimilarIssue, CommentsAndReviews } from '@/types'
@@ -66,10 +67,14 @@ export function BugCreationDialog({
   const [showProjectDropdown, setShowProjectDropdown] = useState(false)
   const [showSecurityDropdown, setShowSecurityDropdown] = useState(false)
   const [securityLevels, setSecurityLevels] = useState<Array<{id: string; name: string; description: string}>>([])
+  const [jiraIssueType, setJiraIssueType] = useState('Bug')
+  const [customIssueType, setCustomIssueType] = useState('')
+
+  const JIRA_ISSUE_TYPES = ['Bug', 'Task', 'Story', 'Epic', 'Sub-task']
 
   const previewPath = target === 'github' ? 'preview-github-issue' : 'preview-jira-bug'
   const createPath = target === 'github' ? 'create-github-issue' : 'create-jira-bug'
-  const label = target === 'github' ? 'GitHub Issue' : 'Jira Bug'
+  const label = target === 'github' ? 'GitHub Issue' : 'Jira Ticket'
   const hasToken = target === 'github' ? !!getGithubToken() : !!getJiraToken()
 
   function getTrackerCredentials() {
@@ -80,6 +85,7 @@ export function BugCreationDialog({
       ...(target === 'github' && selectedRepo ? { github_repo_url: selectedRepo } : {}),
       ...(target === 'jira' && jiraProjectKey ? { jira_project_key: jiraProjectKey } : {}),
       ...(target === 'jira' && jiraSecurityLevel ? { jira_security_level: jiraSecurityLevel } : {}),
+      ...(target === 'jira' ? { jira_issue_type: jiraIssueType === '__custom__' ? customIssueType : jiraIssueType } : {}),
     }
   }
 
@@ -192,6 +198,8 @@ export function BugCreationDialog({
       setSecurityLevels([])
       setShowProjectDropdown(false)
       setShowSecurityDropdown(false)
+      setJiraIssueType('Bug')
+      setCustomIssueType('')
     }, 200)
   }
 
@@ -269,6 +277,32 @@ export function BugCreationDialog({
                     </div>
                   )}
                 </div>
+              </div>
+            )}
+            {target === 'jira' && (
+              <div className="space-y-2">
+                <label htmlFor="bug-jira-issue-type" className="text-xs font-display uppercase tracking-widest text-text-tertiary">Issue Type</label>
+                <Select value={jiraIssueType} onValueChange={setJiraIssueType}>
+                  <SelectTrigger id="bug-jira-issue-type" className="w-full">
+                    <SelectValue placeholder="Select issue type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {JIRA_ISSUE_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>{t}</SelectItem>
+                    ))}
+                    <SelectItem value="__custom__">Custom...</SelectItem>
+                  </SelectContent>
+                </Select>
+                {jiraIssueType === '__custom__' && (
+                  <input
+                    type="text"
+                    value={customIssueType}
+                    onChange={(e) => setCustomIssueType(e.target.value)}
+                    placeholder="Enter custom issue type..."
+                    autoComplete="off"
+                    className="w-full h-9 rounded-md border border-border-default bg-surface-elevated px-2 text-sm text-text-primary placeholder:text-text-tertiary mt-1"
+                  />
+                )}
               </div>
             )}
             {target === 'jira' && (

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -479,7 +479,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
               <IssueButton
                 disabled={!jiraIssuesEnabled}
                 tooltip={!jiraIssuesEnabled ? 'Jira issues are disabled on this server' : undefined}
-                label="Jira Bug"
+                label="Jira Ticket"
                 onClick={() => setBugTarget('jira')}
               />
             </div>

--- a/src/jenkins_job_insight/bug_creation.py
+++ b/src/jenkins_job_insight/bug_creation.py
@@ -675,12 +675,16 @@ async def create_jira_bug(
     else:
         api_path = "/rest/api/2"
 
+    effective_issue_type = issue_type.strip() if issue_type else "Bug"
+    if not effective_issue_type:
+        effective_issue_type = "Bug"
+
     payload: dict = {
         "fields": {
             "project": {"key": effective_project_key},
             "summary": title,
             "description": body,
-            "issuetype": {"name": issue_type},
+            "issuetype": {"name": effective_issue_type},
         }
     }
     if priority:

--- a/src/jenkins_job_insight/bug_creation.py
+++ b/src/jenkins_job_insight/bug_creation.py
@@ -642,6 +642,7 @@ async def create_jira_bug(
     priority: str = "",
     project_key: str = "",
     security_level: str = "",
+    issue_type: str = "Bug",
 ) -> dict:
     """Create a Jira Bug issue via the REST API.
 
@@ -679,7 +680,7 @@ async def create_jira_bug(
             "project": {"key": effective_project_key},
             "summary": title,
             "description": body,
-            "issuetype": {"name": "Bug"},
+            "issuetype": {"name": issue_type},
         }
     }
     if priority:

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -558,6 +558,7 @@ class JJIClient:
         jira_email: str = "",
         jira_project_key: str = "",
         jira_security_level: str = "",
+        jira_issue_type: str = "Bug",
     ) -> dict:
         """Create a Jira bug. POST /results/{job_id}/create-jira-bug"""
         payload = self._build_tracker_body(
@@ -572,6 +573,8 @@ class JJIClient:
             jira_security_level=jira_security_level,
             include_github=False,
         )
+        if jira_issue_type and jira_issue_type != "Bug":
+            payload["jira_issue_type"] = jira_issue_type
         return self._request(
             "POST",
             f"/results/{job_id}/create-jira-bug",

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1652,6 +1652,11 @@ def create_issue(
         "--jira-security-level",
         help="Jira security level name for restricted issues.",
     ),
+    jira_issue_type: str = typer.Option(
+        "Bug",
+        "--jira-issue-type",
+        help="Jira issue type name (e.g. Bug, Story, Task). Default: Bug.",
+    ),
     json_output: bool = _JSON_OPTION,
 ):
     """Create a GitHub issue or Jira bug from a failure analysis."""
@@ -1697,6 +1702,7 @@ def create_issue(
                 jira_email=_jira_email,
                 jira_project_key=_jira_project_key,
                 jira_security_level=_jira_security_level,
+                jira_issue_type=jira_issue_type,
             )
     except JJIError as err:
         _handle_error(err)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -2902,6 +2902,7 @@ async def create_jira_bug_endpoint(
             settings=effective_jira_settings,
             project_key=body.jira_project_key,
             security_level=body.jira_security_level,
+            issue_type=body.jira_issue_type,
         )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code in (401, 403):

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -648,6 +648,12 @@ class CreateIssueRequest(_ChildJobFieldsValidator, _TrackerCredentialsMixin):
         default="Bug", description="Jira issue type name (e.g. Bug, Story, Task)"
     )
 
+    @field_validator("jira_issue_type")
+    @classmethod
+    def jira_issue_type_not_empty(cls, v: str) -> str:
+        stripped = v.strip()
+        return stripped if stripped else "Bug"
+
     @field_validator("title")
     @classmethod
     def title_not_empty(cls, v: str) -> str:

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -644,6 +644,9 @@ class CreateIssueRequest(_ChildJobFieldsValidator, _TrackerCredentialsMixin):
     test_name: str
     title: str
     body: str
+    jira_issue_type: str = Field(
+        default="Bug", description="Jira issue type name (e.g. Bug, Story, Task)"
+    )
 
     @field_validator("title")
     @classmethod

--- a/tests/test_bug_creation.py
+++ b/tests/test_bug_creation.py
@@ -9,6 +9,7 @@ from ai_cli_runner import AIResult
 from jenkins_job_insight.models import (
     AnalysisDetail,
     CodeFix,
+    CreateIssueRequest,
     FailureAnalysis,
     ProductBugReport,
 )
@@ -352,6 +353,81 @@ class TestCreateJiraBug:
             )
             assert result["key"] == "PROJ-789"
 
+    async def test_creates_bug_with_custom_issue_type(self):
+        """Test creating a Jira issue with a custom issue type."""
+        from jenkins_job_insight.bug_creation import create_jira_bug
+
+        mock_settings = MagicMock()
+        mock_settings.jira_url = "https://jira.example.com"
+        mock_settings.jira_project_key = "PROJ"
+        mock_settings.jira_email = "test@example.com"
+        mock_settings.jira_api_token = MagicMock()
+        mock_settings.jira_api_token.get_secret_value.return_value = "token123"
+        mock_settings.jira_pat = None
+        mock_settings.jira_ssl_verify = True
+
+        mock_response = httpx.Response(
+            201,
+            json={"key": "PROJ-999"},
+            request=_mock_request(),
+        )
+        with patch("jenkins_job_insight.bug_creation.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await create_jira_bug(
+                title="Story title",
+                body="Story description",
+                settings=mock_settings,
+                issue_type="Story",
+            )
+            assert result["key"] == "PROJ-999"
+
+            # Verify the payload sent to Jira uses the custom issue type
+            call_args = mock_client.post.call_args
+            payload = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert payload["fields"]["issuetype"] == {"name": "Story"}
+
+    async def test_creates_bug_default_issue_type(self):
+        """Test that default issue type is 'Bug' when not specified."""
+        from jenkins_job_insight.bug_creation import create_jira_bug
+
+        mock_settings = MagicMock()
+        mock_settings.jira_url = "https://jira.example.com"
+        mock_settings.jira_project_key = "PROJ"
+        mock_settings.jira_email = "test@example.com"
+        mock_settings.jira_api_token = MagicMock()
+        mock_settings.jira_api_token.get_secret_value.return_value = "token123"
+        mock_settings.jira_pat = None
+        mock_settings.jira_ssl_verify = True
+
+        mock_response = httpx.Response(
+            201,
+            json={"key": "PROJ-100"},
+            request=_mock_request(),
+        )
+        with patch("jenkins_job_insight.bug_creation.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await create_jira_bug(
+                title="Bug title",
+                body="Bug description",
+                settings=mock_settings,
+            )
+            assert result["key"] == "PROJ-100"
+
+            # Verify the payload uses default 'Bug' issue type
+            call_args = mock_client.post.call_args
+            payload = call_args.kwargs.get("json") or call_args[1].get("json")
+            assert payload["fields"]["issuetype"] == {"name": "Bug"}
+
 
 class TestParseGithubRepoUrl:
     def test_standard_url(self):
@@ -425,3 +501,33 @@ class TestBuildFailbackContent:
         ctx = _build_failure_context(code_issue_failure)
         result = _build_fallback_github_content(ctx, "", "")
         assert "test_valid_credentials" in result["title"]
+
+
+class TestCreateIssueRequestJiraIssueType:
+    """Tests for the jira_issue_type field on CreateIssueRequest."""
+
+    def test_default_issue_type_is_bug(self):
+        req = CreateIssueRequest(
+            test_name="test_foo",
+            title="title",
+            body="body",
+        )
+        assert req.jira_issue_type == "Bug"
+
+    def test_custom_issue_type(self):
+        req = CreateIssueRequest(
+            test_name="test_foo",
+            title="title",
+            body="body",
+            jira_issue_type="Story",
+        )
+        assert req.jira_issue_type == "Story"
+
+    def test_issue_type_task(self):
+        req = CreateIssueRequest(
+            test_name="test_foo",
+            title="title",
+            body="body",
+            jira_issue_type="Task",
+        )
+        assert req.jira_issue_type == "Task"


### PR DESCRIPTION
Closes #205

## Changes

### Backend
- Added `jira_issue_type` field to `CreateIssueRequest` (default: "Bug")
- `create_jira_bug()` now accepts `issue_type` parameter instead of hardcoding "Bug"
- Endpoint passes `issue_type=body.jira_issue_type` to the function
- CLI: added `--jira-issue-type` option

### Frontend
- Renamed "Jira Bug" → "Jira Ticket" in button labels
- Added issue type dropdown in BugCreationDialog (Bug, Task, Story, Epic, Sub-task, Custom)
- Custom option reveals a free-text input for arbitrary Jira issue types
- `jira_issue_type` included in create request body

## Done
- [x] Renamed button from "Jira Bug" to "Jira Ticket"
- [x] Issue type dropdown with common types + custom option
- [x] Backend accepts and passes through issue_type
- [x] CLI parity with --jira-issue-type
- [x] Tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jira issue type selection when creating tickets (supports Bug, Story, Task, and custom types).
  * CLI option to specify Jira issue type for ticket creation.

* **Improvements**
  * Renamed ticket action from "Jira Bug" to "Jira Ticket."
  * Dialog now hides close/cancel while creation is in progress and prevents accidental closure.
  * Create button disabled until a custom issue type is provided when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->