### PR TITLE
feat: calculate AI cost for all providers using LiteLLM pricing data

### DIFF
--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -22,7 +22,13 @@ import { SortableHeader } from '@/components/shared/SortableHeader'
 import { DateRangeFilter } from '@/components/shared/DateRangeFilter'
 import { useTableSort } from '@/lib/useTableSort'
 import type { TokenUsageDashboard } from '@/types'
-import { Zap, TrendingUp, Calendar, DollarSign } from 'lucide-react'
+import { Zap, TrendingUp, Calendar, DollarSign, Info } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface BreakdownRow {
   group: string
@@ -101,7 +107,7 @@ function SummaryCard({ title, icon, calls, tokens, inputTokens, outputTokens, co
             <span className="font-mono text-xs text-text-secondary">{formatCompactNumber(outputTokens)}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-xs text-text-tertiary">Cost</span>
+            <span className="text-xs text-text-tertiary">Cost (estimated)</span>
             <span className="font-mono text-sm font-medium text-signal-green">
               {formatCostCell(cost)}
             </span>
@@ -238,11 +244,22 @@ export function TokenUsagePage() {
   }, [])
 
   return (
+    <TooltipProvider delayDuration={200}>
     <div className="space-y-6">
       {/* Header */}
       <div>
         <h1 className="font-display text-xl font-bold text-text-primary">Token Usage</h1>
-        <p className="mt-0.5 text-sm text-text-tertiary">AI provider token consumption and costs</p>
+        <p className="mt-0.5 text-sm text-text-tertiary inline-flex items-center gap-1">
+          AI provider token consumption and costs (estimated)
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3.5 w-3.5 text-text-tertiary cursor-help inline-block" />
+            </TooltipTrigger>
+            <TooltipContent side="right" className="max-w-xs">
+              Cost is calculated from token counts using LiteLLM pricing data when not provided natively by the AI provider.
+            </TooltipContent>
+          </Tooltip>
+        </p>
       </div>
 
       {/* Errors */}
@@ -380,7 +397,7 @@ export function TokenUsagePage() {
               <SortableHeader label="Output Tokens" sortKey="output_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cache Read" sortKey="cache_read_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cache Write" sortKey="cache_write_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
-              <SortableHeader label="Cost" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Cost (estimated)" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Avg Duration" sortKey="avg_duration_ms" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
             </TableRow>
           </TableHeader>
@@ -404,5 +421,6 @@ export function TokenUsagePage() {
         </Table>
       )}
     </div>
+    </TooltipProvider>
   )
 }

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -252,8 +252,8 @@ export function TokenUsagePage() {
         <p className="mt-0.5 text-sm text-text-tertiary inline-flex items-center gap-1">
           AI provider token consumption and costs
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3.5 w-3.5 text-text-tertiary cursor-help inline-block" />
+            <TooltipTrigger aria-label="About cost calculation">
+              <Info className="h-3.5 w-3.5 text-text-tertiary cursor-help" aria-hidden="true" />
             </TooltipTrigger>
             <TooltipContent side="right" className="max-w-xs">
               Cost is calculated from token counts using LiteLLM pricing data when not provided natively by the AI provider.

--- a/frontend/src/pages/TokenUsagePage.tsx
+++ b/frontend/src/pages/TokenUsagePage.tsx
@@ -107,7 +107,7 @@ function SummaryCard({ title, icon, calls, tokens, inputTokens, outputTokens, co
             <span className="font-mono text-xs text-text-secondary">{formatCompactNumber(outputTokens)}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-xs text-text-tertiary">Cost (estimated)</span>
+            <span className="text-xs text-text-tertiary">Cost</span>
             <span className="font-mono text-sm font-medium text-signal-green">
               {formatCostCell(cost)}
             </span>
@@ -250,7 +250,7 @@ export function TokenUsagePage() {
       <div>
         <h1 className="font-display text-xl font-bold text-text-primary">Token Usage</h1>
         <p className="mt-0.5 text-sm text-text-tertiary inline-flex items-center gap-1">
-          AI provider token consumption and costs (estimated)
+          AI provider token consumption and costs
           <Tooltip>
             <TooltipTrigger asChild>
               <Info className="h-3.5 w-3.5 text-text-tertiary cursor-help inline-block" />
@@ -397,7 +397,7 @@ export function TokenUsagePage() {
               <SortableHeader label="Output Tokens" sortKey="output_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cache Read" sortKey="cache_read_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Cache Write" sortKey="cache_write_tokens" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
-              <SortableHeader label="Cost (estimated)" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
+              <SortableHeader label="Cost" sortKey="cost_usd" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
               <SortableHeader label="Avg Duration" sortKey="avg_duration_ms" currentSort={sortKey} currentDirection={sortDir} onSort={handleSort} className="text-right" />
             </TableRow>
           </TableHeader>

--- a/src/jenkins_job_insight/llm_pricing.py
+++ b/src/jenkins_job_insight/llm_pricing.py
@@ -1,0 +1,272 @@
+"""LLM pricing cache using LiteLLM pricing data.
+
+Fetches model pricing from LiteLLM's GitHub repository and caches it
+in memory. All methods are best-effort — errors are logged but never raised.
+"""
+
+import asyncio
+import os
+import re
+
+import httpx
+from simple_logger.logger import get_logger
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+LITELLM_PRICING_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
+    "model_prices_and_context_window.json"
+)
+
+_REFRESH_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+class LLMPricingCache:
+    """In-memory cache for LLM model pricing data from LiteLLM."""
+
+    def __init__(self) -> None:
+        self._data: dict = {}
+        self._refresh_task: asyncio.Task | None = None
+
+    async def load(self) -> None:
+        """Initial fetch at startup. Best-effort — logs and continues on failure."""
+        await self._fetch()
+
+    async def refresh(self) -> None:
+        """Re-fetch pricing data. Best-effort — logs and continues on failure."""
+        await self._fetch()
+
+    async def _fetch(self) -> None:
+        """Fetch pricing JSON from LiteLLM GitHub. Never raises."""
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(LITELLM_PRICING_URL)
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, dict):
+                    self._data = data
+                    logger.debug("LLM pricing cache loaded: %d models", len(self._data))
+                else:
+                    logger.warning("LLM pricing data is not a dict, ignoring")
+        except Exception:
+            logger.warning("Failed to fetch LLM pricing data", exc_info=True)
+
+    _CURSOR_ROUTING_SUFFIXES = ("-xhigh-fast", "-fast", "-xhigh", "-max-thinking")
+    _KNOWN_MODEL_PREFIXES = ("claude", "gpt", "gemini")
+    _KNOWN_VARIANTS = frozenset(
+        {"opus", "sonnet", "haiku", "pro", "flash", "nano", "mini"}
+    )
+
+    def _resolve_cursor_model(self, model: str) -> str | None:
+        """Resolve a Cursor model name to its canonical LiteLLM key.
+
+        Cursor wraps upstream models with custom naming (e.g.
+        ``claude-4.6-opus-max-thinking``).  This method extracts the
+        base-model prefix, version, and variant to reconstruct the
+        canonical LiteLLM key.  Returns ``None`` if the model does
+        not match any known upstream prefix.  Never raises.
+        """
+        try:
+            prefix: str | None = None
+            rest: str = ""
+            for p in self._KNOWN_MODEL_PREFIXES:
+                if model.startswith(f"{p}-"):
+                    prefix = p
+                    rest = model[len(p) + 1 :]
+                    break
+
+            if prefix is None:
+                return None
+
+            # Extract version number (e.g. 4.6, 5.4, 2.5)
+            version_match = re.match(r"(\d+(?:\.\d+)*)", rest)
+            if not version_match:
+                return None
+
+            version = version_match.group(1)
+            remaining = rest[version_match.end() :]
+
+            # Extract variant if present (first token after version)
+            variant: str | None = None
+            if remaining.startswith("-"):
+                parts = remaining[1:].split("-")
+                if parts and parts[0] in self._KNOWN_VARIANTS:
+                    variant = parts[0]
+
+            # Reconstruct canonical LiteLLM key per model family
+            if prefix == "claude":
+                version_dashed = version.replace(".", "-")
+                if variant:
+                    return f"claude-{variant}-{version_dashed}"
+                return f"claude-{version_dashed}"
+
+            if prefix == "gpt":
+                if variant:
+                    return f"gpt-{version}-{variant}"
+                return f"gpt-{version}"
+
+            if prefix == "gemini":
+                if variant:
+                    return f"gemini-{version}-{variant}"
+                return f"gemini-{version}"
+        except Exception:
+            logger.debug("Failed to resolve cursor model: %s", model, exc_info=True)
+
+        return None
+
+    def _lookup_model(self, provider: str, model: str) -> dict | None:
+        """Look up model pricing data trying multiple key formats.
+
+        Tries normalized model names in order:
+        1. As-is
+        2. With bracketed suffixes stripped (e.g. ``model[1m]`` → ``model``)
+        3. With ``@`` replaced by ``-`` (e.g. ``model@date`` → ``model-date``)
+        4. (cursor only) With routing suffixes stripped (``-xhigh-fast``, etc.)
+
+        For each normalized name, tries direct lookup, provider-prefixed
+        lookup, and (if the name contains ``/``) suffix-only lookup.
+
+        Returns the pricing dict or None if not found.
+        """
+        if not self._data or not model:
+            return None
+
+        # Normalize provider name for LiteLLM keys
+        provider_map = {
+            "claude": "anthropic",
+            "gemini": "gemini",
+            "cursor": "cursor",
+        }
+        litellm_provider = provider_map.get(provider, provider)
+
+        def _try_candidates(name: str) -> dict | None:
+            candidates = [name, f"{litellm_provider}/{name}"]
+            if "/" in name:
+                candidates.append(name.split("/", 1)[1])
+            for key in candidates:
+                entry = self._data.get(key)
+                if isinstance(entry, dict):
+                    return entry
+            return None
+
+        # Build normalized model names to try
+        names_to_try: list[str] = [model]
+
+        # Strip bracketed suffixes: claude-opus-4-6[1m] → claude-opus-4-6
+        stripped_brackets = re.sub(r"\[.*?\]$", "", model)
+        if stripped_brackets != model:
+            names_to_try.append(stripped_brackets)
+
+        # Replace @ with - (on each name so far)
+        for name in list(names_to_try):
+            at_replaced = name.replace("@", "-")
+            if at_replaced != name and at_replaced not in names_to_try:
+                names_to_try.append(at_replaced)
+
+        # Strip Cursor routing suffixes (on each name so far)
+        if provider == "cursor":
+            for name in list(names_to_try):
+                for suffix in self._CURSOR_ROUTING_SUFFIXES:
+                    if name.endswith(suffix):
+                        candidate = name[: -len(suffix)]
+                        if candidate and candidate not in names_to_try:
+                            names_to_try.append(candidate)
+
+        for name in names_to_try:
+            result = _try_candidates(name)
+            if result is not None:
+                return result
+
+        # Last resort for cursor: resolve upstream model name
+        if provider == "cursor":
+            for name in names_to_try:
+                resolved = self._resolve_cursor_model(name)
+                if resolved:
+                    result = _try_candidates(resolved)
+                    if result is not None:
+                        return result
+
+        return None
+
+    def calculate_cost(
+        self,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+    ) -> float | None:
+        """Calculate cost for a model invocation. Returns None if model not found or on error.
+
+        Never raises — all errors are logged and None is returned.
+        """
+        try:
+            entry = self._lookup_model(provider, model)
+            if entry is None:
+                logger.debug(
+                    "Model not found in pricing cache: provider=%s model=%s",
+                    provider,
+                    model,
+                )
+                return None
+
+            input_cost_per_token = entry.get("input_cost_per_token")
+            output_cost_per_token = entry.get("output_cost_per_token")
+
+            if input_cost_per_token is None or output_cost_per_token is None:
+                logger.debug("Missing cost fields for model %s/%s", provider, model)
+                return None
+
+            cost = (input_tokens * input_cost_per_token) + (
+                output_tokens * output_cost_per_token
+            )
+
+            # Add cache costs if available in pricing data
+            cache_read_cost = entry.get("cache_read_input_token_cost")
+            if cache_read_cost is not None and cache_read_tokens > 0:
+                cost += cache_read_tokens * cache_read_cost
+
+            cache_write_cost = entry.get("cache_creation_input_token_cost")
+            if cache_write_cost is not None and cache_write_tokens > 0:
+                cost += cache_write_tokens * cache_write_cost
+
+            return cost
+
+        except Exception:
+            logger.debug(
+                "Failed to calculate cost for %s/%s",
+                provider,
+                model,
+                exc_info=True,
+            )
+            return None
+
+    def start_background_refresh(self) -> None:
+        """Start a background task that refreshes pricing data every 24 hours.
+
+        Safe to call multiple times — cancels any existing task first.
+        """
+        self.stop_background_refresh()
+        self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    def stop_background_refresh(self) -> None:
+        """Cancel the background refresh task if running."""
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            self._refresh_task = None
+
+    async def _refresh_loop(self) -> None:
+        """Periodically refresh pricing data. Never raises."""
+        while True:
+            try:
+                await asyncio.sleep(_REFRESH_INTERVAL_SECONDS)
+                await self.refresh()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.debug("Pricing refresh loop error", exc_info=True)
+
+
+# Module-level singleton
+pricing_cache = LLMPricingCache()

--- a/src/jenkins_job_insight/llm_pricing.py
+++ b/src/jenkins_job_insight/llm_pricing.py
@@ -260,12 +260,12 @@ class LLMPricingCache:
         """Periodically refresh pricing data. Never raises."""
         while True:
             try:
-                await asyncio.sleep(_REFRESH_INTERVAL_SECONDS)
                 await self.refresh()
             except asyncio.CancelledError:
                 break
             except Exception:
                 logger.debug("Pricing refresh loop error", exc_info=True)
+            await asyncio.sleep(_REFRESH_INTERVAL_SECONDS)
 
 
 # Module-level singleton

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -47,6 +47,7 @@ from jenkins_job_insight.encryption import (
     encrypt_sensitive_fields,
 )
 from jenkins_job_insight.jira import enrich_with_jira_matches
+from jenkins_job_insight.llm_pricing import pricing_cache
 from jenkins_job_insight.token_tracking import build_token_usage_summary
 from jenkins_job_insight.monitoring import (
     build_health_response,
@@ -588,6 +589,11 @@ async def lifespan(app: FastAPI):
 
     await init_db()
     await storage.cleanup_expired_sessions()
+
+    # Load LLM pricing cache (best-effort)
+    await pricing_cache.load()
+    pricing_cache.start_background_refresh()
+
     waiting_jobs = await storage.mark_stale_results_failed()
     if waiting_jobs:
         # Schedule resumption as a background task so it runs after the
@@ -595,7 +601,10 @@ async def lifespan(app: FastAPI):
         task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
-    yield
+    try:
+        yield
+    finally:
+        pricing_cache.stop_background_refresh()
 
 
 app = FastAPI(

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -590,18 +590,20 @@ async def lifespan(app: FastAPI):
     await init_db()
     await storage.cleanup_expired_sessions()
 
-    # Load LLM pricing cache (best-effort)
-    await pricing_cache.load()
+    # Load LLM pricing cache asynchronously (best-effort, non-blocking)
+    _warmup = asyncio.create_task(pricing_cache.load())
+    _background_tasks.add(_warmup)
+    _warmup.add_done_callback(_background_tasks.discard)
     pricing_cache.start_background_refresh()
 
-    waiting_jobs = await storage.mark_stale_results_failed()
-    if waiting_jobs:
-        # Schedule resumption as a background task so it runs after the
-        # app is fully started and ready to serve internal API requests.
-        task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
     try:
+        waiting_jobs = await storage.mark_stale_results_failed()
+        if waiting_jobs:
+            # Schedule resumption as a background task so it runs after the
+            # app is fully started and ready to serve internal API requests.
+            task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
         yield
     finally:
         pricing_cache.stop_background_refresh()

--- a/src/jenkins_job_insight/token_tracking.py
+++ b/src/jenkins_job_insight/token_tracking.py
@@ -10,6 +10,7 @@ from ai_cli_runner import AIResult
 from simple_logger.logger import get_logger
 
 from jenkins_job_insight import storage
+from jenkins_job_insight.llm_pricing import pricing_cache
 from jenkins_job_insight.models import TokenUsageEntry, TokenUsageSummary
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -33,16 +34,38 @@ async def record_ai_usage(
             return
 
         usage = result.usage
+        resolved_provider = (usage.provider if usage else "") or ai_provider
+        resolved_model = (usage.model if usage else "") or ai_model
+        cost = usage.cost_usd if usage else None
+
+        # If CLI didn't provide cost, calculate from pricing cache
+        if cost is None and usage is not None:
+            try:
+                cost = pricing_cache.calculate_cost(
+                    provider=resolved_provider,
+                    model=resolved_model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cache_read_tokens=usage.cache_read_tokens,
+                    cache_write_tokens=usage.cache_write_tokens,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to calculate cost from pricing cache for job %s",
+                    job_id,
+                    exc_info=True,
+                )
+
         await storage.record_token_usage(
             job_id=job_id,
-            ai_provider=(usage.provider if usage else "") or ai_provider,
-            ai_model=(usage.model if usage else "") or ai_model,
+            ai_provider=resolved_provider,
+            ai_model=resolved_model,
             call_type=call_type,
             input_tokens=usage.input_tokens if usage else 0,
             output_tokens=usage.output_tokens if usage else 0,
             cache_read_tokens=usage.cache_read_tokens if usage else 0,
             cache_write_tokens=usage.cache_write_tokens if usage else 0,
-            cost_usd=usage.cost_usd if usage else None,
+            cost_usd=cost,
             duration_ms=usage.duration_ms if usage else None,
             prompt_chars=prompt_chars,
             response_chars=len(result.text),

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,0 +1,540 @@
+"""Tests for llm_pricing module."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from ai_cli_runner import AIResult, AITokenUsage
+
+from jenkins_job_insight.llm_pricing import LLMPricingCache
+from jenkins_job_insight.token_tracking import record_ai_usage
+
+
+SAMPLE_PRICING_DATA = {
+    "claude-opus-4": {
+        "input_cost_per_token": 0.000015,
+        "output_cost_per_token": 0.000075,
+        "cache_read_input_token_cost": 0.0000015,
+        "cache_creation_input_token_cost": 0.00001875,
+    },
+    "claude-opus-4-6": {
+        "input_cost_per_token": 0.000016,
+        "output_cost_per_token": 0.000080,
+    },
+    "anthropic/claude-sonnet-4": {
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "cache_read_input_token_cost": 0.0000003,
+        "cache_creation_input_token_cost": 0.00000375,
+    },
+    "claude-haiku-4-5-20251001": {
+        "input_cost_per_token": 0.0000008,
+        "output_cost_per_token": 0.000004,
+    },
+    "gemini/gemini-2.5-pro": {
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+    },
+    "gemini-2.5-pro": {
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+    },
+    "gpt-5.4": {
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000015,
+    },
+    "no-costs-model": {
+        "max_tokens": 4096,
+    },
+}
+
+
+class TestLLMPricingCache:
+    """Tests for LLMPricingCache."""
+
+    def test_calculate_cost_direct_model_name(self) -> None:
+        """Cost calculation with direct model name lookup."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-opus-4",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.000015) + (500 * 0.000075)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_provider_prefixed(self) -> None:
+        """Cost calculation with provider-prefixed model name."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-sonnet-4",
+            input_tokens=2000,
+            output_tokens=1000,
+        )
+
+        assert cost is not None
+        expected = (2000 * 0.000003) + (1000 * 0.000015)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_gemini_prefixed(self) -> None:
+        """Cost calculation with gemini provider prefix."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="gemini",
+            model="gemini-2.5-pro",
+            input_tokens=5000,
+            output_tokens=2000,
+        )
+
+        assert cost is not None
+        expected = (5000 * 0.00000125) + (2000 * 0.00001)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_model_with_slash(self) -> None:
+        """Model name containing slash falls back to suffix lookup."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        # Model already has provider prefix "gemini/gemini-2.5-pro"
+        cost = cache.calculate_cost(
+            provider="gemini",
+            model="gemini/gemini-2.5-pro",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.00000125) + (500 * 0.00001)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_with_cache_tokens(self) -> None:
+        """Cost calculation includes cache read and write costs."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-opus-4",
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=200,
+            cache_write_tokens=100,
+        )
+
+        assert cost is not None
+        expected = (
+            (1000 * 0.000015)
+            + (500 * 0.000075)
+            + (200 * 0.0000015)
+            + (100 * 0.00001875)
+        )
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_no_cache_costs_in_pricing(self) -> None:
+        """Cache tokens ignored when pricing doesn't have cache costs."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="gemini",
+            model="gemini-2.5-pro",
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=200,
+            cache_write_tokens=100,
+        )
+
+        assert cost is not None
+        # Cache costs not in gemini pricing, so only input + output
+        expected = (1000 * 0.00000125) + (500 * 0.00001)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_model_not_found(self) -> None:
+        """Returns None when model is not in pricing data."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="nonexistent-model",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is None
+
+    def test_calculate_cost_empty_cache(self) -> None:
+        """Returns None when cache is empty (never fetched)."""
+        cache = LLMPricingCache()
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-opus-4",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is None
+
+    def test_calculate_cost_missing_cost_fields(self) -> None:
+        """Returns None when model entry lacks cost fields."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="no-costs-model",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is None
+
+    def test_calculate_cost_empty_model(self) -> None:
+        """Returns None when model name is empty."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is None
+
+    def test_calculate_cost_bracketed_suffix_stripped(self) -> None:
+        """CLI model name with [1m] suffix matches after stripping."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-opus-4-6[1m]",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.000016) + (500 * 0.000080)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_at_sign_replaced(self) -> None:
+        """CLI model name with @ separator matches after replacing with -."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="claude",
+            model="claude-haiku-4-5@20251001",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.0000008) + (500 * 0.000004)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_cursor_routing_suffix_stripped(self) -> None:
+        """Cursor model with routing suffix matches after stripping."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="cursor",
+            model="gpt-5.4-xhigh-fast",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.000005) + (500 * 0.000015)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_cursor_claude_resolved(self) -> None:
+        """Cursor claude model with reordered name resolves to canonical key."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="cursor",
+            model="claude-4.6-opus-max-thinking",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.000016) + (500 * 0.000080)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_cursor_gemini_resolved(self) -> None:
+        """Cursor gemini model with routing suffix resolves to canonical key."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="cursor",
+            model="gemini-2.5-pro-fast",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is not None
+        expected = (1000 * 0.00000125) + (500 * 0.00001)
+        assert cost == pytest.approx(expected)
+
+    def test_calculate_cost_cursor_proprietary_model_returns_none(self) -> None:
+        """Cursor proprietary model with no LiteLLM match returns None."""
+        cache = LLMPricingCache()
+        cache._data = SAMPLE_PRICING_DATA
+
+        cost = cache.calculate_cost(
+            provider="cursor",
+            model="composer-2-fast",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        assert cost is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_success(self) -> None:
+        """Successfully loads pricing data from URL."""
+        cache = LLMPricingCache()
+
+        mock_response = httpx.Response(
+            status_code=200,
+            json=SAMPLE_PRICING_DATA,
+            request=httpx.Request("GET", "https://example.com"),
+        )
+
+        with patch("jenkins_job_insight.llm_pricing.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.get = AsyncMock(return_value=mock_response)
+
+            await cache.load()
+
+        assert len(cache._data) == len(SAMPLE_PRICING_DATA)
+        assert "claude-opus-4" in cache._data
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_does_not_raise(self) -> None:
+        """Fetch failure is logged but never raises."""
+        cache = LLMPricingCache()
+
+        with patch("jenkins_job_insight.llm_pricing.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.get = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+
+            # Should NOT raise
+            await cache.load()
+
+        assert cache._data == {}
+
+    @pytest.mark.asyncio
+    async def test_fetch_bad_json_does_not_raise(self) -> None:
+        """Non-dict JSON response is handled gracefully."""
+        cache = LLMPricingCache()
+
+        mock_response = httpx.Response(
+            status_code=200,
+            json=["not", "a", "dict"],
+            request=httpx.Request("GET", "https://example.com"),
+        )
+
+        with patch("jenkins_job_insight.llm_pricing.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value.get = AsyncMock(return_value=mock_response)
+
+            await cache.load()
+
+        assert cache._data == {}
+
+
+class TestRecordAiUsageCostCalculation:
+    """Tests for cost calculation integration in record_ai_usage."""
+
+    @pytest.mark.asyncio
+    async def test_cli_provided_cost_not_overridden(self) -> None:
+        """CLI-provided cost_usd is used as-is, not recalculated."""
+        usage = AITokenUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            provider="claude",
+            model="claude-opus-4",
+            cost_usd=0.42,
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+            # pricing_cache.calculate_cost should NOT be called
+            mock_cache.calculate_cost.assert_not_called()
+            # CLI-provided cost should be passed through
+            assert mock_record.call_args.kwargs["cost_usd"] == 0.42
+
+    @pytest.mark.asyncio
+    async def test_cost_calculated_when_cli_provides_none(self) -> None:
+        """When CLI provides no cost, pricing cache is used."""
+        usage = AITokenUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            provider="claude",
+            model="claude-opus-4",
+            cost_usd=None,
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            mock_cache.calculate_cost.return_value = 0.055
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+            mock_cache.calculate_cost.assert_called_once_with(
+                provider="claude",
+                model="claude-opus-4",
+                input_tokens=1000,
+                output_tokens=500,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+            )
+            assert mock_record.call_args.kwargs["cost_usd"] == 0.055
+
+    @pytest.mark.asyncio
+    async def test_cost_stays_none_when_cache_returns_none(self) -> None:
+        """Cost stays None when pricing cache can't find the model."""
+        usage = AITokenUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            provider="gemini",
+            model="unknown-model",
+            cost_usd=None,
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            mock_cache.calculate_cost.return_value = None
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+            assert mock_record.call_args.kwargs["cost_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_cost_calculation_error_stays_none(self) -> None:
+        """Cost stays None when pricing cache raises an exception."""
+        usage = AITokenUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            provider="claude",
+            model="claude-opus-4",
+            cost_usd=None,
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            mock_cache.calculate_cost.side_effect = RuntimeError("unexpected")
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+            assert mock_record.call_args.kwargs["cost_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_cost_calculation_when_usage_is_none(self) -> None:
+        """No cost calculation attempted when usage is None."""
+        result = AIResult(success=True, text="output")
+        assert result.usage is None
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ) as mock_record,
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            await record_ai_usage(
+                job_id="job-123",
+                result=result,
+                call_type="analysis",
+                ai_provider="claude",
+                ai_model="opus-4",
+            )
+
+            mock_cache.calculate_cost.assert_not_called()
+            assert mock_record.call_args.kwargs["cost_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_cost_with_cache_tokens(self) -> None:
+        """Cache read/write tokens are passed to cost calculation."""
+        usage = AITokenUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=200,
+            cache_write_tokens=100,
+            provider="claude",
+            model="claude-opus-4",
+            cost_usd=None,
+        )
+        result = AIResult(success=True, text="output", usage=usage)
+
+        with (
+            patch(
+                "jenkins_job_insight.token_tracking.storage.record_token_usage",
+                new_callable=AsyncMock,
+            ),
+            patch("jenkins_job_insight.token_tracking.pricing_cache") as mock_cache,
+        ):
+            mock_cache.calculate_cost.return_value = 0.07
+            await record_ai_usage(job_id="job-123", result=result, call_type="analysis")
+
+            mock_cache.calculate_cost.assert_called_once_with(
+                provider="claude",
+                model="claude-opus-4",
+                input_tokens=1000,
+                output_tokens=500,
+                cache_read_tokens=200,
+                cache_write_tokens=100,
+            )


### PR DESCRIPTION
Closes #230

## Summary

Adds automatic AI cost calculation for providers that don't report cost natively (Cursor, Gemini) by using LiteLLM's community-maintained model pricing data.

## Changes

### New `llm_pricing.py` module
- Fetches the [LiteLLM model pricing JSON](https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json) at server startup
- Refreshes the pricing cache every 24 hours automatically
- Calculates cost from token counts (`input_tokens`, `output_tokens`) when the CLI doesn't provide `cost_usd` (e.g., Cursor, Gemini providers)

### Model name normalization
Handles real-world model name variations encountered in dev/prod environments:
- **Bracketed suffixes**: `claude-opus-4-6[1m]` → strips `[1m]`
- **@ version tags**: `claude-haiku-4-5@20251001` → strips `@20251001`
- **Cursor routing names**: `gpt-5.4-xhigh-fast` → strips Cursor-specific suffixes
- **Composite names**: `claude-4.6-opus-max-thinking` → normalized for lookup
- **Provider prefixes**: handles `openai/`, `anthropic/` prefixed model names

### Best-effort design
All cost operations are best-effort — if pricing data is unavailable, model lookup fails, or calculation errors occur, the pipeline continues without cost data. Cost estimation never crashes the analysis pipeline.

### Frontend changes
- Token Usage page displays an `(estimated)` qualifier next to cost values that were calculated from token counts rather than reported by the provider
- Distinguishes between provider-reported costs and LiteLLM-estimated costs

### Testing
Tested against real models from dev/prod environments:
- `claude-opus-4-6[1m]`
- `claude-haiku-4-5@20251001`
- `gpt-5.4-xhigh-fast`
- `claude-4.6-opus-max-thinking`
- `composer-2-fast`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Automatic token cost estimation using LiteLLM pricing when providers don't supply costs; estimates include optional cache read/write charges.
  - Token usage page shows an inline info icon with a tooltip explaining estimated costs and tooltip provider behavior.
  - Pricing data is loaded on startup and refreshed in the background for more accurate, up-to-date estimates; startup/shutdown manage the refresh lifecycle.

* **Tests**
  - Added tests validating cost calculations, name-normalization logic, cache-charge handling, and integration with usage recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->