### PR TITLE
fix: disambiguate test timeout from analysis timeout in UI

### DIFF
--- a/frontend/src/components/shared/StatusChip.tsx
+++ b/frontend/src/components/shared/StatusChip.tsx
@@ -6,7 +6,7 @@ const STATUS_MAP: Record<string, { variant: 'default' | 'destructive' | 'success
   waiting: { variant: 'warning', label: 'Waiting' },
   pending: { variant: 'outline', label: 'Pending' },
   failed: { variant: 'destructive', label: 'Failed' },
-  timeout: { variant: 'warning', label: 'Timed Out' },
+  timeout: { variant: 'warning', label: 'Analysis Timed Out' },
 }
 
 interface StatusChipProps {

--- a/frontend/src/components/shared/__tests__/StatusChip.test.tsx
+++ b/frontend/src/components/shared/__tests__/StatusChip.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusChip } from '../StatusChip'
+
+describe('StatusChip', () => {
+  it('renders "Analysis Timed Out" for timeout status', () => {
+    render(<StatusChip status="timeout" />)
+    expect(screen.getByText('Analysis Timed Out')).toBeDefined()
+  })
+
+  it('renders "Completed" for completed status', () => {
+    render(<StatusChip status="completed" />)
+    expect(screen.getByText('Completed')).toBeDefined()
+  })
+
+  it('renders "Running" for running status', () => {
+    render(<StatusChip status="running" />)
+    expect(screen.getByText('Running')).toBeDefined()
+  })
+
+  it('renders "Failed" for failed status', () => {
+    render(<StatusChip status="failed" />)
+    expect(screen.getByText('Failed')).toBeDefined()
+  })
+
+  it('renders raw status text for unknown statuses', () => {
+    render(<StatusChip status="custom-status" />)
+    expect(screen.getByText('custom-status')).toBeDefined()
+  })
+})

--- a/frontend/src/pages/report/FailureCard.tsx
+++ b/frontend/src/pages/report/FailureCard.tsx
@@ -21,7 +21,7 @@ import { ClassificationSelect } from './ClassificationSelect'
 import { BugCreationDialog } from './BugCreationDialog'
 import { useReviewSuggestion } from './useReviewSuggestion'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
-import { ChevronDown, ChevronRight, Bug, MessageSquare, CheckCircle2, Copy, Check, Clock } from 'lucide-react'
+import { ChevronDown, ChevronRight, Bug, MessageSquare, CheckCircle2, Copy, Check } from 'lucide-react'
 
 function IssueButton({ disabled, tooltip, label, onClick }: {
   disabled: boolean
@@ -326,12 +326,7 @@ export function FailureCard({ group, jobId, childJobName, childBuildNumber, inde
                   sectionId="analysis"
                   copiedSection={copiedSection}
                   onCopy={copyToClipboard}
-                  extra={/timed?\s*-?\s*out/i.test(analysis.details) ? (
-                    <Badge variant="warning" className="text-[10px] gap-1">
-                      <Clock className="h-3 w-3" />
-                      Timed Out
-                    </Badge>
-                  ) : undefined}
+
                 />
                 <div className="rounded-md bg-glow-blue p-3 text-sm text-text-secondary whitespace-pre-wrap"><LinkedText text={analysis.details} repoUrls={repoUrls} /></div>
               </div>


### PR DESCRIPTION
## Summary

Fixes #217 — Removed the misleading **Timed Out** badge from the analysis section that was incorrectly triggered by test error content containing timeout keywords, and renamed the analysis status chip to **Analysis Timed Out** for clarity.

## Problem / Motivation

The UI displayed a "Timed Out" badge in the analysis results whenever a test's error message contained timeout-related text (e.g., `timed out`). This was confusing because it conflated *test-level timeouts* (the test itself timed out) with *analysis-level timeouts* (the AI analysis process timed out). Users couldn't distinguish between the two, leading to misinterpretation of results.

## Changes

- Removed the misleading Timed Out badge that was scanning test error content for timeout keywords in the analysis section
- Renamed the analysis status chip from "Timed Out" to "Analysis Timed Out" to make it unambiguous that it refers to the analysis process, not the test itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for status displays.

* **Bug Fixes**
  * Updated timeout status label to display more descriptive text.
  * Removed redundant timeout warning badge from failure reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->