### PR TITLE
feat: add New Analysis page with shared form components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { TestHistoryPage } from '@/pages/TestHistoryPage'
 import { UsersPage } from '@/pages/UsersPage'
 import { TokenUsagePage } from '@/pages/TokenUsagePage'
 import { MentionsPage } from '@/pages/MentionsPage'
+import { NewAnalysisPage } from '@/pages/NewAnalysisPage'
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
           <Route element={<Layout />}>
             <Route index element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
             <Route path="/dashboard" element={<Navigate to="/" replace />} />
+            <Route path="/new-analysis" element={<ProtectedRoute><NewAnalysisPage /></ProtectedRoute>} />
             <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
             <Route path="/history/test/:testName" element={<ProtectedRoute><TestHistoryPage /></ProtectedRoute>} />
             <Route path="/mentions" element={<ProtectedRoute><MentionsPage /></ProtectedRoute>} />

--- a/frontend/src/components/shared/FieldLabel.tsx
+++ b/frontend/src/components/shared/FieldLabel.tsx
@@ -1,0 +1,3 @@
+export function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <label className="text-xs text-text-tertiary">{children}</label>
+}

--- a/frontend/src/components/shared/FieldLabel.tsx
+++ b/frontend/src/components/shared/FieldLabel.tsx
@@ -1,3 +1,3 @@
-export function FieldLabel({ children }: { children: React.ReactNode }) {
-  return <label className="text-xs text-text-tertiary">{children}</label>
+export function FieldLabel({ htmlFor, children }: { htmlFor?: string; children: React.ReactNode }) {
+  return <label htmlFor={htmlFor} className="text-xs text-text-tertiary">{children}</label>
 }

--- a/frontend/src/components/shared/Section.tsx
+++ b/frontend/src/components/shared/Section.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { ChevronRight } from 'lucide-react'
+
+export function Section({
+  title,
+  dotColor,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  dotColor: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-2 py-2 text-left group"
+      >
+        <ChevronRight
+          className={`h-3 w-3 text-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
+        />
+        <span className={`w-1.5 h-1.5 rounded-full ${dotColor} flex-shrink-0`} />
+        <span className="font-display text-[11px] font-semibold tracking-widest text-text-secondary uppercase">
+          {title}
+        </span>
+      </button>
+      {open && <div className="pl-5 space-y-4 pb-4">{children}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/Section.tsx
+++ b/frontend/src/components/shared/Section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 
 export function Section({
@@ -13,11 +13,15 @@ export function Section({
   children: React.ReactNode
 }) {
   const [open, setOpen] = useState(defaultOpen)
+  const id = useId()
+  const contentId = `${id}-content`
   return (
     <div>
       <button
         type="button"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-controls={contentId}
         className="w-full flex items-center gap-2 py-2 text-left group"
       >
         <ChevronRight
@@ -28,7 +32,7 @@ export function Section({
           {title}
         </span>
       </button>
-      {open && <div className="pl-5 space-y-4 pb-4">{children}</div>}
+      {open && <div id={contentId} className="pl-5 space-y-4 pb-4">{children}</div>}
     </div>
   )
 }

--- a/frontend/src/components/shared/Toggle.tsx
+++ b/frontend/src/components/shared/Toggle.tsx
@@ -1,0 +1,20 @@
+export function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label: string }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative w-11 h-6 rounded-full transition-colors ${
+        checked ? 'bg-signal-blue' : 'bg-surface-hover'
+      }`}
+    >
+      <span
+        className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-5' : ''
+        }`}
+      />
+    </button>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -35,7 +35,7 @@ import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
 import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
 import { useTableSort } from '@/lib/useTableSort'
-import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } from 'lucide-react'
+import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github, Plus } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 import { useMetadataOptions, MetadataDropdowns, MetadataLabelChips, MetadataClearButton } from '@/components/shared/MetadataFilterBar'
 import { MetadataBadges } from '@/components/shared/MetadataBadges'
@@ -446,6 +446,10 @@ export function DashboardPage() {
               </SelectContent>
             </Select>
             <MetadataClearButton hasFilters={hasMetadataFilters} onClearAll={clearMetadataFilters} />
+            <Button onClick={() => navigate('/new-analysis')} className="gap-1.5 whitespace-nowrap">
+              <Plus className="h-3.5 w-3.5" />
+              New Analysis
+            </Button>
           </div>
         </div>
 

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -16,6 +16,12 @@ import { Toggle } from '@/components/shared/Toggle'
 import { FieldLabel } from '@/components/shared/FieldLabel'
 import { Plus, Trash2, Send, Upload } from 'lucide-react'
 
+function toIntInRange(value: string, min: number, max: number, fallback: number): number {
+  const n = Number(value)
+  if (!value || Number.isNaN(n)) return fallback
+  return Math.max(min, Math.min(max, Math.floor(n)))
+}
+
 export function NewAnalysisPage() {
   const navigate = useNavigate()
 
@@ -222,7 +228,7 @@ export function NewAnalysisPage() {
                   min={1}
                   placeholder="123"
                   value={buildNumber}
-                  onChange={(e) => setBuildNumber(e.target.value ? Number(e.target.value) : '')}
+                  onChange={(e) => setBuildNumber(e.target.value ? toIntInRange(e.target.value, 1, Number.MAX_SAFE_INTEGER, 1) : '')}
                   required
                 />
               </div>
@@ -266,7 +272,7 @@ export function NewAnalysisPage() {
                     type="number"
                     min={1}
                     value={pollInterval}
-                    onChange={(e) => setPollInterval(Number(e.target.value) || 1)}
+                    onChange={(e) => setPollInterval(toIntInRange(e.target.value, 1, 1440, 1))}
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -275,7 +281,7 @@ export function NewAnalysisPage() {
                     type="number"
                     min={0}
                     value={maxWait}
-                    onChange={(e) => setMaxWait(Number(e.target.value) || 0)}
+                    onChange={(e) => setMaxWait(toIntInRange(e.target.value, 0, 1440, 0))}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -119,13 +119,12 @@ export function NewAnalysisPage() {
           ? peerConfigs.map(({ ai_provider, ai_model }) => ({ ai_provider, ai_model }))
           : [],
         peer_analysis_max_rounds: maxRounds,
-        additional_repos: additionalRepos
-          .filter((r) => r.name && r.url)
-          .map((r) => ({
-            name: r.name,
-            url: r.url,
-            ...(r.ref && { ref: r.ref }),
-          })),
+        ...(() => {
+          const validRepos = additionalRepos
+            .filter((r) => r.name.trim() && r.url.trim())
+            .map((r) => ({ name: r.name.trim(), url: r.url.trim(), ...(r.ref.trim() && { ref: r.ref.trim() }) }))
+          return validRepos.length > 0 ? { additional_repos: validRepos } : {}
+        })(),
       }
 
       if (inputMode === 'jenkins') {

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -50,14 +50,14 @@ export function NewAnalysisPage() {
 
   // Peer analysis
   const [enablePeers, setEnablePeers] = useState(false)
-  const [peerConfigs, setPeerConfigs] = useState<AiConfig[]>([])
+  const [peerConfigs, setPeerConfigs] = useState<Array<AiConfig & { id: string }>>([])
   const [maxRounds, setMaxRounds] = useState(3)
 
   // Source repositories
   const [testsRepoUrl, setTestsRepoUrl] = useState('')
   const [testsRepoRef, setTestsRepoRef] = useState('')
   const [additionalRepos, setAdditionalRepos] = useState<
-    Array<{ name: string; url: string; ref: string }>
+    Array<{ id: string; name: string; url: string; ref: string }>
   >([])
 
   // Jira integration
@@ -69,6 +69,8 @@ export function NewAnalysisPage() {
   const [force, setForce] = useState(false)
   const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(undefined)
   const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(undefined)
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -87,6 +89,9 @@ export function NewAnalysisPage() {
         setUploadFileName(file.name)
       }
     }
+    reader.onerror = () => {
+      setError(`Failed to read file: ${file.name}`)
+    }
     reader.readAsText(file)
   }, [])
 
@@ -104,7 +109,9 @@ export function NewAnalysisPage() {
         ...(jiraUrl && { jira_url: jiraUrl }),
         ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
         ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
-        peer_ai_configs: enablePeers ? peerConfigs : [],
+        peer_ai_configs: enablePeers
+          ? peerConfigs.map(({ ai_provider, ai_model }) => ({ ai_provider, ai_model }))
+          : [],
         peer_analysis_max_rounds: maxRounds,
         additional_repos: additionalRepos
           .filter((r) => r.name && r.url)
@@ -316,7 +323,7 @@ export function NewAnalysisPage() {
                 const file = e.dataTransfer.files[0]
                 if (file && file.name.endsWith('.xml')) handleFileUpload(file)
               }}
-              onClick={() => document.getElementById('xml-file-input')?.click()}
+              onClick={() => fileInputRef.current?.click()}
             >
               <Upload className="h-8 w-8 text-text-tertiary mb-2" />
               <p className="text-sm text-text-secondary">
@@ -331,7 +338,7 @@ export function NewAnalysisPage() {
                 </p>
               )}
               <input
-                id="xml-file-input"
+                ref={fileInputRef}
                 type="file"
                 accept=".xml"
                 className="hidden"
@@ -405,16 +412,16 @@ export function NewAnalysisPage() {
                 <div className="space-y-2">
                   {peerConfigs.map((peer, i) => (
                     <div
-                      key={i}
+                      key={peer.id}
                       className="bg-surface-elevated border border-border-default rounded-lg p-2.5 flex items-center gap-2"
                     >
                       <Select
                         value={peer.ai_provider}
-                        onValueChange={(v) => {
-                          const next = [...peerConfigs]
-                          next[i] = { ...next[i], ai_provider: v }
-                          setPeerConfigs(next)
-                        }}
+                        onValueChange={(v) =>
+                          setPeerConfigs((prev) =>
+                            prev.map((p) => (p.id === peer.id ? { ...p, ai_provider: v } : p))
+                          )
+                        }
                       >
                         <SelectTrigger className="w-[120px]">
                           <SelectValue />
@@ -429,16 +436,18 @@ export function NewAnalysisPage() {
                         className="flex-1"
                         placeholder="Model"
                         value={peer.ai_model}
-                        onChange={(e) => {
-                          const next = [...peerConfigs]
-                          next[i] = { ...next[i], ai_model: e.target.value }
-                          setPeerConfigs(next)
-                        }}
+                        onChange={(e) =>
+                          setPeerConfigs((prev) =>
+                            prev.map((p) =>
+                              p.id === peer.id ? { ...p, ai_model: e.target.value } : p
+                            )
+                          )
+                        }
                       />
                       <button
                         type="button"
                         className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
-                        onClick={() => setPeerConfigs(peerConfigs.filter((_, j) => j !== i))}
+                        onClick={() => setPeerConfigs((prev) => prev.filter((p) => p.id !== peer.id))}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
@@ -449,7 +458,10 @@ export function NewAnalysisPage() {
                   type="button"
                   className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
                   onClick={() =>
-                    setPeerConfigs([...peerConfigs, { ai_provider: 'claude', ai_model: '' }])
+                    setPeerConfigs((prev) => [
+                      ...prev,
+                      { id: crypto.randomUUID(), ai_provider: 'claude', ai_model: '' },
+                    ])
                   }
                 >
                   <Plus className="h-3.5 w-3.5" />
@@ -462,7 +474,7 @@ export function NewAnalysisPage() {
                     min={1}
                     max={10}
                     value={maxRounds}
-                    onChange={(e) => setMaxRounds(Number(e.target.value) || 1)}
+                    onChange={(e) => setMaxRounds(toIntInRange(e.target.value, 1, 10, 1))}
                     className="w-24"
                   />
                 </div>
@@ -494,9 +506,9 @@ export function NewAnalysisPage() {
             </div>
             <div className="space-y-2">
               <FieldLabel>Additional Repositories</FieldLabel>
-              {additionalRepos.map((repo, i) => (
+              {additionalRepos.map((repo) => (
                 <div
-                  key={i}
+                  key={repo.id}
                   className="bg-surface-elevated border border-border-default rounded-lg p-2.5 space-y-2"
                 >
                   <div className="flex items-center gap-2">
@@ -504,37 +516,43 @@ export function NewAnalysisPage() {
                       className="w-32"
                       placeholder="Name"
                       value={repo.name}
-                      onChange={(e) => {
-                        const next = [...additionalRepos]
-                        next[i] = { ...next[i], name: e.target.value }
-                        setAdditionalRepos(next)
-                      }}
+                      onChange={(e) =>
+                        setAdditionalRepos((prev) =>
+                          prev.map((r) =>
+                            r.id === repo.id ? { ...r, name: e.target.value } : r
+                          )
+                        )
+                      }
                     />
                     <Input
                       className="flex-1"
                       placeholder="URL"
                       value={repo.url}
-                      onChange={(e) => {
-                        const next = [...additionalRepos]
-                        next[i] = { ...next[i], url: e.target.value }
-                        setAdditionalRepos(next)
-                      }}
+                      onChange={(e) =>
+                        setAdditionalRepos((prev) =>
+                          prev.map((r) =>
+                            r.id === repo.id ? { ...r, url: e.target.value } : r
+                          )
+                        )
+                      }
                     />
                     <Input
                       className="w-24"
                       placeholder="Ref"
                       value={repo.ref}
-                      onChange={(e) => {
-                        const next = [...additionalRepos]
-                        next[i] = { ...next[i], ref: e.target.value }
-                        setAdditionalRepos(next)
-                      }}
+                      onChange={(e) =>
+                        setAdditionalRepos((prev) =>
+                          prev.map((r) =>
+                            r.id === repo.id ? { ...r, ref: e.target.value } : r
+                          )
+                        )
+                      }
                     />
                     <button
                       type="button"
                       className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
                       onClick={() =>
-                        setAdditionalRepos(additionalRepos.filter((_, j) => j !== i))
+                        setAdditionalRepos((prev) => prev.filter((r) => r.id !== repo.id))
                       }
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -546,7 +564,10 @@ export function NewAnalysisPage() {
                 type="button"
                 className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
                 onClick={() =>
-                  setAdditionalRepos([...additionalRepos, { name: '', url: '', ref: '' }])
+                  setAdditionalRepos((prev) => [
+                    ...prev,
+                    { id: crypto.randomUUID(), name: '', url: '', ref: '' },
+                  ])
                 }
               >
                 <Plus className="h-3.5 w-3.5" />

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -90,11 +90,13 @@ export function NewAnalysisPage() {
         setRawXml(content)
         setUploadFileName(file.name)
       }
+      if (fileInputRef.current) fileInputRef.current.value = ''
     }
     reader.onerror = () => {
       setRawXml('')
       setUploadFileName('')
       setError(`Failed to read file: ${file.name}`)
+      if (fileInputRef.current) fileInputRef.current.value = ''
     }
     reader.readAsText(file)
   }, [])
@@ -152,7 +154,8 @@ export function NewAnalysisPage() {
         navigate(`/results/${data.job_id}`)
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to submit analysis')
+      console.error('Failed to submit analysis', err)
+      setError('Failed to submit analysis. Please try again.')
     } finally {
       setSubmitting(false)
     }
@@ -328,6 +331,14 @@ export function NewAnalysisPage() {
                 if (file && file.name.endsWith('.xml')) handleFileUpload(file)
               }}
               onClick={() => fileInputRef.current?.click()}
+              tabIndex={0}
+              role="button"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  fileInputRef.current?.click()
+                }
+              }}
             >
               <Upload className="h-8 w-8 text-text-tertiary mb-2" />
               <p className="text-sm text-text-secondary">
@@ -450,6 +461,7 @@ export function NewAnalysisPage() {
                       />
                       <button
                         type="button"
+                        aria-label={`Remove peer ${i + 1}`}
                         className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
                         onClick={() => setPeerConfigs((prev) => prev.filter((p) => p.id !== peer.id))}
                       >
@@ -554,6 +566,7 @@ export function NewAnalysisPage() {
                     />
                     <button
                       type="button"
+                      aria-label={`Remove repository ${repo.name || repo.id}`}
                       className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
                       onClick={() =>
                         setAdditionalRepos((prev) => prev.filter((r) => r.id !== repo.id))

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -81,6 +81,7 @@ export function NewAnalysisPage() {
       : rawXml.trim() !== ''
 
   const handleFileUpload = useCallback((file: File) => {
+    setError('')
     setRawXml('')
     setUploadFileName('')
     const reader = new FileReader()
@@ -115,9 +116,9 @@ export function NewAnalysisPage() {
         ...(jiraUrl && { jira_url: jiraUrl }),
         ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
         ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
-        peer_ai_configs: enablePeers
-          ? peerConfigs.map(({ ai_provider, ai_model }) => ({ ai_provider, ai_model }))
-          : [],
+        ...(enablePeers && peerConfigs.length > 0 && {
+          peer_ai_configs: peerConfigs.map(({ ai_provider, ai_model }) => ({ ai_provider, ai_model })),
+        }),
         peer_analysis_max_rounds: maxRounds,
         ...(() => {
           const validRepos = additionalRepos
@@ -419,7 +420,12 @@ export function NewAnalysisPage() {
           <Section title="Peer Analysis" dotColor="bg-signal-purple">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Enable peer review</span>
-              <Toggle checked={enablePeers} onChange={setEnablePeers} label="Enable peer review" />
+              <Toggle checked={enablePeers} onChange={(v) => {
+                setEnablePeers(v)
+                if (v && peerConfigs.length === 0) {
+                  setPeerConfigs([{ id: crypto.randomUUID(), ai_provider: 'claude', ai_model: '' }])
+                }
+              }} label="Enable peer review" />
             </div>
             {enablePeers && (
               <>

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -1,0 +1,639 @@
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select'
+import { api } from '@/lib/api'
+import type { AiConfig } from '@/types'
+import { Section } from '@/components/shared/Section'
+import { Toggle } from '@/components/shared/Toggle'
+import { FieldLabel } from '@/components/shared/FieldLabel'
+import { Plus, Trash2, Send, Upload } from 'lucide-react'
+
+export function NewAnalysisPage() {
+  const navigate = useNavigate()
+
+  // Input mode
+  const [inputMode, setInputMode] = useState<'jenkins' | 'paste' | 'upload'>('jenkins')
+
+  // Raw XML (paste / upload)
+  const [rawXml, setRawXml] = useState('')
+  const [uploadFileName, setUploadFileName] = useState('')
+
+  // Jenkins fields
+  const [jobName, setJobName] = useState('')
+  const [buildNumber, setBuildNumber] = useState<number | ''>('')
+  const [jenkinsUrl, setJenkinsUrl] = useState('')
+  const [jenkinsUser, setJenkinsUser] = useState('')
+  const [jenkinsPassword, setJenkinsPassword] = useState('')
+  const [waitForCompletion, setWaitForCompletion] = useState(true)
+  const [pollInterval, setPollInterval] = useState(2)
+  const [maxWait, setMaxWait] = useState(0)
+
+  // AI configuration
+  const [aiProvider, setAiProvider] = useState('claude')
+  const [aiModel, setAiModel] = useState('')
+  const [aiCliTimeout, setAiCliTimeout] = useState<number | undefined>(undefined)
+  const [rawPrompt, setRawPrompt] = useState('')
+
+  // Peer analysis
+  const [enablePeers, setEnablePeers] = useState(false)
+  const [peerConfigs, setPeerConfigs] = useState<AiConfig[]>([])
+  const [maxRounds, setMaxRounds] = useState(3)
+
+  // Source repositories
+  const [testsRepoUrl, setTestsRepoUrl] = useState('')
+  const [testsRepoRef, setTestsRepoRef] = useState('')
+  const [additionalRepos, setAdditionalRepos] = useState<
+    Array<{ name: string; url: string; ref: string }>
+  >([])
+
+  // Jira integration
+  const [enableJira, setEnableJira] = useState<boolean | undefined>(undefined)
+  const [jiraUrl, setJiraUrl] = useState('')
+  const [jiraProjectKey, setJiraProjectKey] = useState('')
+
+  // Advanced
+  const [force, setForce] = useState(false)
+  const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(undefined)
+  const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(undefined)
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const canSubmit =
+    inputMode === 'jenkins'
+      ? jobName.trim() !== '' && buildNumber !== '' && buildNumber > 0
+      : rawXml.trim() !== ''
+
+  const handleFileUpload = useCallback((file: File) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const content = e.target?.result
+      if (typeof content === 'string') {
+        setRawXml(content)
+        setUploadFileName(file.name)
+      }
+    }
+    reader.readAsText(file)
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError('')
+    try {
+      const commonFields: Record<string, unknown> = {
+        ai_provider: aiProvider,
+        ...(aiModel && { ai_model: aiModel }),
+        ...(aiCliTimeout !== undefined && { ai_cli_timeout: aiCliTimeout }),
+        ...(rawPrompt && { raw_prompt: rawPrompt }),
+        ...(enableJira !== undefined && { enable_jira: enableJira }),
+        ...(jiraUrl && { jira_url: jiraUrl }),
+        ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
+        ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
+        peer_ai_configs: enablePeers ? peerConfigs : [],
+        peer_analysis_max_rounds: maxRounds,
+        additional_repos: additionalRepos
+          .filter((r) => r.name && r.url)
+          .map((r) => ({
+            name: r.name,
+            url: r.url,
+            ...(r.ref && { ref: r.ref }),
+          })),
+      }
+
+      if (inputMode === 'jenkins') {
+        const body: Record<string, unknown> = {
+          ...commonFields,
+          job_name: jobName.trim(),
+          build_number: buildNumber,
+          force,
+          wait_for_completion: waitForCompletion,
+          poll_interval_minutes: pollInterval,
+          max_wait_minutes: maxWait,
+          ...(jenkinsUrl && { jenkins_url: jenkinsUrl }),
+          ...(jenkinsUser && { jenkins_user: jenkinsUser }),
+          ...(jenkinsPassword && { jenkins_password: jenkinsPassword }),
+          ...(getArtifacts !== undefined && { get_job_artifacts: getArtifacts }),
+          ...(maxArtifactsSize !== undefined && { jenkins_artifacts_max_size_mb: maxArtifactsSize }),
+        }
+        const data = await api.post<{ job_id: string }>('/analyze', body)
+        navigate(`/status/${data.job_id}`)
+      } else {
+        const body: Record<string, unknown> = {
+          ...commonFields,
+          raw_xml: rawXml,
+        }
+        const data = await api.post<{ job_id: string }>('/analyze-failures', body)
+        navigate(`/results/${data.job_id}`)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit analysis')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [
+    canSubmit,
+    inputMode,
+    rawXml,
+    jobName,
+    buildNumber,
+    aiProvider,
+    aiModel,
+    force,
+    waitForCompletion,
+    pollInterval,
+    maxWait,
+    aiCliTimeout,
+    rawPrompt,
+    jenkinsUrl,
+    jenkinsUser,
+    jenkinsPassword,
+    enablePeers,
+    peerConfigs,
+    maxRounds,
+    testsRepoUrl,
+    testsRepoRef,
+    additionalRepos,
+    enableJira,
+    jiraUrl,
+    jiraProjectKey,
+    getArtifacts,
+    maxArtifactsSize,
+    navigate,
+  ])
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="font-display text-xl font-bold text-text-primary">New Analysis</h1>
+        <p className="mt-0.5 text-sm text-text-tertiary">
+          Submit a Jenkins job for AI-powered failure analysis.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border-default bg-surface-card">
+        <div className="space-y-1 p-6">
+          {/* Input Mode Selector */}
+          <div className="flex gap-2 pb-2">
+            {(['jenkins', 'paste', 'upload'] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setInputMode(mode)}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  inputMode === mode
+                    ? 'bg-signal-blue text-white'
+                    : 'bg-surface-elevated text-text-secondary hover:text-text-primary'
+                }`}
+              >
+                {mode === 'jenkins' ? 'Jenkins Job' : mode === 'paste' ? 'Paste XML' : 'Upload File'}
+              </button>
+            ))}
+          </div>
+
+          <hr className="border-border-muted" />
+
+          {/* Jenkins Job */}
+          {inputMode === 'jenkins' && (
+          <Section title="Jenkins Job" dotColor="bg-signal-red" defaultOpen>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <FieldLabel>Job Name *</FieldLabel>
+                <Input
+                  placeholder="folder/job-name"
+                  value={jobName}
+                  onChange={(e) => setJobName(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>Build Number *</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  placeholder="123"
+                  value={buildNumber}
+                  onChange={(e) => setBuildNumber(e.target.value ? Number(e.target.value) : '')}
+                  required
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Jenkins URL</FieldLabel>
+              <Input
+                placeholder="https://jenkins.example.com (overrides server default)"
+                value={jenkinsUrl}
+                onChange={(e) => setJenkinsUrl(e.target.value)}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <FieldLabel>Jenkins User</FieldLabel>
+                <Input
+                  placeholder="Username"
+                  value={jenkinsUser}
+                  onChange={(e) => setJenkinsUser(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>Jenkins Password / Token</FieldLabel>
+                <Input
+                  type="password"
+                  placeholder="API token"
+                  value={jenkinsPassword}
+                  onChange={(e) => setJenkinsPassword(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Wait for build completion</span>
+              <Toggle checked={waitForCompletion} onChange={setWaitForCompletion} label="Wait for build completion" />
+            </div>
+            {waitForCompletion && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <FieldLabel>Poll Interval (min)</FieldLabel>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={pollInterval}
+                    onChange={(e) => setPollInterval(Number(e.target.value) || 1)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <FieldLabel>Max Wait (min, 0 = no limit)</FieldLabel>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={maxWait}
+                    onChange={(e) => setMaxWait(Number(e.target.value) || 0)}
+                  />
+                </div>
+              </div>
+            )}
+          </Section>
+          )}
+
+          {/* Paste XML */}
+          {inputMode === 'paste' && (
+          <Section title="Paste XML" dotColor="bg-signal-red" defaultOpen>
+            <div className="space-y-1.5">
+              <FieldLabel>JUnit XML Content *</FieldLabel>
+              <textarea
+                className="flex w-full rounded-md border border-border-default bg-surface-elevated px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-accent min-h-[200px] resize-y font-mono"
+                placeholder="Paste JUnit XML content..."
+                value={rawXml}
+                onChange={(e) => setRawXml(e.target.value)}
+              />
+            </div>
+          </Section>
+          )}
+
+          {/* Upload XML File */}
+          {inputMode === 'upload' && (
+          <Section title="Upload XML File" dotColor="bg-signal-red" defaultOpen>
+            <div
+              className="relative flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-border-default bg-surface-elevated p-8 transition-colors hover:border-signal-blue hover:bg-surface-hover cursor-pointer"
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation() }}
+              onDrop={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                const file = e.dataTransfer.files[0]
+                if (file && file.name.endsWith('.xml')) handleFileUpload(file)
+              }}
+              onClick={() => document.getElementById('xml-file-input')?.click()}
+            >
+              <Upload className="h-8 w-8 text-text-tertiary mb-2" />
+              <p className="text-sm text-text-secondary">
+                {uploadFileName
+                  ? <><span className="font-medium text-text-primary">{uploadFileName}</span> loaded</>
+                  : <>Drag & drop an XML file here, or <span className="text-text-link font-medium">browse</span></>
+                }
+              </p>
+              {rawXml && (
+                <p className="text-xs text-text-tertiary mt-1">
+                  {rawXml.length.toLocaleString()} characters
+                </p>
+              )}
+              <input
+                id="xml-file-input"
+                type="file"
+                accept=".xml"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0]
+                  if (file) handleFileUpload(file)
+                }}
+              />
+            </div>
+          </Section>
+          )}
+
+          <hr className="border-border-muted" />
+
+          {/* AI Configuration */}
+          <Section title="AI Configuration" dotColor="bg-signal-blue">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <FieldLabel>AI Provider</FieldLabel>
+                <Select value={aiProvider} onValueChange={setAiProvider}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="claude">Claude</SelectItem>
+                    <SelectItem value="gemini">Gemini</SelectItem>
+                    <SelectItem value="cursor">Cursor</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>AI CLI Timeout</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  value={aiCliTimeout ?? ''}
+                  placeholder="10"
+                  onChange={(e) => setAiCliTimeout(e.target.value ? Number(e.target.value) || 1 : undefined)}
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>AI Model</FieldLabel>
+              <Input
+                placeholder="Default model"
+                value={aiModel}
+                onChange={(e) => setAiModel(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Raw Prompt</FieldLabel>
+              <textarea
+                className="flex w-full rounded-md border border-border-default bg-surface-elevated px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-accent min-h-[80px] resize-y"
+                placeholder="Custom prompt to send to AI..."
+                value={rawPrompt}
+                onChange={(e) => setRawPrompt(e.target.value)}
+              />
+            </div>
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Peer Analysis */}
+          <Section title="Peer Analysis" dotColor="bg-signal-purple">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Enable peer review</span>
+              <Toggle checked={enablePeers} onChange={setEnablePeers} label="Enable peer review" />
+            </div>
+            {enablePeers && (
+              <>
+                <div className="space-y-2">
+                  {peerConfigs.map((peer, i) => (
+                    <div
+                      key={i}
+                      className="bg-surface-elevated border border-border-default rounded-lg p-2.5 flex items-center gap-2"
+                    >
+                      <Select
+                        value={peer.ai_provider}
+                        onValueChange={(v) => {
+                          const next = [...peerConfigs]
+                          next[i] = { ...next[i], ai_provider: v }
+                          setPeerConfigs(next)
+                        }}
+                      >
+                        <SelectTrigger className="w-[120px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="claude">Claude</SelectItem>
+                          <SelectItem value="gemini">Gemini</SelectItem>
+                          <SelectItem value="cursor">Cursor</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        className="flex-1"
+                        placeholder="Model"
+                        value={peer.ai_model}
+                        onChange={(e) => {
+                          const next = [...peerConfigs]
+                          next[i] = { ...next[i], ai_model: e.target.value }
+                          setPeerConfigs(next)
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
+                        onClick={() => setPeerConfigs(peerConfigs.filter((_, j) => j !== i))}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
+                  onClick={() =>
+                    setPeerConfigs([...peerConfigs, { ai_provider: 'claude', ai_model: '' }])
+                  }
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add Peer
+                </button>
+                <div className="space-y-1.5">
+                  <FieldLabel>Max Rounds</FieldLabel>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={maxRounds}
+                    onChange={(e) => setMaxRounds(Number(e.target.value) || 1)}
+                    className="w-24"
+                  />
+                </div>
+              </>
+            )}
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Source Repositories */}
+          <Section title="Source Repositories" dotColor="bg-signal-green">
+            <div className="grid grid-cols-3 gap-3">
+              <div className="col-span-2 space-y-1.5">
+                <FieldLabel>Tests Repo URL</FieldLabel>
+                <Input
+                  placeholder="https://github.com/org/repo"
+                  value={testsRepoUrl}
+                  onChange={(e) => setTestsRepoUrl(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel>Ref / Branch</FieldLabel>
+                <Input
+                  placeholder="main"
+                  value={testsRepoRef}
+                  onChange={(e) => setTestsRepoRef(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <FieldLabel>Additional Repositories</FieldLabel>
+              {additionalRepos.map((repo, i) => (
+                <div
+                  key={i}
+                  className="bg-surface-elevated border border-border-default rounded-lg p-2.5 space-y-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Input
+                      className="w-32"
+                      placeholder="Name"
+                      value={repo.name}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], name: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <Input
+                      className="flex-1"
+                      placeholder="URL"
+                      value={repo.url}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], url: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <Input
+                      className="w-24"
+                      placeholder="Ref"
+                      value={repo.ref}
+                      onChange={(e) => {
+                        const next = [...additionalRepos]
+                        next[i] = { ...next[i], ref: e.target.value }
+                        setAdditionalRepos(next)
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="p-1 rounded hover:bg-surface-hover text-text-tertiary hover:text-signal-red transition flex-shrink-0"
+                      onClick={() =>
+                        setAdditionalRepos(additionalRepos.filter((_, j) => j !== i))
+                      }
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="text-xs text-text-link hover:text-signal-blue font-medium flex items-center gap-1"
+                onClick={() =>
+                  setAdditionalRepos([...additionalRepos, { name: '', url: '', ref: '' }])
+                }
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add Repository
+              </button>
+            </div>
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Jira Integration */}
+          <Section title="Jira Integration" dotColor="bg-signal-orange">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Enable Jira search</span>
+              <Toggle checked={enableJira ?? true} onChange={setEnableJira} label="Enable Jira search" />
+            </div>
+            {enableJira !== false && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <FieldLabel>Jira URL</FieldLabel>
+                  <Input
+                    placeholder="https://jira.example.com"
+                    value={jiraUrl}
+                    onChange={(e) => setJiraUrl(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <FieldLabel>Project Key</FieldLabel>
+                  <Input
+                    placeholder="PROJ"
+                    value={jiraProjectKey}
+                    onChange={(e) => setJiraProjectKey(e.target.value)}
+                  />
+                </div>
+              </div>
+            )}
+          </Section>
+
+          {inputMode === 'jenkins' && (
+          <>
+          <hr className="border-border-muted" />
+
+          {/* Advanced */}
+          <Section title="Advanced" dotColor="bg-text-tertiary">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Force analysis on successful builds</span>
+              <Toggle checked={force} onChange={setForce} label="Force analysis on successful builds" />
+            </div>
+            <p className="text-[11px] text-text-tertiary">
+              When enabled, analysis runs even if Jenkins reports the build as SUCCESS.
+            </p>
+          </Section>
+
+          <hr className="border-border-muted" />
+
+          {/* Jenkins Artifacts */}
+          <Section title="Jenkins Artifacts" dotColor="bg-[#58a6ff]">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-text-secondary">Fetch build artifacts</span>
+              <Toggle checked={getArtifacts ?? true} onChange={setGetArtifacts} label="Fetch build artifacts" />
+            </div>
+            {(getArtifacts ?? true) && (
+              <div className="space-y-1.5">
+                <FieldLabel>Max Size (MB)</FieldLabel>
+                <Input
+                  type="number"
+                  min={1}
+                  value={maxArtifactsSize ?? ''}
+                  placeholder="50"
+                  onChange={(e) => setMaxArtifactsSize(e.target.value ? Number(e.target.value) || 1 : undefined)}
+                />
+              </div>
+            )}
+          </Section>
+          </>)}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-border-default px-6 py-4">
+          <div>
+            {error && <p className="text-signal-red text-xs">{error}</p>}
+          </div>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={() => navigate('/')} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={submitting || !canSubmit} className="gap-1.5">
+              <Send className={`h-3.5 w-3.5 ${submitting ? 'animate-pulse' : ''}`} />
+              {submitting ? 'Submitting…' : 'Submit Analysis'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -61,13 +61,13 @@ export function NewAnalysisPage() {
   >([])
 
   // Jira integration
-  const [enableJira, setEnableJira] = useState<boolean | undefined>(undefined)
+  const [enableJira, setEnableJira] = useState(true)
   const [jiraUrl, setJiraUrl] = useState('')
   const [jiraProjectKey, setJiraProjectKey] = useState('')
 
   // Advanced
   const [force, setForce] = useState(false)
-  const [getArtifacts, setGetArtifacts] = useState<boolean | undefined>(undefined)
+  const [getArtifacts, setGetArtifacts] = useState(true)
   const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(undefined)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -81,6 +81,8 @@ export function NewAnalysisPage() {
       : rawXml.trim() !== ''
 
   const handleFileUpload = useCallback((file: File) => {
+    setRawXml('')
+    setUploadFileName('')
     const reader = new FileReader()
     reader.onload = (e) => {
       const content = e.target?.result
@@ -90,6 +92,8 @@ export function NewAnalysisPage() {
       }
     }
     reader.onerror = () => {
+      setRawXml('')
+      setUploadFileName('')
       setError(`Failed to read file: ${file.name}`)
     }
     reader.readAsText(file)
@@ -105,7 +109,7 @@ export function NewAnalysisPage() {
         ...(aiModel && { ai_model: aiModel }),
         ...(aiCliTimeout !== undefined && { ai_cli_timeout: aiCliTimeout }),
         ...(rawPrompt && { raw_prompt: rawPrompt }),
-        ...(enableJira !== undefined && { enable_jira: enableJira }),
+        enable_jira: enableJira,
         ...(jiraUrl && { jira_url: jiraUrl }),
         ...(jiraProjectKey && { jira_project_key: jiraProjectKey }),
         ...(testsRepoUrl && { tests_repo_url: testsRepoRef ? `${testsRepoUrl}:${testsRepoRef}` : testsRepoUrl }),
@@ -134,7 +138,7 @@ export function NewAnalysisPage() {
           ...(jenkinsUrl && { jenkins_url: jenkinsUrl }),
           ...(jenkinsUser && { jenkins_user: jenkinsUser }),
           ...(jenkinsPassword && { jenkins_password: jenkinsPassword }),
-          ...(getArtifacts !== undefined && { get_job_artifacts: getArtifacts }),
+          get_job_artifacts: getArtifacts,
           ...(maxArtifactsSize !== undefined && { jenkins_artifacts_max_size_mb: maxArtifactsSize }),
         }
         const data = await api.post<{ job_id: string }>('/analyze', body)
@@ -376,7 +380,7 @@ export function NewAnalysisPage() {
                   min={1}
                   value={aiCliTimeout ?? ''}
                   placeholder="10"
-                  onChange={(e) => setAiCliTimeout(e.target.value ? Number(e.target.value) || 1 : undefined)}
+                  onChange={(e) => setAiCliTimeout(e.target.value ? toIntInRange(e.target.value, 1, 3600, 1) : undefined)}
                 />
               </div>
             </div>
@@ -582,9 +586,9 @@ export function NewAnalysisPage() {
           <Section title="Jira Integration" dotColor="bg-signal-orange">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Enable Jira search</span>
-              <Toggle checked={enableJira ?? true} onChange={setEnableJira} label="Enable Jira search" />
+              <Toggle checked={enableJira} onChange={setEnableJira} label="Enable Jira search" />
             </div>
-            {enableJira !== false && (
+            {!enableJira ? null : (
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
                   <FieldLabel>Jira URL</FieldLabel>
@@ -627,9 +631,9 @@ export function NewAnalysisPage() {
           <Section title="Jenkins Artifacts" dotColor="bg-[#58a6ff]">
             <div className="flex items-center justify-between">
               <span className="text-sm text-text-secondary">Fetch build artifacts</span>
-              <Toggle checked={getArtifacts ?? true} onChange={setGetArtifacts} label="Fetch build artifacts" />
+              <Toggle checked={getArtifacts} onChange={setGetArtifacts} label="Fetch build artifacts" />
             </div>
-            {(getArtifacts ?? true) && (
+            {getArtifacts && (
               <div className="space-y-1.5">
                 <FieldLabel>Max Size (MB)</FieldLabel>
                 <Input
@@ -637,7 +641,7 @@ export function NewAnalysisPage() {
                   min={1}
                   value={maxArtifactsSize ?? ''}
                   placeholder="50"
-                  onChange={(e) => setMaxArtifactsSize(e.target.value ? Number(e.target.value) || 1 : undefined)}
+                  onChange={(e) => setMaxArtifactsSize(e.target.value ? toIntInRange(e.target.value, 1, 10000, 1) : undefined)}
                 />
               </div>
             )}

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -19,70 +19,16 @@ import {
 } from '@/components/ui/select'
 import { api } from '@/lib/api'
 import type { AnalysisResult, AiConfig } from '@/types'
-import { ChevronRight, Plus, Trash2, RotateCw } from 'lucide-react'
+import { Section } from '@/components/shared/Section'
+import { Toggle } from '@/components/shared/Toggle'
+import { FieldLabel } from '@/components/shared/FieldLabel'
+import { Plus, Trash2, RotateCw } from 'lucide-react'
 
 interface ReAnalyzeDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   result: AnalysisResult
   jobId: string
-}
-
-function Section({
-  title,
-  dotColor,
-  defaultOpen = false,
-  children,
-}: {
-  title: string
-  dotColor: string
-  defaultOpen?: boolean
-  children: React.ReactNode
-}) {
-  const [open, setOpen] = useState(defaultOpen)
-  return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center gap-2 py-2 text-left group"
-      >
-        <ChevronRight
-          className={`h-3 w-3 text-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`}
-        />
-        <span className={`w-1.5 h-1.5 rounded-full ${dotColor} flex-shrink-0`} />
-        <span className="font-display text-[11px] font-semibold tracking-widest text-text-secondary uppercase">
-          {title}
-        </span>
-      </button>
-      {open && <div className="pl-5 space-y-4 pb-4">{children}</div>}
-    </div>
-  )
-}
-
-function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label: string }) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      onClick={() => onChange(!checked)}
-      className={`relative w-11 h-6 rounded-full transition-colors ${
-        checked ? 'bg-signal-blue' : 'bg-surface-hover'
-      }`}
-    >
-      <span
-        className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow transition-transform ${
-          checked ? 'translate-x-5' : ''
-        }`}
-      />
-    </button>
-  )
-}
-
-function FieldLabel({ children }: { children: React.ReactNode }) {
-  return <label className="text-xs text-text-tertiary">{children}</label>
 }
 
 function initFormState(p: AnalysisResult['request_params']) {


### PR DESCRIPTION
Closes #204

## Changes
- Extract Section, Toggle, FieldLabel into shared components
- Refactor ReAnalyzeDialog to use shared components (-60 lines)
- Create NewAnalysisPage with Jenkins connection + all analysis fields
- Add /new-analysis route and '+ New Analysis' Dashboard button

## Done
- [x] New Analysis page accessible from Dashboard
- [x] All AnalyzeRequest fields available as form inputs
- [x] Required fields validated (job_name, build_number)
- [x] Submit calls POST /analyze endpoint
- [x] Redirects to status page on success
- [x] Shared components extracted from ReAnalyzeDialog (no duplication)
- [x] Frontend tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected "New Analysis" route and a dashboard "New Analysis" button for quick access.

* **New Page**
  * New Analysis page: enter Jenkins details or provide/upload JUnit XML, configure AI settings, peer review rounds, repo refs, Jira integration, artifact/timeout options, and view submission status.

* **New Components**
  * Shared FieldLabel, Section, and Toggle controls for consistent form UI.

* **Refactor**
  * Re-analyze dialog now uses shared controls for UI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->