### PR TITLE
fix: consolidate dashboard filters to single row layout

### DIFF
--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { BookOpen, MessageSquarePlus, type LucideIcon } from 'lucide-react'
+import { BookOpen, MessageSquarePlus, Plus, type LucideIcon } from 'lucide-react'
 import { UserBadge } from './UserBadge'
 import { FeedbackDialog } from '@/components/shared/FeedbackDialog'
 import { useAuth } from '@/lib/auth'
@@ -135,6 +135,19 @@ export function NavBar() {
                 )}
               </Link>
             ))}
+            <div className="h-6 w-px bg-border-default" />
+            <Link
+              to="/new-analysis"
+              className={cn(
+                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150',
+                location.pathname === '/new-analysis'
+                  ? 'bg-surface-elevated text-text-primary'
+                  : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+              )}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              New Analysis
+            </Link>
           </nav>
         </div>
         <div className="flex items-center gap-3">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -35,7 +35,7 @@ import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { SortableHeader } from '@/components/shared/SortableHeader'
 import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
 import { useTableSort } from '@/lib/useTableSort'
-import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github, Plus } from 'lucide-react'
+import { Trash2, MessageSquare, CheckCircle2, GitFork, AlertTriangle, Github } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 import { useMetadataOptions, MetadataDropdowns, MetadataLabelChips, MetadataClearButton } from '@/components/shared/MetadataFilterBar'
 import { MetadataBadges } from '@/components/shared/MetadataBadges'
@@ -427,10 +427,6 @@ export function DashboardPage() {
             </SelectContent>
           </Select>
           <MetadataClearButton hasFilters={hasMetadataFilters} onClearAll={clearMetadataFilters} />
-          <Button onClick={() => navigate('/new-analysis')} className="gap-1.5 whitespace-nowrap">
-            <Plus className="h-3.5 w-3.5" />
-            New Analysis
-          </Button>
         </div>
 
         {/* Tag filter chips — only shown when labels exist */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -391,66 +391,46 @@ export function DashboardPage() {
   return (
     <TooltipProvider delayDuration={200}>
       <div className="space-y-6">
-        {/* Header */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="font-display text-xl font-bold text-text-primary">Dashboard</h1>
-            <div className="mt-0.5 flex items-center gap-3">
-              <p className="text-sm text-text-tertiary">
-                {filtered.length} analysis {filtered.length === 1 ? 'run' : 'runs'}
-              </p>
-              <a
-                href={`${GITHUB_REPO_URL}/issues`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="View GitHub issues"
-                className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
-              >
-                <Github className="h-3 w-3" />
-                View Issues
-              </a>
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-3 items-center">
-            <SearchInput value={search} onChange={setSearch} placeholder="Filter jobs..." className="w-full sm:w-64" />
-            <MetadataDropdowns
-              options={metadataOptions}
-              team={metaTeam}
-              tier={metaTier}
-              version={metaVersion}
-              onTeamChange={(v) => setMetaParam('team', v)}
-              onTierChange={(v) => setMetaParam('tier', v)}
-              onVersionChange={(v) => setMetaParam('version', v)}
-            />
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger aria-label="Filter by status" className="w-full sm:w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {STATUS_FILTER_OPTIONS.map((s) => (
-                  <SelectItem key={s} value={s}>
-                    {s === STATUS_FILTER_ALL ? 'All statuses' : s}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} onClear={clearDates} />
-            <Select value={String(perPage)} onValueChange={(v) => setPerPage(Number(v))}>
-              <SelectTrigger aria-label="Rows per page" className="w-full sm:w-20">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="10">10</SelectItem>
-                <SelectItem value="20">20</SelectItem>
-                <SelectItem value="50">50</SelectItem>
-              </SelectContent>
-            </Select>
-            <MetadataClearButton hasFilters={hasMetadataFilters} onClearAll={clearMetadataFilters} />
-            <Button onClick={() => navigate('/new-analysis')} className="gap-1.5 whitespace-nowrap">
-              <Plus className="h-3.5 w-3.5" />
-              New Analysis
-            </Button>
-          </div>
+        {/* Filters — single wrapping row */}
+        <div className="flex flex-wrap gap-3 items-center">
+          <SearchInput value={search} onChange={setSearch} placeholder="Filter jobs..." className="w-full sm:w-64" />
+          <MetadataDropdowns
+            options={metadataOptions}
+            team={metaTeam}
+            tier={metaTier}
+            version={metaVersion}
+            onTeamChange={(v) => setMetaParam('team', v)}
+            onTierChange={(v) => setMetaParam('tier', v)}
+            onVersionChange={(v) => setMetaParam('version', v)}
+          />
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger aria-label="Filter by status" className="w-full sm:w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_FILTER_OPTIONS.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {s === STATUS_FILTER_ALL ? 'All statuses' : s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DateRangeFilter from={dateFrom} to={dateTo} onFromChange={setDateFrom} onToChange={setDateTo} onClear={clearDates} />
+          <Select value={String(perPage)} onValueChange={(v) => setPerPage(Number(v))}>
+            <SelectTrigger aria-label="Rows per page" className="w-full sm:w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="10">10</SelectItem>
+              <SelectItem value="20">20</SelectItem>
+              <SelectItem value="50">50</SelectItem>
+            </SelectContent>
+          </Select>
+          <MetadataClearButton hasFilters={hasMetadataFilters} onClearAll={clearMetadataFilters} />
+          <Button onClick={() => navigate('/new-analysis')} className="gap-1.5 whitespace-nowrap">
+            <Plus className="h-3.5 w-3.5" />
+            New Analysis
+          </Button>
         </div>
 
         {/* Tag filter chips — only shown when labels exist */}
@@ -459,6 +439,23 @@ export function DashboardPage() {
           labels={metaLabels}
           onLabelsChange={setMetaLabels}
         />
+
+        {/* Summary row: count + View Issues */}
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-text-tertiary">
+            {filtered.length} analysis {filtered.length === 1 ? 'run' : 'runs'}
+          </p>
+          <a
+            href={`${GITHUB_REPO_URL}/issues`}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="View GitHub issues"
+            className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-secondary"
+          >
+            <Github className="h-3 w-3" />
+            View Issues
+          </a>
+        </div>
 
         {/* Bulk result message */}
         {bulkResultMessage && (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -444,37 +444,45 @@ class TestAnalyzeFailuresEndpoint:
 
     def test_analyze_failures_missing_ai_provider(self, test_client) -> None:
         """Test that missing AI provider (no env var, no body param) returns 400."""
-        response = test_client.post(
-            "/analyze-failures",
-            json={
-                "failures": [
-                    {
-                        "test_name": "test_foo",
-                        "error_message": "assert False",
-                    }
-                ],
-                "ai_model": "test-model",
-            },
-        )
-        assert response.status_code == 400
-        assert "AI provider" in response.json()["detail"]
+        with (
+            patch("jenkins_job_insight.main.AI_PROVIDER", ""),
+            patch("jenkins_job_insight.main.AI_MODEL", ""),
+        ):
+            response = test_client.post(
+                "/analyze-failures",
+                json={
+                    "failures": [
+                        {
+                            "test_name": "test_foo",
+                            "error_message": "assert False",
+                        }
+                    ],
+                    "ai_model": "test-model",
+                },
+            )
+            assert response.status_code == 400
+            assert "AI provider" in response.json()["detail"]
 
     def test_analyze_failures_missing_ai_model(self, test_client) -> None:
         """Test that missing AI model returns 400."""
-        response = test_client.post(
-            "/analyze-failures",
-            json={
-                "failures": [
-                    {
-                        "test_name": "test_foo",
-                        "error_message": "assert False",
-                    }
-                ],
-                "ai_provider": "claude",
-            },
-        )
-        assert response.status_code == 400
-        assert "AI model" in response.json()["detail"]
+        with (
+            patch("jenkins_job_insight.main.AI_PROVIDER", ""),
+            patch("jenkins_job_insight.main.AI_MODEL", ""),
+        ):
+            response = test_client.post(
+                "/analyze-failures",
+                json={
+                    "failures": [
+                        {
+                            "test_name": "test_foo",
+                            "error_message": "assert False",
+                        }
+                    ],
+                    "ai_provider": "claude",
+                },
+            )
+            assert response.status_code == 400
+            assert "AI model" in response.json()["detail"]
 
     def test_analyze_failures_handles_analysis_exception(self, test_client) -> None:
         """Test that when analyze_failure_group raises, endpoint returns status 'failed'."""


### PR DESCRIPTION
## Summary

Consolidates dashboard filter controls into a single wrapping row layout for a cleaner, more compact UI.

Fixes #214

## Changes

- Removed redundant **Dashboard** heading that duplicated the sidebar navigation context
- Moved the analysis count indicator below the tag filters for better visual hierarchy
- Arranged all filter controls (search, status, tags, date range, clear) on a single wrapping row using `flex-wrap`, eliminating unnecessary vertical stacking

## Result

The filters section is now more compact and scannable, reducing vertical space usage while keeping all controls easily accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "New Analysis" navigation item.

* **Refactor**
  * Reorganized dashboard top area: filter controls moved to their own row; title removed; analysis count (with singular/plural) and GitHub "View Issues" link moved to a separate summary row.

* **Tests**
  * Made tests for missing AI configuration deterministic by explicitly patching the AI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->