### PR TITLE
feat: search tests repo for related issues on code issue classification

### DIFF
--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -281,9 +281,18 @@ If CODE ISSUE:
     "line": "line number",
     "change": "specific code change that fixes all affected tests",
     "original_code": "optional complete current contents of exact/file/path.py for diff/editor display (raw code string, NO markdown formatting)",
-    "suggested_code": "complete replacement contents of exact/file/path.py after applying the fix (raw code string, NO markdown formatting)"
+    "suggested_code": "complete replacement contents of exact/file/path.py after applying the fix (raw code string, NO markdown formatting)",
+    "tests_repo_search_keywords": ["specific error symptom", "component + behavior", "error type"]
   }
 }
+
+tests_repo_search_keywords rules:
+- Generate 3-5 SHORT specific keywords for finding matching issues in the tests repository
+- Focus on the specific error symptom and broken behavior from the test code perspective
+- Combine component name with the specific failure (e.g. "fixture setup timeout", "API mock validation error")
+- AVOID generic/broad terms alone like "timeout", "failure", "error"
+- Each keyword should be specific enough to narrow GitHub issue search results to relevant issues
+- Think: "what would someone title a GitHub issue for this exact test code problem?"
 
 If PRODUCT BUG:
 {
@@ -468,6 +477,14 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
         suggested_code_match = re.search(
             r'"suggested_code"\s*:\s*"((?:[^"\\]|\\.)*)"', details, re.DOTALL
         )
+        tests_repo_kw_match = re.search(
+            r'"tests_repo_search_keywords"\s*:\s*\[([^\]]*)\]', details
+        )
+        tests_repo_keywords = (
+            re.findall(r'"([^"]+)"', tests_repo_kw_match.group(1))
+            if tests_repo_kw_match
+            else []
+        )
         code_fix = CodeFix(
             file=file_match.group(1),
             line=line_match.group(1) if line_match else "",
@@ -482,6 +499,7 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
                 if suggested_code_match
                 else None
             ),
+            tests_repo_search_keywords=tests_repo_keywords,
         )
 
     # Extract artifacts_evidence (top-level field)

--- a/src/jenkins_job_insight/analyzer.py
+++ b/src/jenkins_job_insight/analyzer.py
@@ -419,6 +419,34 @@ def _decode_recovered_json_string(value: str) -> str:
         return value.replace("\\n", "\n")
 
 
+def _extract_string_array_field(details: str, field_name: str) -> list[str]:
+    """Extract a JSON string-array field from raw AI response text.
+
+    Searches for ``"field_name": [...]`` via regex, parses the array
+    content, strips whitespace, removes empty/whitespace-only entries,
+    and deduplicates while preserving order.
+
+    Args:
+        details: Raw AI response text.
+        field_name: JSON field name whose value is a string array.
+
+    Returns:
+        Deduplicated list of non-empty strings, or ``[]`` on failure.
+    """
+    match = re.search(rf'"{re.escape(field_name)}"\s*:\s*\[([^\]]*)\]', details)
+    if not match:
+        return []
+    raw = re.findall(r'"([^"]+)"', match.group(1))
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in raw:
+        stripped = item.strip()
+        if stripped and stripped not in seen:
+            seen.add(stripped)
+            result.append(stripped)
+    return result
+
+
 def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
     """Attempt to recover structured fields from a fallback result.
 
@@ -477,13 +505,8 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
         suggested_code_match = re.search(
             r'"suggested_code"\s*:\s*"((?:[^"\\]|\\.)*)"', details, re.DOTALL
         )
-        tests_repo_kw_match = re.search(
-            r'"tests_repo_search_keywords"\s*:\s*\[([^\]]*)\]', details
-        )
-        tests_repo_keywords = (
-            re.findall(r'"([^"]+)"', tests_repo_kw_match.group(1))
-            if tests_repo_kw_match
-            else []
+        tests_repo_keywords = _extract_string_array_field(
+            details, "tests_repo_search_keywords"
         )
         code_fix = CodeFix(
             file=file_match.group(1),
@@ -519,12 +542,7 @@ def _recover_from_details(result: AnalysisDetail) -> AnalysisDetail:
         evidence_match = re.search(
             r'"evidence"\s*:\s*"((?:[^"\\]|\\.)*)"', details, re.DOTALL
         )
-        keywords_match = re.search(
-            r'"jira_search_keywords"\s*:\s*\[([^\]]*)\]', details
-        )
-        jira_keywords = (
-            re.findall(r'"([^"]+)"', keywords_match.group(1)) if keywords_match else []
-        )
+        jira_keywords = _extract_string_array_field(details, "jira_search_keywords")
 
         product_bug_report = ProductBugReport(
             title=title_match.group(1),

--- a/src/jenkins_job_insight/github_issues.py
+++ b/src/jenkins_job_insight/github_issues.py
@@ -1,0 +1,282 @@
+"""GitHub Issues integration for code issue deduplication.
+
+Searches the tests repository's GitHub Issues for existing issues that
+match code issue failures (AUTOMATION BUG, TEST CODE BUG, CODE ISSUE),
+then uses AI to determine actual relevance, helping teams avoid filing
+duplicate issues.
+
+Mirrors the Jira integration pattern in ``jira.py``.
+"""
+
+import asyncio
+import os
+import re
+from collections.abc import Sequence
+
+import httpx
+from simple_logger.logger import get_logger
+
+from jenkins_job_insight.config import Settings
+from jenkins_job_insight.issue_matching import filter_issue_matches_with_ai
+from jenkins_job_insight.models import (
+    AnalysisDetail,
+    CodeFix,
+    FailureAnalysis,
+    SimilarIssue,
+)
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+# Classifications considered "code issues" for tests repo search
+_CODE_ISSUE_CLASSIFICATIONS = frozenset({"CODE ISSUE"})
+
+
+def _parse_github_repo_url(repo_url: str) -> tuple[str, str]:
+    """Extract owner and repo from a GitHub repository URL.
+
+    Reuses the same regex as ``bug_creation._parse_github_repo_url``
+    but is defined here to avoid circular imports.
+
+    Returns (owner, repo) tuple.
+
+    Raises ValueError if the URL cannot be parsed.
+    """
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$", repo_url)
+    if not match:
+        raise ValueError(f"Cannot parse GitHub repo URL: {repo_url}")
+    return match.group(1), match.group(2)
+
+
+async def search_github_issues(
+    keywords: list[str],
+    repo_url: str,
+    github_token: str = "",
+    max_results: int = 10,
+) -> list[dict]:
+    """Search GitHub Issues API for issues matching the given keywords.
+
+    Args:
+        keywords: Search terms to look for.
+        repo_url: GitHub repository URL (e.g. https://github.com/owner/repo).
+        github_token: Optional GitHub token for authenticated requests.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        List of candidate dicts with key, title, description, status, url.
+        Returns empty list on any error.
+    """
+    if not keywords:
+        return []
+
+    try:
+        owner, repo = _parse_github_repo_url(repo_url)
+    except ValueError:
+        logger.warning("Could not parse GitHub repo URL for issue search: %s", repo_url)
+        return []
+
+    headers: dict[str, str] = {"Accept": "application/vnd.github.v3+json"}
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    # Build search query from keywords
+    query_parts = " ".join(keywords)
+    search_query = f"{query_parts} repo:{owner}/{repo} is:issue"
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(
+                "https://api.github.com/search/issues",
+                params={
+                    "q": search_query,
+                    "per_page": max_results,
+                    "sort": "updated",
+                    "order": "desc",
+                },
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                logger.debug(
+                    "GitHub Issues search returned status %d", resp.status_code
+                )
+                return []
+            data = resp.json()
+            candidates: list[dict] = []
+            for item in data.get("items", []):
+                candidates.append(
+                    {
+                        "key": str(item["number"]),
+                        "title": item.get("title", ""),
+                        "summary": item.get("title", ""),
+                        "description": item.get("body", "") or "",
+                        "status": item.get("state", ""),
+                        "url": item.get("html_url", ""),
+                        "number": item["number"],
+                    }
+                )
+            return candidates
+    except Exception:
+        logger.debug("GitHub Issues search failed", exc_info=True)
+        return []
+
+
+def _collect_code_fix_reports(
+    failures: Sequence[FailureAnalysis],
+) -> list[tuple[FailureAnalysis, CodeFix]]:
+    """Collect all failures with CodeFix instances that have search keywords.
+
+    Args:
+        failures: List of failure analyses to scan.
+
+    Returns:
+        List of (failure, code_fix) tuples for code issue failures.
+    """
+    results: list[tuple[FailureAnalysis, CodeFix]] = []
+    for failure in failures:
+        detail: AnalysisDetail = failure.analysis
+        if (
+            isinstance(detail.code_fix, CodeFix)
+            and detail.classification.upper() in _CODE_ISSUE_CLASSIFICATIONS
+        ):
+            results.append((failure, detail.code_fix))
+    return results
+
+
+async def enrich_with_tests_repo_matches(
+    failures: Sequence[FailureAnalysis],
+    settings: Settings,
+    ai_provider: str = "",
+    ai_model: str = "",
+    job_id: str = "",
+) -> None:
+    """Search GitHub Issues for matching issues and attach results in-place.
+
+    Collects CODE ISSUE failures with tests_repo_search_keywords,
+    deduplicates by keyword set, searches GitHub in parallel,
+    uses AI to filter relevant matches, and attaches results to
+    each ``CodeFix.tests_repo_matches``.
+
+    This function never raises — all errors are logged and swallowed
+    so the analysis pipeline is never interrupted.
+
+    Args:
+        failures: Failure analyses to enrich (modified in-place).
+        settings: Application settings with tests repo configuration.
+        ai_provider: AI provider for relevance filtering.
+        ai_model: AI model for relevance filtering.
+        job_id: Job identifier for token usage tracking.
+    """
+    tests_repo_url = settings.tests_repo_url
+    if not tests_repo_url:
+        return
+
+    github_token = (
+        settings.github_token.get_secret_value() if settings.github_token else ""
+    )
+
+    code_fix_pairs = _collect_code_fix_reports(failures)
+    if not code_fix_pairs:
+        return
+
+    # Deduplicate by keyword set — same keywords = one GitHub search
+    keyword_to_pairs: dict[tuple[str, ...], list[tuple[FailureAnalysis, CodeFix]]] = {}
+    for failure, code_fix in code_fix_pairs:
+        if not code_fix.tests_repo_search_keywords:
+            continue
+        key = tuple(sorted(code_fix.tests_repo_search_keywords))
+        keyword_to_pairs.setdefault(key, []).append((failure, code_fix))
+
+    if not keyword_to_pairs:
+        logger.debug(
+            "No CODE ISSUE failures with tests_repo_search_keywords, "
+            "skipping GitHub Issues lookup"
+        )
+        return
+
+    logger.info(
+        "Searching GitHub Issues for %d unique keyword set(s) across %d CODE ISSUE failure(s)",
+        len(keyword_to_pairs),
+        len(code_fix_pairs),
+    )
+
+    total_matches = 0
+    try:
+        # Search GitHub for each unique keyword set in parallel
+        async def _search_safe(keywords: list[str]) -> list[dict]:
+            try:
+                return await search_github_issues(
+                    keywords, tests_repo_url, github_token
+                )
+            except Exception:
+                logger.exception(
+                    "GitHub Issues search failed for keywords: %s", keywords
+                )
+                return []
+
+        tasks = [_search_safe(list(kw_tuple)) for kw_tuple in keyword_to_pairs]
+        search_results = await asyncio.gather(*tasks)
+
+        # AI relevance filtering for each keyword set
+        for kw_tuple, candidates in zip(keyword_to_pairs, search_results):
+            if not candidates:
+                continue
+
+            # Use the first failure's details as context for AI filtering
+            representative_failure, representative_fix = keyword_to_pairs[kw_tuple][0]
+
+            if ai_provider and ai_model:
+                evaluations = await filter_issue_matches_with_ai(
+                    bug_title=f"{representative_fix.file}: {representative_fix.change}",
+                    bug_description=(
+                        f"Test: {representative_failure.test_name}\n"
+                        f"Error: {representative_failure.error}\n"
+                        f"Analysis: {representative_failure.analysis.details}"
+                    ),
+                    candidates=candidates,
+                    ai_provider=ai_provider,
+                    ai_model=ai_model,
+                    ai_cli_timeout=settings.ai_cli_timeout,
+                    job_id=job_id,
+                    call_type="tests_repo_filter",
+                )
+
+                # Convert evaluations to SimilarIssue objects
+                candidate_by_key = {c["key"]: c for c in candidates}
+                matches = [
+                    SimilarIssue(
+                        number=candidate_by_key[ev["key"]].get("number"),
+                        title=candidate_by_key[ev["key"]].get("title", ""),
+                        url=candidate_by_key[ev["key"]].get("url", ""),
+                        status=candidate_by_key[ev["key"]].get("status", ""),
+                    )
+                    for ev in evaluations
+                    if ev["key"] in candidate_by_key
+                ]
+            else:
+                # No AI config — fall back to returning all candidates as matches
+                logger.debug(
+                    "No AI provider configured for GitHub Issues relevance filtering, "
+                    "returning all candidates"
+                )
+                matches = [
+                    SimilarIssue(
+                        number=c.get("number"),
+                        title=c.get("title", ""),
+                        url=c.get("url", ""),
+                        status=c.get("status", ""),
+                    )
+                    for c in candidates
+                ]
+
+            # Attach matches to all code_fix objects sharing the same keyword set
+            for _failure, code_fix in keyword_to_pairs[kw_tuple]:
+                code_fix.tests_repo_matches = matches
+
+            total_matches += len(matches)
+
+        logger.info(
+            "GitHub Issues search complete: %d relevant match(es) found",
+            total_matches,
+        )
+
+    except Exception:
+        logger.exception("GitHub Issues enrichment failed unexpectedly")

--- a/src/jenkins_job_insight/issue_matching.py
+++ b/src/jenkins_job_insight/issue_matching.py
@@ -1,0 +1,153 @@
+"""Shared AI relevance filtering for issue matching (Jira, GitHub, etc.).
+
+Provides the common logic for using AI to evaluate whether candidate
+issues from any tracker match a given bug/failure description.
+"""
+
+import json
+import os
+
+from simple_logger.logger import get_logger
+
+from ai_cli_runner import call_ai_cli
+from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
+from jenkins_job_insight.token_tracking import record_ai_usage
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+async def filter_issue_matches_with_ai(
+    bug_title: str,
+    bug_description: str,
+    candidates: list[dict],
+    ai_provider: str,
+    ai_model: str,
+    ai_cli_timeout: int | None = None,
+    job_id: str = "",
+    call_type: str = "issue_filter",
+) -> list[dict]:
+    """Use AI to determine which candidate issues are relevant to a bug.
+
+    Sends the bug context and all candidate issues to the AI, asking it
+    to evaluate relevance. Returns evaluation dicts for relevant candidates
+    only. The caller is responsible for converting these into the appropriate
+    model type (JiraMatch, SimilarIssue, etc.).
+
+    Each candidate dict must have a ``key`` field used as the identifier.
+
+    Args:
+        bug_title: The bug/failure report title.
+        bug_description: The bug/failure report description.
+        candidates: List of candidate dicts from issue search.
+            Each must have ``key``, ``summary``/``title``, ``description``,
+            and ``status`` fields.
+        ai_provider: AI provider name.
+        ai_model: AI model identifier.
+        ai_cli_timeout: Timeout in minutes (overrides AI_CLI_TIMEOUT env var).
+        job_id: Job identifier for token usage tracking.
+        call_type: Token tracking call type label.
+
+    Returns:
+        List of dicts with ``key``, ``relevant`` (True), and ``score`` for
+        relevant candidates only, sorted by score descending.
+    """
+    if not candidates:
+        return []
+
+    # Build candidate list for the AI prompt
+    candidate_lines = []
+    for i, c in enumerate(candidates, 1):
+        title = c.get("summary") or c.get("title") or ""
+        desc = c.get("description") or "No description"
+        status = c.get("status", "")
+        key = c.get("key", "")
+        candidate_lines.append(
+            f"{i}. {key} [{status}] - {title}\n   Description: {desc}"
+        )
+
+    prompt = f"""You are evaluating whether existing issue tickets match a newly discovered bug.
+
+NEW BUG:
+Title: {bug_title}
+Description: {bug_description}
+
+CANDIDATES:
+{chr(10).join(candidate_lines)}
+
+For each candidate, determine if it describes the SAME bug or a closely related issue
+(including regressions of previously fixed bugs).
+
+A match means the ticket describes essentially the same broken behavior,
+not just that it mentions similar components or technologies.
+
+Respond with ONLY a JSON array. For each candidate include:
+- "key": the issue key/identifier
+- "relevant": true or false
+- "score": relevance score 0.0 to 1.0 (1.0 = exact same bug, 0.5+ = likely related)
+
+Example: [{{"key": "PROJ-123", "relevant": true, "score": 0.9}}, {{"key": "PROJ-456", "relevant": false, "score": 0.1}}]
+
+Respond with ONLY the JSON array, no other text."""
+
+    result = await call_ai_cli(
+        prompt,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        ai_cli_timeout=ai_cli_timeout,
+        cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
+        output_format="json",
+    )
+
+    if job_id:
+        await record_ai_usage(
+            job_id=job_id,
+            result=result,
+            call_type=call_type,
+            prompt_chars=len(prompt),
+            ai_provider=ai_provider,
+            ai_model=ai_model,
+        )
+
+    if not result.success:
+        logger.warning("AI relevance filtering failed: %s", result.text)
+        return []
+
+    # Parse AI response
+    try:
+        text = result.text.strip()
+        # Strip markdown code block if present
+        if "```json" in text:
+            start = text.index("```json") + len("```json")
+            end = text.index("```", start)
+            text = text[start:end].strip()
+        elif "```" in text:
+            start = text.index("```") + len("```")
+            end = text.index("```", start)
+            text = text[start:end].strip()
+
+        json_start = text.find("[")
+        json_end = text.rfind("]")
+        if json_start != -1 and json_end != -1:
+            text = text[json_start : json_end + 1]
+
+        evaluations = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Failed to parse AI relevance response")
+        return []
+
+    relevant: list[dict] = []
+    for evaluation in evaluations:
+        if not isinstance(evaluation, dict):
+            continue
+        key = evaluation.get("key", "")
+        is_relevant = evaluation.get("relevant", False)
+        try:
+            score = float(evaluation.get("score", 0.0))
+        except (ValueError, TypeError):
+            score = 0.0
+
+        if is_relevant and key:
+            relevant.append({"key": key, "relevant": True, "score": score})
+
+    relevant.sort(key=lambda m: m["score"], reverse=True)
+    return relevant

--- a/src/jenkins_job_insight/jira.py
+++ b/src/jenkins_job_insight/jira.py
@@ -6,23 +6,20 @@ filing duplicate bug reports.
 """
 
 import asyncio
-import json
 import os
 from collections.abc import Sequence
 
 import httpx
 from simple_logger.logger import get_logger
 
-from ai_cli_runner import call_ai_cli
-from jenkins_job_insight.analyzer import PROVIDER_CLI_FLAGS
 from jenkins_job_insight.config import Settings, _resolve_jira_auth
+from jenkins_job_insight.issue_matching import filter_issue_matches_with_ai
 from jenkins_job_insight.models import (
     AnalysisDetail,
     FailureAnalysis,
     JiraMatch,
     ProductBugReport,
 )
-from jenkins_job_insight.token_tracking import record_ai_usage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -323,9 +320,8 @@ async def _filter_matches_with_ai(
 ) -> list[JiraMatch]:
     """Use AI to determine which Jira candidates are relevant to the bug.
 
-    Sends the bug context and all candidate issues to the AI, asking it
-    to evaluate relevance. Only candidates the AI deems relevant are
-    returned as JiraMatch objects.
+    Delegates to the shared :func:`filter_issue_matches_with_ai` and
+    converts the results into Jira-specific ``JiraMatch`` objects.
 
     Args:
         bug_title: The product bug report title.
@@ -339,103 +335,24 @@ async def _filter_matches_with_ai(
     Returns:
         List of JiraMatch objects for relevant candidates only.
     """
-    if not candidates:
-        return []
-
-    # Build candidate list for the AI prompt
-    candidate_lines = []
-    for i, c in enumerate(candidates, 1):
-        desc_preview = c["description"] if c["description"] else "No description"
-        candidate_lines.append(
-            f"{i}. {c['key']} [{c['status']}] - {c['summary']}\n"
-            f"   Description: {desc_preview}"
-        )
-
-    prompt = f"""You are evaluating whether existing Jira bug tickets match a newly discovered bug.
-
-NEW BUG:
-Title: {bug_title}
-Description: {bug_description}
-
-JIRA CANDIDATES:
-{chr(10).join(candidate_lines)}
-
-For each candidate, determine if it describes the SAME bug or a closely related issue
-(including regressions of previously fixed bugs).
-
-A match means the Jira ticket describes essentially the same broken behavior,
-not just that it mentions similar components or technologies.
-
-Respond with ONLY a JSON array. For each candidate include:
-- "key": the Jira issue key
-- "relevant": true or false
-- "score": relevance score 0.0 to 1.0 (1.0 = exact same bug, 0.5+ = likely related)
-
-Example: [{{"key": "PROJ-123", "relevant": true, "score": 0.9}}, {{"key": "PROJ-456", "relevant": false, "score": 0.1}}]
-
-Respond with ONLY the JSON array, no other text."""
-
-    result = await call_ai_cli(
-        prompt,
+    # Ensure candidates have a consistent 'key' field for the shared filter
+    evaluations = await filter_issue_matches_with_ai(
+        bug_title=bug_title,
+        bug_description=bug_description,
+        candidates=candidates,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
-        cli_flags=PROVIDER_CLI_FLAGS.get(ai_provider, []),
-        output_format="json",
+        job_id=job_id,
+        call_type="jira_filter",
     )
 
-    if job_id:
-        await record_ai_usage(
-            job_id=job_id,
-            result=result,
-            call_type="jira_filter",
-            prompt_chars=len(prompt),
-            ai_provider=ai_provider,
-            ai_model=ai_model,
-        )
-
-    if not result.success:
-        logger.warning("AI relevance filtering failed: %s", result.text)
-        return []
-
-    # Parse AI response
-    try:
-        text = result.text.strip()
-        # Strip markdown code block if present
-        if "```json" in text:
-            start = text.index("```json") + len("```json")
-            end = text.index("```", start)
-            text = text[start:end].strip()
-        elif "```" in text:
-            start = text.index("```") + len("```")
-            end = text.index("```", start)
-            text = text[start:end].strip()
-
-        json_start = text.find("[")
-        json_end = text.rfind("]")
-        if json_start != -1 and json_end != -1:
-            text = text[json_start : json_end + 1]
-
-        evaluations = json.loads(text)
-    except (json.JSONDecodeError, ValueError):
-        logger.warning("Failed to parse AI relevance response")
-        return []
-
-    # Build lookup of candidate data by key
+    # Convert evaluations to JiraMatch objects
     candidate_by_key = {c["key"]: c for c in candidates}
-
     relevant_matches: list[JiraMatch] = []
-    for evaluation in evaluations:
-        if not isinstance(evaluation, dict):
-            continue
-        key = evaluation.get("key", "")
-        is_relevant = evaluation.get("relevant", False)
-        try:
-            score = float(evaluation.get("score", 0.0))
-        except (ValueError, TypeError):
-            score = 0.0
-
-        if is_relevant and key in candidate_by_key:
+    for ev in evaluations:
+        key = ev["key"]
+        if key in candidate_by_key:
             c = candidate_by_key[key]
             relevant_matches.append(
                 JiraMatch(
@@ -444,11 +361,10 @@ Respond with ONLY the JSON array, no other text."""
                     status=c["status"],
                     priority=c["priority"],
                     url=c["url"],
-                    score=score,
+                    score=ev["score"],
                 )
             )
 
-    relevant_matches.sort(key=lambda m: m.score, reverse=True)
     return relevant_matches
 
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1212,13 +1212,13 @@ async def _enrich_result_with_tests_repo_matches(
             temporary settings copy is created so that
             ``enrich_with_tests_repo_matches`` sees the URL.
     """
-    effective_url = str(settings.tests_repo_url or "") or tests_repo_url
+    effective_url = tests_repo_url or str(settings.tests_repo_url or "")
     if not effective_url:
         return
 
     # When the URL came from the request (not env), inject it into a
     # settings copy so downstream helpers see it.
-    if not settings.tests_repo_url and effective_url:
+    if effective_url != str(settings.tests_repo_url or ""):
         merged_data = settings.model_dump(mode="python")
         merged_data["tests_repo_url"] = effective_url
         settings = Settings.model_validate(merged_data)

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -9,6 +9,7 @@ import time as _time
 import urllib.parse
 import uuid
 from collections import defaultdict
+from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, Any, Coroutine, Literal
@@ -46,6 +47,7 @@ from jenkins_job_insight.encryption import (
     decrypt_sensitive_fields,
     encrypt_sensitive_fields,
 )
+from jenkins_job_insight.github_issues import enrich_with_tests_repo_matches
 from jenkins_job_insight.jira import enrich_with_jira_matches
 from jenkins_job_insight.token_tracking import build_token_usage_summary
 from jenkins_job_insight.monitoring import (
@@ -1133,6 +1135,29 @@ def _merge_settings(body: BaseAnalysisRequest, settings: Settings) -> Settings:
     return settings
 
 
+def _collect_all_failures(
+    items: Sequence[FailureAnalysis | ChildJobAnalysis],
+) -> list[FailureAnalysis]:
+    """Recursively collect all FailureAnalysis objects from a mixed list.
+
+    Recurses into ChildJobAnalysis objects to find nested failures.
+
+    Args:
+        items: Mixed list of FailureAnalysis and ChildJobAnalysis objects.
+
+    Returns:
+        Flat list of all FailureAnalysis objects found.
+    """
+    result: list[FailureAnalysis] = []
+    for item in items:
+        if isinstance(item, FailureAnalysis):
+            result.append(item)
+        elif isinstance(item, ChildJobAnalysis):
+            result.extend(_collect_all_failures(item.failures))
+            result.extend(_collect_all_failures(item.failed_children))
+    return result
+
+
 async def _enrich_result_with_jira(
     failures: list[FailureAnalysis | ChildJobAnalysis],
     settings: Settings,
@@ -1156,19 +1181,37 @@ async def _enrich_result_with_jira(
     if not settings.jira_enabled:
         return
 
-    all_failures: list[FailureAnalysis] = []
-
-    def _collect(items: list) -> None:
-        for item in items:
-            if isinstance(item, FailureAnalysis):
-                all_failures.append(item)
-            elif isinstance(item, ChildJobAnalysis):
-                _collect(item.failures)
-                _collect(item.failed_children)
-
-    _collect(failures)
-
+    all_failures = _collect_all_failures(failures)
     await enrich_with_jira_matches(
+        all_failures, settings, ai_provider, ai_model, job_id=job_id
+    )
+
+
+async def _enrich_result_with_tests_repo_matches(
+    failures: list[FailureAnalysis | ChildJobAnalysis],
+    settings: Settings,
+    ai_provider: str = "",
+    ai_model: str = "",
+    job_id: str = "",
+) -> None:
+    """Enrich CODE ISSUE failures with tests repo issue matches.
+
+    Collects all FailureAnalysis objects from the provided list,
+    recursing into ChildJobAnalysis objects, then searches GitHub
+    Issues for matching issues. Results are attached in-place.
+
+    Args:
+        failures: Mixed list of FailureAnalysis and ChildJobAnalysis objects.
+        settings: Application settings with tests repo configuration.
+        ai_provider: AI provider for relevance filtering.
+        ai_model: AI model for relevance filtering.
+        job_id: Job identifier for token usage tracking.
+    """
+    if not settings.tests_repo_url:
+        return
+
+    all_failures = _collect_all_failures(failures)
+    await enrich_with_tests_repo_matches(
         all_failures, settings, ai_provider, ai_model, job_id=job_id
     )
 
@@ -1403,6 +1446,20 @@ async def process_analysis_with_id(
                 f"process_analysis_with_id: enriching with Jira matches, job_id={job_id}"
             )
             await _enrich_result_with_jira(
+                result.failures + list(result.child_job_analyses),
+                settings,
+                ai_provider,
+                ai_model,
+                job_id=job_id,
+            )
+
+        # Enrich CODE ISSUE failures with tests repo issue matches
+        if settings.tests_repo_url:
+            await _safe_update_progress_phase("enriching_tests_repo")
+            logger.debug(
+                f"process_analysis_with_id: enriching with tests repo matches, job_id={job_id}"
+            )
+            await _enrich_result_with_tests_repo_matches(
                 result.failures + list(result.child_job_analyses),
                 settings,
                 ai_provider,
@@ -1852,6 +1909,12 @@ async def analyze_failures(
         # Enrich PRODUCT BUG failures with Jira matches
         if _resolve_enable_jira(body, merged):
             await enrich_with_jira_matches(
+                all_analyses, merged, ai_provider, ai_model, job_id=job_id
+            )
+
+        # Enrich CODE ISSUE failures with tests repo issue matches
+        if merged.tests_repo_url:
+            await enrich_with_tests_repo_matches(
                 all_analyses, merged, ai_provider, ai_model, job_id=job_id
             )
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1213,6 +1213,7 @@ async def _enrich_result_with_tests_repo_matches(
             ``enrich_with_tests_repo_matches`` sees the URL.
     """
     effective_url = tests_repo_url or str(settings.tests_repo_url or "")
+    effective_url, _ = parse_repo_ref(effective_url)
     if not effective_url:
         return
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -1193,6 +1193,7 @@ async def _enrich_result_with_tests_repo_matches(
     ai_provider: str = "",
     ai_model: str = "",
     job_id: str = "",
+    tests_repo_url: str = "",
 ) -> None:
     """Enrich CODE ISSUE failures with tests repo issue matches.
 
@@ -1206,9 +1207,21 @@ async def _enrich_result_with_tests_repo_matches(
         ai_provider: AI provider for relevance filtering.
         ai_model: AI model for relevance filtering.
         job_id: Job identifier for token usage tracking.
+        tests_repo_url: Per-request tests repo URL override.  When
+            non-empty and ``settings.tests_repo_url`` is unset, a
+            temporary settings copy is created so that
+            ``enrich_with_tests_repo_matches`` sees the URL.
     """
-    if not settings.tests_repo_url:
+    effective_url = str(settings.tests_repo_url or "") or tests_repo_url
+    if not effective_url:
         return
+
+    # When the URL came from the request (not env), inject it into a
+    # settings copy so downstream helpers see it.
+    if not settings.tests_repo_url and effective_url:
+        merged_data = settings.model_dump(mode="python")
+        merged_data["tests_repo_url"] = effective_url
+        settings = Settings.model_validate(merged_data)
 
     all_failures = _collect_all_failures(failures)
     await enrich_with_tests_repo_matches(
@@ -1454,7 +1467,8 @@ async def process_analysis_with_id(
             )
 
         # Enrich CODE ISSUE failures with tests repo issue matches
-        if settings.tests_repo_url:
+        request_tests_repo_url = str(body.tests_repo_url or "")
+        if settings.tests_repo_url or request_tests_repo_url:
             await _safe_update_progress_phase("enriching_tests_repo")
             logger.debug(
                 f"process_analysis_with_id: enriching with tests repo matches, job_id={job_id}"
@@ -1465,6 +1479,7 @@ async def process_analysis_with_id(
                 ai_provider,
                 ai_model,
                 job_id=job_id,
+                tests_repo_url=request_tests_repo_url,
             )
 
         await _safe_update_progress_phase("saving")
@@ -1913,9 +1928,14 @@ async def analyze_failures(
             )
 
         # Enrich CODE ISSUE failures with tests repo issue matches
-        if merged.tests_repo_url:
-            await enrich_with_tests_repo_matches(
-                all_analyses, merged, ai_provider, ai_model, job_id=job_id
+        if merged.tests_repo_url or tests_repo_url:
+            await _enrich_result_with_tests_repo_matches(
+                all_analyses,
+                merged,
+                ai_provider,
+                ai_model,
+                job_id=job_id,
+                tests_repo_url=tests_repo_url,
             )
 
         # If raw_xml was provided, produce enriched XML

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -302,6 +302,14 @@ class CodeFix(BaseModel):
         default=None,
         description="Complete replacement file content after applying the suggested fix (raw string, no markdown)",
     )
+    tests_repo_search_keywords: list[str] = Field(
+        default_factory=list,
+        description="AI-suggested keywords for searching related issues in the tests repository",
+    )
+    tests_repo_matches: list["SimilarIssue"] = Field(
+        default_factory=list,
+        description="Matched issues from the tests repository (populated in post-processing)",
+    )
 
 
 class AnalysisDetail(BaseModel):
@@ -909,3 +917,7 @@ class FeedbackResponse(BaseModel):
     issue_url: str = Field(description="URL to the created GitHub issue")
     issue_number: int = Field(description="GitHub issue number")
     title: str = Field(description="Issue title as created")
+
+
+# Resolve forward references (CodeFix references SimilarIssue which is defined later)
+CodeFix.model_rebuild()

--- a/src/jenkins_job_insight/models.py
+++ b/src/jenkins_job_insight/models.py
@@ -311,6 +311,18 @@ class CodeFix(BaseModel):
         description="Matched issues from the tests repository (populated in post-processing)",
     )
 
+    @field_validator("tests_repo_search_keywords")
+    @classmethod
+    def _normalize_tests_repo_search_keywords(cls, v: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for item in v:
+            stripped = item.strip()
+            if stripped and stripped not in seen:
+                seen.add(stripped)
+                result.append(stripped)
+        return result
+
 
 class AnalysisDetail(BaseModel):
     """Structured AI analysis broken into sections."""

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -1,0 +1,513 @@
+"""Tests for GitHub Issues integration (tests repo issue matching)."""
+
+import os
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from jenkins_job_insight.config import Settings
+from jenkins_job_insight.github_issues import (
+    _CODE_ISSUE_CLASSIFICATIONS,
+    _collect_code_fix_reports,
+    _parse_github_repo_url,
+    enrich_with_tests_repo_matches,
+    search_github_issues,
+)
+from jenkins_job_insight.models import (
+    AnalysisDetail,
+    CodeFix,
+    FailureAnalysis,
+)
+
+
+_BASE_ENV = {
+    "JENKINS_URL": "https://jenkins.example.com",
+    "JENKINS_USER": "testuser",
+    "JENKINS_PASSWORD": "testpassword",  # pragma: allowlist secret
+}
+
+
+@pytest.fixture
+def settings_with_tests_repo() -> Generator[Settings, None, None]:
+    """Create Settings with TESTS_REPO_URL and GITHUB_TOKEN configured."""
+    env = {
+        **_BASE_ENV,
+        "TESTS_REPO_URL": "https://github.com/org/test-repo",
+        "GITHUB_TOKEN": "ghp_test_token_123",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        yield Settings(_env_file=None)
+
+
+@pytest.fixture
+def settings_no_tests_repo() -> Generator[Settings, None, None]:
+    """Create Settings without TESTS_REPO_URL."""
+    with patch.dict(os.environ, _BASE_ENV, clear=True):
+        yield Settings(_env_file=None)
+
+
+@pytest.fixture
+def code_issue_failure() -> FailureAnalysis:
+    """A failure classified as CODE ISSUE with search keywords."""
+    return FailureAnalysis(
+        test_name="test_login_form",
+        error="AssertionError: element not found",
+        analysis=AnalysisDetail(
+            classification="CODE ISSUE",
+            details="Test selector is outdated",
+            code_fix=CodeFix(
+                file="tests/test_login.py",
+                line="42",
+                change="Update CSS selector",
+                tests_repo_search_keywords=[
+                    "login form selector",
+                    "element not found login",
+                    "CSS selector update",
+                ],
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def code_issue_no_keywords() -> FailureAnalysis:
+    """A CODE ISSUE failure without search keywords."""
+    return FailureAnalysis(
+        test_name="test_config",
+        error="ImportError",
+        analysis=AnalysisDetail(
+            classification="CODE ISSUE",
+            details="Missing import",
+            code_fix=CodeFix(
+                file="tests/test_config.py",
+                line="10",
+                change="Add missing import",
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def product_bug_failure() -> FailureAnalysis:
+    """A failure classified as PRODUCT BUG (should be skipped)."""
+    return FailureAnalysis(
+        test_name="test_api",
+        error="HTTP 500",
+        analysis=AnalysisDetail(
+            classification="PRODUCT BUG",
+            details="API broken",
+        ),
+    )
+
+
+class TestParseGitHubRepoUrl:
+    """Tests for _parse_github_repo_url."""
+
+    def test_parses_https_url(self) -> None:
+        owner, repo = _parse_github_repo_url("https://github.com/org/my-repo")
+        assert owner == "org"
+        assert repo == "my-repo"
+
+    def test_parses_git_url(self) -> None:
+        owner, repo = _parse_github_repo_url("https://github.com/org/my-repo.git")
+        assert owner == "org"
+        assert repo == "my-repo"
+
+    def test_parses_trailing_slash(self) -> None:
+        owner, repo = _parse_github_repo_url("https://github.com/org/my-repo/")
+        assert owner == "org"
+        assert repo == "my-repo"
+
+    def test_raises_on_invalid_url(self) -> None:
+        with pytest.raises(ValueError, match="Cannot parse"):
+            _parse_github_repo_url("https://gitlab.com/org/repo")
+
+    def test_raises_on_non_github_url(self) -> None:
+        with pytest.raises(ValueError, match="Cannot parse"):
+            _parse_github_repo_url("not-a-url")
+
+
+class TestSearchGitHubIssues:
+    """Tests for search_github_issues."""
+
+    async def test_returns_candidates(self) -> None:
+        """Search returns candidate dicts from GitHub API."""
+        mock_response = httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "number": 42,
+                        "title": "Login selector broken",
+                        "body": "The CSS selector for login form is outdated",
+                        "state": "open",
+                        "html_url": "https://github.com/org/repo/issues/42",
+                    },
+                ]
+            },
+            request=httpx.Request("GET", "https://api.github.com/search/issues"),
+        )
+
+        with patch("jenkins_job_insight.github_issues.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            candidates = await search_github_issues(
+                ["login selector"],
+                "https://github.com/org/repo",
+                "ghp_token",
+            )
+
+        assert len(candidates) == 1
+        assert candidates[0]["key"] == "42"
+        assert candidates[0]["title"] == "Login selector broken"
+        assert candidates[0]["number"] == 42
+        assert candidates[0]["status"] == "open"
+        assert candidates[0]["url"] == "https://github.com/org/repo/issues/42"
+
+    async def test_empty_keywords(self) -> None:
+        """Search with empty keywords returns empty list."""
+        result = await search_github_issues([], "https://github.com/org/repo")
+        assert result == []
+
+    async def test_invalid_repo_url(self) -> None:
+        """Search with invalid repo URL returns empty list."""
+        result = await search_github_issues(["test"], "https://gitlab.com/org/repo")
+        assert result == []
+
+    async def test_api_error_returns_empty(self) -> None:
+        """GitHub API errors return empty list (never raises)."""
+        mock_response = httpx.Response(
+            403,
+            json={"message": "rate limit exceeded"},
+            request=httpx.Request("GET", "https://api.github.com/search/issues"),
+        )
+
+        with patch("jenkins_job_insight.github_issues.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await search_github_issues(["test"], "https://github.com/org/repo")
+
+        assert result == []
+
+    async def test_network_error_returns_empty(self) -> None:
+        """Network errors return empty list (never raises)."""
+        with patch("jenkins_job_insight.github_issues.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            result = await search_github_issues(["test"], "https://github.com/org/repo")
+
+        assert result == []
+
+    async def test_sends_auth_header_when_token_provided(self) -> None:
+        """Includes Authorization header when github_token is provided."""
+        mock_response = httpx.Response(
+            200,
+            json={"items": []},
+            request=httpx.Request("GET", "https://api.github.com/search/issues"),
+        )
+
+        with patch("jenkins_job_insight.github_issues.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            await search_github_issues(
+                ["test"], "https://github.com/org/repo", "ghp_my_token"
+            )
+
+            call_kwargs = mock_client.get.call_args
+            headers = call_kwargs.kwargs.get("headers", {})
+            assert headers["Authorization"] == "Bearer ghp_my_token"
+
+
+class TestCollectCodeFixReports:
+    """Tests for _collect_code_fix_reports."""
+
+    def test_collects_code_issues(self, code_issue_failure) -> None:
+        reports = _collect_code_fix_reports([code_issue_failure])
+        assert len(reports) == 1
+        assert reports[0][1].file == "tests/test_login.py"
+
+    def test_skips_product_bugs(self, product_bug_failure) -> None:
+        reports = _collect_code_fix_reports([product_bug_failure])
+        assert len(reports) == 0
+
+    def test_mixed_failures(self, code_issue_failure, product_bug_failure) -> None:
+        reports = _collect_code_fix_reports([code_issue_failure, product_bug_failure])
+        assert len(reports) == 1
+
+    def test_empty_list(self) -> None:
+        reports = _collect_code_fix_reports([])
+        assert len(reports) == 0
+
+    def test_code_issue_without_code_fix(self) -> None:
+        """CODE ISSUE without a CodeFix object is skipped."""
+        failure = FailureAnalysis(
+            test_name="test_x",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="CODE ISSUE",
+                details="some issue",
+            ),
+        )
+        reports = _collect_code_fix_reports([failure])
+        assert len(reports) == 0
+
+    def test_classification_case_insensitive(self) -> None:
+        """Classification matching is case-insensitive."""
+        failure = FailureAnalysis(
+            test_name="test_x",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="code issue",
+                details="some issue",
+                code_fix=CodeFix(file="f.py", line="1", change="fix"),
+            ),
+        )
+        reports = _collect_code_fix_reports([failure])
+        assert len(reports) == 1
+
+
+class TestEnrichWithTestsRepoMatches:
+    """Tests for enrich_with_tests_repo_matches."""
+
+    async def test_skips_when_no_tests_repo(
+        self, code_issue_failure, settings_no_tests_repo
+    ) -> None:
+        """Does nothing when TESTS_REPO_URL is not configured."""
+        await enrich_with_tests_repo_matches(
+            [code_issue_failure], settings_no_tests_repo
+        )
+        assert code_issue_failure.analysis.code_fix.tests_repo_matches == []
+
+    async def test_skips_when_no_code_issues(
+        self, product_bug_failure, settings_with_tests_repo
+    ) -> None:
+        """Does nothing when no CODE ISSUE failures exist."""
+        await enrich_with_tests_repo_matches(
+            [product_bug_failure], settings_with_tests_repo
+        )
+
+    async def test_skips_when_no_keywords(
+        self, code_issue_no_keywords, settings_with_tests_repo
+    ) -> None:
+        """Does nothing when CODE ISSUE has no search keywords."""
+        with patch(
+            "jenkins_job_insight.github_issues.search_github_issues"
+        ) as mock_search:
+            await enrich_with_tests_repo_matches(
+                [code_issue_no_keywords], settings_with_tests_repo
+            )
+            mock_search.assert_not_called()
+
+    async def test_enriches_with_ai_filtering(
+        self, code_issue_failure, settings_with_tests_repo
+    ) -> None:
+        """Searches GitHub then uses AI to filter relevant matches."""
+        mock_candidates = [
+            {
+                "key": "42",
+                "title": "Login selector broken",
+                "summary": "Login selector broken",
+                "description": "The CSS selector is outdated",
+                "status": "open",
+                "url": "https://github.com/org/repo/issues/42",
+                "number": 42,
+            },
+        ]
+        mock_evaluations = [
+            {"key": "42", "relevant": True, "score": 0.85},
+        ]
+
+        with (
+            patch(
+                "jenkins_job_insight.github_issues.search_github_issues",
+                new_callable=AsyncMock,
+                return_value=mock_candidates,
+            ),
+            patch(
+                "jenkins_job_insight.github_issues.filter_issue_matches_with_ai",
+                new_callable=AsyncMock,
+                return_value=mock_evaluations,
+            ),
+        ):
+            await enrich_with_tests_repo_matches(
+                [code_issue_failure],
+                settings_with_tests_repo,
+                "claude",
+                "test-model",
+            )
+
+        code_fix = code_issue_failure.analysis.code_fix
+        assert len(code_fix.tests_repo_matches) == 1
+        assert code_fix.tests_repo_matches[0].number == 42
+        assert code_fix.tests_repo_matches[0].title == "Login selector broken"
+        assert code_fix.tests_repo_matches[0].status == "open"
+
+    async def test_fallback_without_ai_config(
+        self, code_issue_failure, settings_with_tests_repo
+    ) -> None:
+        """Returns all candidates when no AI provider is configured."""
+        mock_candidates = [
+            {
+                "key": "10",
+                "title": "Some issue",
+                "summary": "Some issue",
+                "description": "Details",
+                "status": "open",
+                "url": "https://github.com/org/repo/issues/10",
+                "number": 10,
+            },
+        ]
+
+        with patch(
+            "jenkins_job_insight.github_issues.search_github_issues",
+            new_callable=AsyncMock,
+            return_value=mock_candidates,
+        ):
+            # No ai_provider/ai_model — should fall back
+            await enrich_with_tests_repo_matches(
+                [code_issue_failure], settings_with_tests_repo
+            )
+
+        code_fix = code_issue_failure.analysis.code_fix
+        assert len(code_fix.tests_repo_matches) == 1
+        assert code_fix.tests_repo_matches[0].number == 10
+
+    async def test_deduplicates_by_keyword_set(self, settings_with_tests_repo) -> None:
+        """Same keyword set causes only one GitHub search."""
+        failure1 = FailureAnalysis(
+            test_name="test_a",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="CODE ISSUE",
+                details="issue",
+                code_fix=CodeFix(
+                    file="a.py",
+                    line="1",
+                    change="fix",
+                    tests_repo_search_keywords=["login", "selector"],
+                ),
+            ),
+        )
+        failure2 = FailureAnalysis(
+            test_name="test_b",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="CODE ISSUE",
+                details="issue",
+                code_fix=CodeFix(
+                    file="b.py",
+                    line="2",
+                    change="fix",
+                    tests_repo_search_keywords=["selector", "login"],
+                ),
+            ),
+        )
+
+        with patch(
+            "jenkins_job_insight.github_issues.search_github_issues",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_search:
+            await enrich_with_tests_repo_matches(
+                [failure1, failure2], settings_with_tests_repo
+            )
+            assert mock_search.call_count == 1
+
+    async def test_never_raises(
+        self, code_issue_failure, settings_with_tests_repo
+    ) -> None:
+        """GitHub errors are caught and logged, never raised."""
+        with patch(
+            "jenkins_job_insight.github_issues.search_github_issues",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("Connection refused"),
+        ):
+            # Should not raise
+            await enrich_with_tests_repo_matches(
+                [code_issue_failure], settings_with_tests_repo
+            )
+
+        assert code_issue_failure.analysis.code_fix.tests_repo_matches == []
+
+    async def test_shared_matches_across_same_keyword_failures(
+        self, settings_with_tests_repo
+    ) -> None:
+        """Matches are attached to all code_fix objects with the same keywords."""
+        fix_kwargs = {
+            "file": "x.py",
+            "line": "1",
+            "change": "fix",
+            "tests_repo_search_keywords": ["keyword_a", "keyword_b"],
+        }
+        failure1 = FailureAnalysis(
+            test_name="test_a",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="CODE ISSUE",
+                details="issue",
+                code_fix=CodeFix(**fix_kwargs),
+            ),
+        )
+        failure2 = FailureAnalysis(
+            test_name="test_b",
+            error="err",
+            analysis=AnalysisDetail(
+                classification="CODE ISSUE",
+                details="issue",
+                code_fix=CodeFix(**fix_kwargs),
+            ),
+        )
+
+        mock_candidates = [
+            {
+                "key": "5",
+                "title": "Related issue",
+                "summary": "Related issue",
+                "description": "desc",
+                "status": "open",
+                "url": "https://github.com/org/repo/issues/5",
+                "number": 5,
+            },
+        ]
+
+        with patch(
+            "jenkins_job_insight.github_issues.search_github_issues",
+            new_callable=AsyncMock,
+            return_value=mock_candidates,
+        ):
+            await enrich_with_tests_repo_matches(
+                [failure1, failure2], settings_with_tests_repo
+            )
+
+        # Both failures should have the same matches
+        assert len(failure1.analysis.code_fix.tests_repo_matches) == 1
+        assert len(failure2.analysis.code_fix.tests_repo_matches) == 1
+        assert failure1.analysis.code_fix.tests_repo_matches[0].number == 5
+        assert failure2.analysis.code_fix.tests_repo_matches[0].number == 5
+
+
+class TestCodeIssueClassifications:
+    """Tests for classification matching."""
+
+    def test_code_issue_in_classifications(self) -> None:
+        assert "CODE ISSUE" in _CODE_ISSUE_CLASSIFICATIONS

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -22,6 +22,8 @@ from jenkins_job_insight.models import (
 )
 
 
+_TEST_GITHUB_TOKEN = "ghp_test_token_123"  # noqa: S105  # pragma: allowlist secret
+
 _BASE_ENV = {
     "JENKINS_URL": "https://jenkins.example.com",
     "JENKINS_USER": "testuser",
@@ -35,7 +37,7 @@ def settings_with_tests_repo() -> Generator[Settings, None, None]:
     env = {
         **_BASE_ENV,
         "TESTS_REPO_URL": "https://github.com/org/test-repo",
-        "GITHUB_TOKEN": "ghp_test_token_123",
+        "GITHUB_TOKEN": _TEST_GITHUB_TOKEN,
     }
     with patch.dict(os.environ, env, clear=True):
         yield Settings(_env_file=None)
@@ -160,7 +162,7 @@ class TestSearchGitHubIssues:
             candidates = await search_github_issues(
                 ["login selector"],
                 "https://github.com/org/repo",
-                "ghp_token",
+                _TEST_GITHUB_TOKEN,
             )
 
         assert len(candidates) == 1
@@ -169,6 +171,12 @@ class TestSearchGitHubIssues:
         assert candidates[0]["number"] == 42
         assert candidates[0]["status"] == "open"
         assert candidates[0]["url"] == "https://github.com/org/repo/issues/42"
+
+        # Verify the outbound query includes repo scope and issue filter
+        call_kwargs = mock_client.get.call_args
+        query = call_kwargs.kwargs["params"]["q"]
+        assert "repo:org/repo" in query
+        assert "is:issue" in query
 
     async def test_empty_keywords(self) -> None:
         """Search with empty keywords returns empty list."""
@@ -198,6 +206,12 @@ class TestSearchGitHubIssues:
             result = await search_github_issues(["test"], "https://github.com/org/repo")
 
         assert result == []
+
+        # Verify the outbound query still included repo scope and issue filter
+        call_kwargs = mock_client.get.call_args
+        query = call_kwargs.kwargs["params"]["q"]
+        assert "repo:org/repo" in query
+        assert "is:issue" in query
 
     async def test_network_error_returns_empty(self) -> None:
         """Network errors return empty list (never raises)."""
@@ -230,12 +244,12 @@ class TestSearchGitHubIssues:
             mock_cls.return_value = mock_client
 
             await search_github_issues(
-                ["test"], "https://github.com/org/repo", "ghp_my_token"
+                ["test"], "https://github.com/org/repo", _TEST_GITHUB_TOKEN
             )
 
             call_kwargs = mock_client.get.call_args
             headers = call_kwargs.kwargs.get("headers", {})
-            assert headers["Authorization"] == "Bearer ghp_my_token"
+            assert headers["Authorization"] == f"Bearer {_TEST_GITHUB_TOKEN}"
 
 
 class TestCollectCodeFixReports:

--- a/tests/test_issue_matching.py
+++ b/tests/test_issue_matching.py
@@ -1,0 +1,364 @@
+"""Tests for shared issue matching (AI relevance filtering)."""
+
+from unittest.mock import AsyncMock, patch
+
+from ai_cli_runner import AIResult
+from jenkins_job_insight.issue_matching import filter_issue_matches_with_ai
+
+
+class TestFilterIssueMatchesWithAi:
+    """Tests for filter_issue_matches_with_ai."""
+
+    async def test_returns_relevant_candidates(self) -> None:
+        """Returns only relevant candidates with scores."""
+        candidates = [
+            {
+                "key": "PROJ-1",
+                "summary": "Login broken",
+                "description": "Login fails",
+                "status": "Open",
+            },
+            {
+                "key": "PROJ-2",
+                "summary": "Unrelated",
+                "description": "Different thing",
+                "status": "Closed",
+            },
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "PROJ-1", "relevant": true, "score": 0.9}, '
+            '{"key": "PROJ-2", "relevant": false, "score": 0.1}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Login fails",
+                bug_description="Login returns 500",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="test-model",
+                job_id="job-1",
+            )
+
+        assert len(results) == 1
+        assert results[0]["key"] == "PROJ-1"
+        assert results[0]["score"] == 0.9
+        assert results[0]["relevant"] is True
+
+    async def test_empty_candidates(self) -> None:
+        """Returns empty list for empty candidates."""
+        results = await filter_issue_matches_with_ai(
+            bug_title="Title",
+            bug_description="Desc",
+            candidates=[],
+            ai_provider="claude",
+            ai_model="model",
+        )
+        assert results == []
+
+    async def test_ai_failure_returns_empty(self) -> None:
+        """Returns empty list when AI call fails."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(success=False, text="AI error")
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+                job_id="job-1",
+            )
+
+        assert results == []
+
+    async def test_unparseable_response_returns_empty(self) -> None:
+        """Returns empty list when AI response can't be parsed."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(success=True, text="not valid json at all")
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert results == []
+
+    async def test_handles_markdown_wrapped_json(self) -> None:
+        """Extracts JSON from markdown code blocks."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='```json\n[{"key": "X-1", "relevant": true, "score": 0.7}]\n```',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert len(results) == 1
+        assert results[0]["key"] == "X-1"
+        assert results[0]["score"] == 0.7
+
+    async def test_sorted_by_score_descending(self) -> None:
+        """Results are sorted by score in descending order."""
+        candidates = [
+            {"key": "A", "summary": "A", "description": "a", "status": "Open"},
+            {"key": "B", "summary": "B", "description": "b", "status": "Open"},
+            {"key": "C", "summary": "C", "description": "c", "status": "Open"},
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "A", "relevant": true, "score": 0.5}, '
+            '{"key": "B", "relevant": true, "score": 0.9}, '
+            '{"key": "C", "relevant": true, "score": 0.7}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert [r["key"] for r in results] == ["B", "C", "A"]
+
+    async def test_uses_title_field_for_candidates(self) -> None:
+        """Candidates with 'title' instead of 'summary' are handled."""
+        candidates = [
+            {"key": "1", "title": "Issue title", "description": "d", "status": "open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "1", "relevant": true, "score": 0.8}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert len(results) == 1
+
+    async def test_invalid_score_defaults_to_zero(self) -> None:
+        """Invalid score values default to 0.0."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "X-1", "relevant": true, "score": "invalid"}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert len(results) == 1
+        assert results[0]["score"] == 0.0
+
+    async def test_skips_non_dict_evaluations(self) -> None:
+        """Non-dict entries in evaluations are skipped."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='["invalid_entry", {"key": "X-1", "relevant": true, "score": 0.5}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            results = await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+        assert len(results) == 1
+
+    async def test_records_token_usage_when_job_id(self) -> None:
+        """Token usage is recorded when job_id is provided."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "X-1", "relevant": false, "score": 0.1}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+        ):
+            await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+                job_id="job-123",
+                call_type="test_filter",
+            )
+
+            mock_record.assert_called_once()
+            call_kwargs = mock_record.call_args.kwargs
+            assert call_kwargs["job_id"] == "job-123"
+            assert call_kwargs["call_type"] == "test_filter"
+
+    async def test_no_token_usage_without_job_id(self) -> None:
+        """Token usage is not recorded when no job_id."""
+        candidates = [
+            {"key": "X-1", "summary": "Bug", "description": "d", "status": "Open"}
+        ]
+
+        ai_response = AIResult(
+            success=True,
+            text='[{"key": "X-1", "relevant": false, "score": 0.1}]',
+        )
+
+        with (
+            patch(
+                "jenkins_job_insight.issue_matching.call_ai_cli",
+                new_callable=AsyncMock,
+                return_value=ai_response,
+            ),
+            patch(
+                "jenkins_job_insight.issue_matching.record_ai_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+        ):
+            await filter_issue_matches_with_ai(
+                bug_title="Title",
+                bug_description="Desc",
+                candidates=candidates,
+                ai_provider="claude",
+                ai_model="model",
+            )
+
+            mock_record.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #207

Search the tests repository for related GitHub issues when a failure is classified as a code issue (similar to the existing Jira integration for product bugs).

## What Changed

Mirrors the Jira integration pattern for code issue classifications:

1. **AI generates `tests_repo_search_keywords`** — during failure analysis, the AI produces search keywords tailored for finding related issues in the tests repository.
2. **Searches GitHub Issues API** — uses the keywords to search open issues in the configured tests repo.
3. **AI filters for relevance** — each candidate issue is evaluated by the AI for relevance to the actual failure.
4. **Attaches matches to failure results** — relevant issues are included in the analysis output as `tests_repo_issues`.

## Implementation Details

- Extracted shared issue-matching logic from `jira.py` into reusable utilities to avoid code duplication between Jira and GitHub issue search flows.
- The feature is gated on `TESTS_REPO_URL` configuration — when not set, the search is skipped gracefully.
- All GitHub API errors are swallowed gracefully (never crash the pipeline), consistent with the Jira integration pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Issues integration to discover and deduplicate similar code issues in your tests repository
  * CodeFix now stores tests-repo search keywords and matched issues; enrichment runs during background analysis and via the API

* **Refactor**
  * Centralized AI-driven issue relevance filtering used across integrations
  * Unified failure-collection logic for consistent enrichment

* **Bug Fixes**
  * More robust extraction and normalization of AI-generated keyword data from unstructured output

* **Tests**
  * Comprehensive tests for GitHub Issues search and issue-matching workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->