### PR TITLE
fix: set username for non-admin Bearer API key users

### DIFF
--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -770,10 +770,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     authenticated_admin = True
                 else:
                     user = await storage.get_user_by_key(token)
-                    if user and user.get("role") == "admin":
-                        is_admin = True
+                    if user:
                         username = str(user["username"])
-                        authenticated_admin = True
+                        if user.get("role") == "admin":
+                            is_admin = True
+                            authenticated_admin = True
 
         # 3. Check X-Forwarded-User header (SSO via trusted proxy)
         if not username and proxy_username:

--- a/tests/test_allow_list.py
+++ b/tests/test_allow_list.py
@@ -263,3 +263,71 @@ class TestRestrictedAccess:
             cookies={"jji_username": "charlie"},
         )
         assert resp.status_code == 200
+
+    def test_nonadmin_api_key_user_in_allow_list(self, client_restricted, temp_db_path):
+        """Non-admin API key user passes ALLOWED_USERS check when in allow list."""
+        import aiosqlite
+
+        from jenkins_job_insight.storage import generate_api_key, hash_api_key
+
+        raw_key = generate_api_key()
+        key_hash = hash_api_key(raw_key)
+
+        # Insert a non-admin user 'alice' (who is in the allow list) with an API key
+        async def _insert():
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "UPDATE users SET api_key_hash = ? WHERE username = 'alice'",
+                    (key_hash,),
+                )
+                rows = (await (await db.execute("SELECT changes()")).fetchone())[0]
+                if rows == 0:
+                    await db.execute(
+                        "INSERT INTO users (username, api_key_hash, role) VALUES ('alice', ?, 'user')",
+                        (key_hash,),
+                    )
+                await db.commit()
+
+        asyncio.run(_insert())
+
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "api key user comment"},
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert resp.status_code == 201
+
+    def test_nonadmin_api_key_user_not_in_allow_list(
+        self, client_restricted, temp_db_path
+    ):
+        """Non-admin API key user NOT in allow list gets 403."""
+        import aiosqlite
+
+        from jenkins_job_insight.storage import generate_api_key, hash_api_key
+
+        raw_key = generate_api_key()
+        key_hash = hash_api_key(raw_key)
+
+        # Insert a non-admin user 'charlie' (NOT in the allow list) with an API key
+        async def _insert():
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "UPDATE users SET api_key_hash = ? WHERE username = 'charlie'",
+                    (key_hash,),
+                )
+                rows = (await (await db.execute("SELECT changes()")).fetchone())[0]
+                if rows == 0:
+                    await db.execute(
+                        "INSERT INTO users (username, api_key_hash, role) VALUES ('charlie', ?, 'user')",
+                        (key_hash,),
+                    )
+                await db.commit()
+
+        asyncio.run(_insert())
+
+        resp = client_restricted.post(
+            "/results/job-1/comments",
+            json={"test_name": "test_foo", "comment": "should be blocked"},
+            headers={"Authorization": f"Bearer {raw_key}"},
+        )
+        assert resp.status_code == 403

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -313,6 +313,52 @@ class TestBearerTokenAuth:
         assert data["username"] == "apiuser"
         assert data["is_admin"] is True
 
+    def test_bearer_nonadmin_api_key_sets_username(self, client, temp_db_path):
+        """Bearer token with non-admin user API key sets username correctly."""
+        import aiosqlite
+
+        from jenkins_job_insight.storage import generate_api_key, hash_api_key
+
+        raw_key = generate_api_key()
+        key_hash = hash_api_key(raw_key)
+
+        # Insert a non-admin user with an API key directly
+        async def _insert():
+            async with aiosqlite.connect(temp_db_path) as db:
+                await db.execute(
+                    "INSERT INTO users (username, api_key_hash, role) VALUES (?, ?, 'user')",
+                    ("nonadmin-key-user", key_hash),
+                )
+                await db.commit()
+
+        asyncio.run(_insert())
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {raw_key}"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "nonadmin-key-user"
+        assert data["is_admin"] is False
+        assert data["role"] == "user"
+
+    def test_bearer_admin_api_key_unchanged(self, client):
+        """Bearer token with admin API key still grants admin access."""
+        create_resp = client.post(
+            "/api/admin/users",
+            json={"username": "admin-key-user"},
+            headers={"Authorization": "Bearer test-admin-key-16chars"},
+        )
+        assert create_resp.status_code == 200
+        api_key = create_resp.json()["api_key"]
+        resp = client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {api_key}"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "admin-key-user"
+        assert data["is_admin"] is True
+        assert data["role"] == "admin"
+
     def test_bearer_invalid_key(self, client):
         """Bearer token with invalid key returns non-admin."""
         resp = client.get(


### PR DESCRIPTION
## Summary

Fixes #213 — Non-admin API key users now correctly pass the `ALLOWED_USERS` check.

## Problem

When a non-admin user authenticated via a Bearer API key, the `username` was not being set from the API key record. The username extraction only occurred inside the `if is_admin` branch, so non-admin API key users were left without an identified username. This caused the `ALLOWED_USERS` enforcement to fail because the user appeared anonymous.

## Fix

Extract the `username` from the API key record for **all** valid API key users, not just admins. The username assignment is now performed before the admin check, ensuring that non-admin API key users are properly identified and can pass the `ALLOWED_USERS` gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bearer-token authentication now correctly provides username information for non-admin users, enabling proper downstream operations and UI integration.

* **Tests**
  * Added authentication tests for API-key access control with allowed and denied users.
  * Added bearer-token authentication tests verifying correct behavior for both admin and non-admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->