### PR TITLE
fix: extract JUnit failure body text when message attribute is absent

### DIFF
--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -867,7 +867,7 @@ def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
                 test_name = case.get("name", "")
                 full_name = f"{class_name}.{test_name}" if class_name else test_name
 
-                error_details = case.get("errorDetails", "") or ""
+                error_details = (case.get("errorDetails", "") or "").strip()
                 stack_trace = case.get("errorStackTrace", "") or ""
 
                 # Fallback: when errorDetails is empty, extract error summary from errorStackTrace
@@ -876,7 +876,7 @@ def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
                     # Extract first substantive line (skip file:line references)
                     for line in stack_trace.split("\n"):
                         stripped = line.strip()
-                        if stripped and not re.match(r"^[\w/._-]+\.go:\d+$", stripped):
+                        if stripped and not re.match(r"^[\w/._-]+\.\w+:\d+$", stripped):
                             error_details = stripped
                             break
 

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -836,6 +836,30 @@ def extract_failed_child_jobs_from_console(
     return failed_jobs
 
 
+def _derive_error_details(error_details: str, stack_trace: str) -> str:
+    """Derive a usable error message from *error_details* and *stack_trace*.
+
+    1. Strip whitespace from *error_details*; if non-empty, return it.
+    2. Otherwise, collect all non-file:line lines from *stack_trace* and join
+       them with spaces to produce a synthetic error summary.
+    3. Return the result (may still be empty if both inputs are blank).
+    """
+    stripped = error_details.strip()
+    if stripped:
+        return stripped
+
+    if stack_trace:
+        parts: list[str] = []
+        for line in stack_trace.split("\n"):
+            line_stripped = line.strip()
+            if line_stripped and not re.match(r"^[\w/._-]+\.\w+:\d+$", line_stripped):
+                parts.append(line_stripped)
+        if parts:
+            return " ".join(parts)
+
+    return stripped
+
+
 def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
     """Extract failed test cases from Jenkins test report.
 
@@ -867,20 +891,11 @@ def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
                 test_name = case.get("name", "")
                 full_name = f"{class_name}.{test_name}" if class_name else test_name
 
-                error_details = (case.get("errorDetails", "") or "").strip()
+                error_details = _derive_error_details(
+                    case.get("errorDetails", "") or "",
+                    case.get("errorStackTrace", "") or "",
+                )
                 stack_trace = case.get("errorStackTrace", "") or ""
-
-                # Fallback: when errorDetails is empty, extract error summary from errorStackTrace
-                if not error_details and stack_trace:
-                    # errorStackTrace often contains file:line refs interleaved with actual error
-                    # Collect all non-file:line lines and join into a single error message
-                    parts: list[str] = []
-                    for line in stack_trace.split("\n"):
-                        stripped = line.strip()
-                        if stripped and not re.match(r"^[\w/._-]+\.\w+:\d+$", stripped):
-                            parts.append(stripped)
-                    if parts:
-                        error_details = " ".join(parts)
 
                 failures.append(
                     TestFailure(

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -872,13 +872,15 @@ def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
 
                 # Fallback: when errorDetails is empty, extract error summary from errorStackTrace
                 if not error_details and stack_trace:
-                    # errorStackTrace often starts with file:line, followed by the actual error
-                    # Extract first substantive line (skip file:line references)
+                    # errorStackTrace often contains file:line refs interleaved with actual error
+                    # Collect all non-file:line lines and join into a single error message
+                    parts: list[str] = []
                     for line in stack_trace.split("\n"):
                         stripped = line.strip()
                         if stripped and not re.match(r"^[\w/._-]+\.\w+:\d+$", stripped):
-                            error_details = stripped
-                            break
+                            parts.append(stripped)
+                    if parts:
+                        error_details = " ".join(parts)
 
                 failures.append(
                     TestFailure(

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -867,11 +867,24 @@ def extract_failures_from_test_report(test_report: dict) -> list[TestFailure]:
                 test_name = case.get("name", "")
                 full_name = f"{class_name}.{test_name}" if class_name else test_name
 
+                error_details = case.get("errorDetails", "") or ""
+                stack_trace = case.get("errorStackTrace", "") or ""
+
+                # Fallback: when errorDetails is empty, extract error summary from errorStackTrace
+                if not error_details and stack_trace:
+                    # errorStackTrace often starts with file:line, followed by the actual error
+                    # Extract first substantive line (skip file:line references)
+                    for line in stack_trace.split("\n"):
+                        stripped = line.strip()
+                        if stripped and not re.match(r"^[\w/._-]+\.go:\d+$", stripped):
+                            error_details = stripped
+                            break
+
                 failures.append(
                     TestFailure(
                         test_name=full_name,
-                        error_message=case.get("errorDetails", "") or "",
-                        stack_trace=case.get("errorStackTrace", "") or "",
+                        error_message=error_details,
+                        stack_trace=stack_trace,
                         duration=case.get("duration", 0.0) or 0.0,
                         status=status,
                     )

--- a/src/jenkins_job_insight/xml_enrichment.py
+++ b/src/jenkins_job_insight/xml_enrichment.py
@@ -14,6 +14,18 @@ from defusedxml.ElementTree import fromstring as safe_fromstring
 logger = logging.getLogger(__name__)
 
 
+def _first_nonempty_line(text: str) -> str:
+    """Return the first non-blank line from *text*, stripped.
+
+    Returns empty string when *text* is empty or contains only whitespace.
+    """
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
 def extract_failures_from_xml(raw_xml: str) -> list[dict[str, str]]:
     """Extract test failures and errors from a JUnit XML string.
 
@@ -52,7 +64,7 @@ def extract_failures_from_xml(raw_xml: str) -> list[dict[str, str]]:
             {
                 "test_name": test_name,
                 "error_message": result_elem.get("message", "")
-                or ((result_elem.text or "").split("\n")[0].strip()),
+                or _first_nonempty_line(result_elem.text or ""),
                 "stack_trace": result_elem.text or "",
                 "status": "ERROR"
                 if error_elem is not None and failure_elem is None

--- a/src/jenkins_job_insight/xml_enrichment.py
+++ b/src/jenkins_job_insight/xml_enrichment.py
@@ -63,7 +63,7 @@ def extract_failures_from_xml(raw_xml: str) -> list[dict[str, str]]:
         failures.append(
             {
                 "test_name": test_name,
-                "error_message": result_elem.get("message", "")
+                "error_message": (result_elem.get("message", "") or "").strip()
                 or _first_nonempty_line(result_elem.text or ""),
                 "stack_trace": result_elem.text or "",
                 "status": "ERROR"

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3098,7 +3098,10 @@ class TestExtractFailuresFromTestReport:
         )
         failures = extract_failures_from_test_report(report)
         assert len(failures) == 1
-        assert failures[0].error_message == "Expected"
+        assert (
+            failures[0].error_message
+            == "Expected <v1.PersistentVolumeAccessMode>: ReadWriteMany to equal <v1.PersistentVolumeAccessMode>: ReadWriteOnce"
+        )
         assert "ReadWriteMany" in failures[0].stack_trace
         assert "ReadWriteOnce" in failures[0].stack_trace
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3220,3 +3220,25 @@ class TestExtractFailuresFromTestReport:
         failures = extract_failures_from_test_report(report)
         assert len(failures) == 1
         assert failures[0].status == "REGRESSION"
+
+    def test_whitespace_only_error_details_falls_back_to_stack_trace(self) -> None:
+        """When errorDetails is whitespace-only, treat as empty and extract from errorStackTrace."""
+        report = self._make_report(
+            [
+                {
+                    "className": "pkg",
+                    "name": "TestWhitespace",
+                    "status": "FAILED",
+                    "errorDetails": "   ",
+                    "errorStackTrace": "tests/some_test.go:99\nActual value did not match expected",
+                    "duration": 0.5,
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].error_message == "Actual value did not match expected"
+        assert (
+            failures[0].stack_trace
+            == "tests/some_test.go:99\nActual value did not match expected"
+        )

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -13,6 +13,7 @@ from jenkins_job_insight.analyzer import (
     _call_ai_cli_with_retry,
     _parse_json_response,
     _recover_from_details,
+    extract_failures_from_test_report,
     handle_jenkins_exception,
 )
 from jenkins_job_insight.config import Settings
@@ -3049,3 +3050,173 @@ class TestRecoverFromDetailsCodeFields:
         assert result.code_fix
         assert result.code_fix.original_code is None
         assert result.code_fix.suggested_code is None
+
+
+class TestExtractFailuresFromTestReport:
+    """Tests for extract_failures_from_test_report()."""
+
+    @staticmethod
+    def _make_report(cases: list[dict]) -> dict:
+        """Build a minimal Jenkins test report with the given cases."""
+        return {"suites": [{"cases": cases}]}
+
+    def test_basic_failure_with_error_details(self) -> None:
+        """Standard failure with errorDetails and errorStackTrace."""
+        report = self._make_report(
+            [
+                {
+                    "className": "com.example.MyTest",
+                    "name": "testFoo",
+                    "status": "FAILED",
+                    "errorDetails": "expected 1 but got 2",
+                    "errorStackTrace": "at MyTest.java:42\nat Runner.java:10",
+                    "duration": 1.5,
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].test_name == "com.example.MyTest.testFoo"
+        assert failures[0].error_message == "expected 1 but got 2"
+        assert failures[0].stack_trace == "at MyTest.java:42\nat Runner.java:10"
+        assert failures[0].duration == 1.5
+        assert failures[0].status == "FAILED"
+
+    def test_fallback_to_stack_trace_when_error_details_null(self) -> None:
+        """When errorDetails is null, extract error summary from errorStackTrace."""
+        report = self._make_report(
+            [
+                {
+                    "className": "pkg",
+                    "name": "TestVmState",
+                    "status": "FAILED",
+                    "errorDetails": None,
+                    "errorStackTrace": "tests/vm_state_test.go:201\nExpected\n    <v1.PersistentVolumeAccessMode>: ReadWriteMany\nto equal\n    <v1.PersistentVolumeAccessMode>: ReadWriteOnce\ntests/vm_state_test.go:167",
+                    "duration": 0.3,
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].error_message == "Expected"
+        assert "ReadWriteMany" in failures[0].stack_trace
+        assert "ReadWriteOnce" in failures[0].stack_trace
+
+    def test_fallback_skips_file_line_references(self) -> None:
+        """When errorStackTrace starts with file:line, skip to first substantive line."""
+        report = self._make_report(
+            [
+                {
+                    "className": "",
+                    "name": "TestGoUnit",
+                    "status": "REGRESSION",
+                    "errorDetails": None,
+                    "errorStackTrace": "tests/some_test.go:42\nExpected true to be false",
+                    "duration": 0.1,
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].test_name == "TestGoUnit"
+        assert failures[0].error_message == "Expected true to be false"
+        assert (
+            failures[0].stack_trace
+            == "tests/some_test.go:42\nExpected true to be false"
+        )
+
+    def test_no_fallback_when_error_details_present(self) -> None:
+        """When errorDetails is present, errorStackTrace is not used as fallback."""
+        report = self._make_report(
+            [
+                {
+                    "className": "C",
+                    "name": "t",
+                    "status": "FAILED",
+                    "errorDetails": "real error",
+                    "errorStackTrace": "tests/foo.go:10\nsome trace",
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert failures[0].error_message == "real error"
+        assert failures[0].stack_trace == "tests/foo.go:10\nsome trace"
+
+    def test_stack_trace_fallback_extracts_error_summary(self) -> None:
+        """When errorDetails is empty but errorStackTrace exists, extract summary from it."""
+        report = self._make_report(
+            [
+                {
+                    "className": "C",
+                    "name": "t",
+                    "status": "FAILED",
+                    "errorDetails": "",
+                    "errorStackTrace": "existing trace with details",
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert failures[0].error_message == "existing trace with details"
+        assert failures[0].stack_trace == "existing trace with details"
+
+    def test_all_fields_null_no_crash(self) -> None:
+        """When errorDetails and errorStackTrace are null, no crash and empty strings returned."""
+        report = self._make_report(
+            [
+                {
+                    "className": "C",
+                    "name": "t",
+                    "status": "FAILED",
+                    "errorDetails": None,
+                    "errorStackTrace": None,
+                }
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].error_message == ""
+        assert failures[0].stack_trace == ""
+
+    def test_passed_tests_are_excluded(self) -> None:
+        """Tests with PASSED status are not extracted."""
+        report = self._make_report(
+            [
+                {"className": "C", "name": "ok", "status": "PASSED"},
+                {
+                    "className": "C",
+                    "name": "bad",
+                    "status": "FAILED",
+                    "errorDetails": "err",
+                },
+            ]
+        )
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].test_name == "C.bad"
+
+    def test_child_reports_structure(self) -> None:
+        """Failures from childReports are extracted correctly."""
+        report = {
+            "childReports": [
+                {
+                    "result": {
+                        "suites": [
+                            {
+                                "cases": [
+                                    {
+                                        "className": "Sub",
+                                        "name": "test1",
+                                        "status": "REGRESSION",
+                                        "errorDetails": "regressed",
+                                        "errorStackTrace": "trace",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        failures = extract_failures_from_test_report(report)
+        assert len(failures) == 1
+        assert failures[0].status == "REGRESSION"

--- a/tests/test_xml_enrichment.py
+++ b/tests/test_xml_enrichment.py
@@ -67,6 +67,64 @@ class TestExtractFailuresFromXml:
         assert no_msg_failure["error_message"] == "tests/storage/datavolume.go:229"
         assert "Timed out after 500.055s" in no_msg_failure["stack_trace"]
 
+    def test_body_text_with_leading_newlines_extracts_first_nonempty_line(
+        self,
+    ) -> None:
+        """When body text starts with whitespace/newlines, skip blank lines."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="1" failures="1">
+    <testcase classname="tests.network" name="test_id:1514">
+        <failure type="Failure">
+            tests/network/networkpolicy.go:136
+Timed out after 15.001s.
+Expected failure, but got no error.
+</failure>
+    </testcase>
+</testsuite>"""
+        failures = extract_failures_from_xml(xml)
+        assert len(failures) == 1
+        assert failures[0]["error_message"] == "tests/network/networkpolicy.go:136"
+        assert "Timed out after 15.001s" in failures[0]["stack_trace"]
+
+    def test_message_attribute_takes_precedence_over_body(self) -> None:
+        """When both message attribute and body text exist, use attribute."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="1" failures="1">
+    <testcase classname="com.example" name="test_both">
+        <failure message="Attribute message" type="AssertionError">Body text line one
+Body text line two</failure>
+    </testcase>
+</testsuite>"""
+        failures = extract_failures_from_xml(xml)
+        assert len(failures) == 1
+        assert failures[0]["error_message"] == "Attribute message"
+        assert "Body text line one" in failures[0]["stack_trace"]
+
+    def test_empty_message_attribute_falls_back_to_body(self) -> None:
+        """When message attribute is empty string, use body text."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="1" failures="1">
+    <testcase classname="com.example" name="test_empty_msg">
+        <failure message="" type="Failure">actual error text here</failure>
+    </testcase>
+</testsuite>"""
+        failures = extract_failures_from_xml(xml)
+        assert len(failures) == 1
+        assert failures[0]["error_message"] == "actual error text here"
+
+    def test_no_message_no_body_yields_empty_error_message(self) -> None:
+        """Self-closing failure with no message/body gives empty error."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="1" failures="1">
+    <testcase classname="com.example" name="test_bare">
+        <failure type="Failure"/>
+    </testcase>
+</testsuite>"""
+        failures = extract_failures_from_xml(xml)
+        assert len(failures) == 1
+        assert failures[0]["error_message"] == ""
+        assert failures[0]["stack_trace"] == ""
+
     def test_no_failures_returns_empty_list(self) -> None:
         failures = extract_failures_from_xml(JUNIT_XML_NO_FAILURES)
         assert failures == []


### PR DESCRIPTION
## Summary

Fixes #216 — Fall back to reading the `<failure>` element body text when the `message` attribute is absent, instead of returning an empty string.

## Problem / Motivation

Some JUnit XML reports emit failure details only as body text within the `<failure>` element, without a `message` attribute. Previously, the parser returned an empty string in these cases, causing failure information to be silently lost during analysis.

## Changes

- When the `message` attribute is missing from a `<failure>` element, the parser now reads the element's body text as the failure message.
- Ensures failure details are always captured regardless of how the JUnit XML is structured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of error messages/details: ignores leading blank lines/whitespace, prefers explicit message fields, falls back to summarizing stack traces while skipping file:line noise, and safely handles missing/empty fields.

* **Tests**
  * Expanded coverage for failure parsing edge cases: leading whitespace/newlines, message-vs-body precedence, stack-trace fallback, exclusion of passed tests, and nested report structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->