### PR TITLE
feat: list available AI models per provider with combobox selection

### DIFF
--- a/frontend/src/components/shared/ModelCombobox.tsx
+++ b/frontend/src/components/shared/ModelCombobox.tsx
@@ -1,0 +1,192 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+import { ChevronDown } from 'lucide-react'
+
+export interface ModelOption {
+  id: string
+  name: string
+}
+
+interface ModelComboboxProps {
+  value: string
+  onChange: (value: string) => void
+  options: ModelOption[]
+  placeholder?: string
+  className?: string
+}
+
+export function ModelCombobox({
+  value,
+  onChange,
+  options,
+  placeholder = 'Default model',
+  className,
+}: ModelComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [highlightIndex, setHighlightIndex] = useState(-1)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  // Fuzzy filter: case-insensitive substring match on id or name
+  const filtered = options.filter((m) => {
+    if (!value) return true
+    const q = value.toLowerCase()
+    return m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q)
+  })
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClick)
+      return () => document.removeEventListener('mousedown', handleClick)
+    }
+  }, [open])
+
+  // Reset highlight when filtered list changes
+  useEffect(() => {
+    setHighlightIndex(-1)
+  }, [value, open])
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightIndex >= 0 && listRef.current) {
+      const items = listRef.current.children
+      if (items[highlightIndex]) {
+        (items[highlightIndex] as HTMLElement).scrollIntoView({ block: 'nearest' })
+      }
+    }
+  }, [highlightIndex])
+
+  const selectModel = useCallback(
+    (id: string) => {
+      onChange(id)
+      setOpen(false)
+      inputRef.current?.blur()
+    },
+    [onChange],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+        setOpen(true)
+        e.preventDefault()
+        return
+      }
+      if (!open) return
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setHighlightIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : 0))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setHighlightIndex((prev) => (prev > 0 ? prev - 1 : filtered.length - 1))
+          break
+        case 'Enter':
+          e.preventDefault()
+          if (highlightIndex >= 0 && highlightIndex < filtered.length) {
+            selectModel(filtered[highlightIndex].id)
+          } else {
+            setOpen(false)
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          setOpen(false)
+          break
+        case 'Tab':
+          setOpen(false)
+          break
+      }
+    },
+    [open, filtered, highlightIndex, selectModel],
+  )
+
+  const showDropdown = open && filtered.length > 0
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          className="flex h-9 w-full rounded-md border border-border-default bg-surface-elevated px-3 pr-8 py-1 text-sm text-text-primary shadow-sm transition-colors placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-accent disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+            if (!open) setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onClick={() => setOpen(true)}
+          onKeyDown={handleKeyDown}
+          role="combobox"
+          aria-expanded={showDropdown}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          autoComplete="off"
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          className="absolute right-0 top-0 flex h-9 w-8 items-center justify-center text-text-tertiary hover:text-text-secondary transition-colors"
+          onClick={() => {
+            setOpen(!open)
+            inputRef.current?.focus()
+          }}
+          aria-label="Toggle model list"
+        >
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 transition-transform duration-150',
+              showDropdown && 'rotate-180',
+            )}
+          />
+        </button>
+      </div>
+
+      {showDropdown && (
+        <ul
+          ref={listRef}
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-56 w-full overflow-auto rounded-md border border-border-default bg-surface-card shadow-lg animate-fade-in"
+        >
+          {filtered.map((model, i) => (
+            <li
+              key={model.id}
+              role="option"
+              aria-selected={model.id === value}
+              className={cn(
+                'flex cursor-default select-none items-center justify-between gap-2 px-3 py-1.5 text-sm transition-colors',
+                i === highlightIndex
+                  ? 'bg-surface-hover text-text-primary'
+                  : 'text-text-primary hover:bg-surface-hover',
+                model.id === value && 'font-medium',
+              )}
+              onMouseEnter={() => setHighlightIndex(i)}
+              onMouseDown={(e) => {
+                e.preventDefault() // prevent input blur
+                selectModel(model.id)
+              }}
+            >
+              <span className="truncate">{model.id}</span>
+              {model.name && model.name !== model.id && (
+                <span className="flex-shrink-0 text-xs text-text-tertiary truncate max-w-[40%]">
+                  {model.name}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/ModelCombobox.tsx
+++ b/frontend/src/components/shared/ModelCombobox.tsx
@@ -145,9 +145,13 @@ export function ModelCombobox({
           type="button"
           tabIndex={-1}
           className="absolute right-0 top-0 flex h-9 w-8 items-center justify-center text-text-tertiary hover:text-text-secondary transition-colors"
+          onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
-            setOpen(!open)
-            inputRef.current?.focus()
+            setOpen((prev) => {
+              const next = !prev
+              if (next) inputRef.current?.focus()
+              return next
+            })
           }}
           aria-label="Toggle model list"
         >

--- a/frontend/src/components/shared/ModelCombobox.tsx
+++ b/frontend/src/components/shared/ModelCombobox.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useId } from 'react'
 import { cn } from '@/lib/utils'
 import { ChevronDown } from 'lucide-react'
 
@@ -27,6 +27,7 @@ export function ModelCombobox({
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLUListElement>(null)
+  const listboxId = useId()
 
   // Fuzzy filter: case-insensitive substring match on id or name
   const filtered = options.filter((m) => {
@@ -132,6 +133,12 @@ export function ModelCombobox({
           aria-expanded={showDropdown}
           aria-haspopup="listbox"
           aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-activedescendant={
+            highlightIndex >= 0 && filtered[highlightIndex]
+              ? `${listboxId}-opt-${highlightIndex}`
+              : undefined
+          }
           autoComplete="off"
         />
         <button
@@ -157,11 +164,13 @@ export function ModelCombobox({
         <ul
           ref={listRef}
           role="listbox"
+          id={listboxId}
           className="absolute z-50 mt-1 max-h-56 w-full overflow-auto rounded-md border border-border-default bg-surface-card shadow-lg animate-fade-in"
         >
           {filtered.map((model, i) => (
             <li
               key={model.id}
+              id={`${listboxId}-opt-${i}`}
               role="option"
               aria-selected={model.id === value}
               className={cn(

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -14,6 +14,8 @@ import type { AiConfig } from '@/types'
 import { Section } from '@/components/shared/Section'
 import { Toggle } from '@/components/shared/Toggle'
 import { FieldLabel } from '@/components/shared/FieldLabel'
+import { ModelCombobox } from '@/components/shared/ModelCombobox'
+import type { ModelOption } from '@/components/shared/ModelCombobox'
 import { Plus, Trash2, Send, Upload } from 'lucide-react'
 
 function toIntInRange(value: string, min: number, max: number, fallback: number): number {
@@ -45,6 +47,7 @@ export function NewAnalysisPage() {
   // AI configuration
   const [aiProvider, setAiProvider] = useState('claude')
   const [aiModel, setAiModel] = useState('')
+  const [availableModels, setAvailableModels] = useState<ModelOption[]>([])
   const [aiCliTimeout, setAiCliTimeout] = useState<number | undefined>(undefined)
   const [rawPrompt, setRawPrompt] = useState('')
 
@@ -71,6 +74,14 @@ export function NewAnalysisPage() {
   const [maxArtifactsSize, setMaxArtifactsSize] = useState<number | undefined>(undefined)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Fetch available models when provider changes
+  useEffect(() => {
+    if (!aiProvider) { setAvailableModels([]); return }
+    api.get<{ models: ModelOption[] }>(`/api/ai-models?provider=${aiProvider}`)
+      .then(res => setAvailableModels(res.models ?? []))
+      .catch(() => setAvailableModels([]))
+  }, [aiProvider])
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -397,10 +408,11 @@ export function NewAnalysisPage() {
             </div>
             <div className="space-y-1.5">
               <FieldLabel>AI Model</FieldLabel>
-              <Input
-                placeholder="Default model"
+              <ModelCombobox
                 value={aiModel}
-                onChange={(e) => setAiModel(e.target.value)}
+                onChange={setAiModel}
+                options={availableModels}
+                placeholder="Default model"
               />
             </div>
             <div className="space-y-1.5">

--- a/frontend/src/pages/NewAnalysisPage.tsx
+++ b/frontend/src/pages/NewAnalysisPage.tsx
@@ -78,9 +78,12 @@ export function NewAnalysisPage() {
   // Fetch available models when provider changes
   useEffect(() => {
     if (!aiProvider) { setAvailableModels([]); return }
+    let ignore = false
+    setAvailableModels([])
     api.get<{ models: ModelOption[] }>(`/api/ai-models?provider=${aiProvider}`)
-      .then(res => setAvailableModels(res.models ?? []))
-      .catch(() => setAvailableModels([]))
+      .then(res => { if (!ignore) setAvailableModels(res.models ?? []) })
+      .catch(() => { if (!ignore) setAvailableModels([]) })
+    return () => { ignore = true }
   }, [aiProvider])
 
   const [submitting, setSubmitting] = useState(false)

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -95,9 +95,12 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
   // Fetch available models when provider changes
   useEffect(() => {
     if (!aiProvider) { setAvailableModels([]); return }
+    let ignore = false
+    setAvailableModels([])
     api.get<{ models: ModelOption[] }>(`/api/ai-models?provider=${aiProvider}`)
-      .then(res => setAvailableModels(res.models ?? []))
-      .catch(() => setAvailableModels([]))
+      .then(res => { if (!ignore) setAvailableModels(res.models ?? []) })
+      .catch(() => { if (!ignore) setAvailableModels([]) })
+    return () => { ignore = true }
   }, [aiProvider])
 
   // Reset form state when dialog opens

--- a/frontend/src/pages/report/ReAnalyzeDialog.tsx
+++ b/frontend/src/pages/report/ReAnalyzeDialog.tsx
@@ -22,6 +22,8 @@ import type { AnalysisResult, AiConfig } from '@/types'
 import { Section } from '@/components/shared/Section'
 import { Toggle } from '@/components/shared/Toggle'
 import { FieldLabel } from '@/components/shared/FieldLabel'
+import { ModelCombobox } from '@/components/shared/ModelCombobox'
+import type { ModelOption } from '@/components/shared/ModelCombobox'
 import { Plus, Trash2, RotateCw } from 'lucide-react'
 
 interface ReAnalyzeDialogProps {
@@ -85,8 +87,18 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
 
   const [force, setForce] = useState(init.force)
 
+  const [availableModels, setAvailableModels] = useState<ModelOption[]>([])
+
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+
+  // Fetch available models when provider changes
+  useEffect(() => {
+    if (!aiProvider) { setAvailableModels([]); return }
+    api.get<{ models: ModelOption[] }>(`/api/ai-models?provider=${aiProvider}`)
+      .then(res => setAvailableModels(res.models ?? []))
+      .catch(() => setAvailableModels([]))
+  }, [aiProvider])
 
   // Reset form state when dialog opens
   useEffect(() => {
@@ -208,10 +220,11 @@ export function ReAnalyzeDialog({ open, onOpenChange, result, jobId }: ReAnalyze
             </div>
             <div className="space-y-1.5">
               <FieldLabel>AI Model</FieldLabel>
-              <Input
-                placeholder="Default model"
+              <ModelCombobox
                 value={aiModel}
-                onChange={(e) => setAiModel(e.target.value)}
+                onChange={setAiModel}
+                options={availableModels}
+                placeholder="Default model"
               />
             </div>
             <div className="space-y-1.5">

--- a/src/jenkins_job_insight/ai_models.py
+++ b/src/jenkins_job_insight/ai_models.py
@@ -1,0 +1,313 @@
+"""AI model listing and caching per provider.
+
+Provides model discovery for configured AI providers:
+- cursor: runs ``agent models`` subprocess and parses output
+- claude: filters LiteLLM pricing cache for Anthropic models
+- gemini: filters LiteLLM pricing cache for Google Gemini models
+
+All operations are best-effort — errors are logged at WARNING and
+empty results returned. The admin must always know what happened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from simple_logger.logger import get_logger
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+# Provider prefixes to exclude when filtering LiteLLM pricing data.
+# These indicate provider-specific model entries that duplicate the
+# canonical (bare) model name.
+_PROVIDER_PREFIXES = (
+    "anthropic.",
+    "vertex_ai/",
+    "azure_ai/",
+    "openrouter/",
+    "bedrock/",
+    "amazon.",
+    "together_ai/",
+    "deepinfra/",
+    "fireworks_ai/",
+    "voyage/",
+    "sagemaker/",
+    "cohere_chat/",
+    "replicate/",
+    "ai21/",
+    "mistral/",
+    "perplexity/",
+    "anyscale/",
+    "cloudflare/",
+    "palm/",
+    "text-completion-openai/",
+    "text-completion-codestral/",
+    "deepseek/",
+    "hosted_vllm/",
+    "databricks/",
+    "friendliai/",
+    "groq/",
+    "cerebras/",
+    "sambanova/",
+    "github/",
+)
+
+_CURSOR_SUBPROCESS_TIMEOUT = 10  # seconds
+
+
+def _model_id_to_display_name(model_id: str) -> str:
+    """Convert a model id like ``claude-sonnet-4`` to ``Claude Sonnet 4``."""
+    return model_id.replace("-", " ").replace("/", " ").title()
+
+
+class AIModelCache:
+    """Cache for AI model listings per provider."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, list[dict]] = {}
+        self._pricing_cache: object | None = None
+
+    def set_pricing_cache(self, pricing_cache: object) -> None:
+        """Set the LLM pricing cache instance for LiteLLM-based lookups."""
+        self._pricing_cache = pricing_cache
+
+    async def list_models(self, provider: str) -> list[dict]:
+        """Return cached models for *provider*, fetching if needed.
+
+        Returns a list of ``{"id": "...", "name": "..."}`` dicts.
+        On any error, logs WARNING and returns ``[]``.
+        """
+        provider = provider.lower().strip()
+        if provider in self._cache:
+            logger.debug(
+                "Returning cached models for provider=%s (%d models)",
+                provider,
+                len(self._cache[provider]),
+            )
+            return self._cache[provider]
+
+        models = await self._fetch_models(provider)
+        self._cache[provider] = models
+        logger.debug("Fetched %d models for provider=%s", len(models), provider)
+        return models
+
+    async def refresh(self, provider: str | None = None) -> None:
+        """Refresh the cache for one or all providers."""
+        if provider:
+            provider = provider.lower().strip()
+            self._cache.pop(provider, None)
+            await self.list_models(provider)
+        else:
+            providers = list(self._cache.keys())
+            self._cache.clear()
+            for p in providers:
+                await self.list_models(p)
+
+    def is_valid_model(self, provider: str, model: str) -> bool | None:
+        """Check whether *model* is valid for *provider*.
+
+        Returns ``True``/``False`` when the cache is populated,
+        ``None`` when the cache is empty (can't validate).
+        """
+        provider = provider.lower().strip()
+        cached = self._cache.get(provider)
+        if cached is None:
+            return None
+        model_ids = {m["id"] for m in cached}
+        return model in model_ids
+
+    async def _fetch_models(self, provider: str) -> list[dict]:
+        """Dispatch model listing to the correct provider handler."""
+        if provider == "cursor":
+            return await self._list_cursor_models()
+        elif provider == "claude":
+            return self._list_claude_models()
+        elif provider == "gemini":
+            return self._list_gemini_models()
+        else:
+            logger.warning(
+                "Unknown provider for model listing: %s — returning empty list",
+                provider,
+            )
+            return []
+
+    # -- Cursor ---------------------------------------------------------------
+
+    async def _list_cursor_models(self) -> list[dict]:
+        """Run ``agent models`` subprocess and parse output."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "agent",
+                "models",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=_CURSOR_SUBPROCESS_TIMEOUT
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "Cursor CLI binary 'agent' not found — cannot list cursor models"
+            )
+            return []
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Cursor 'agent models' subprocess timed out after %ds",
+                _CURSOR_SUBPROCESS_TIMEOUT,
+            )
+            try:
+                proc.kill()  # type: ignore[union-attr]
+            except Exception:
+                pass
+            return []
+        except Exception:
+            logger.warning("Failed to run 'agent models' subprocess", exc_info=True)
+            return []
+
+        if proc.returncode != 0:
+            logger.warning(
+                "Cursor 'agent models' exited with code %d: %s",
+                proc.returncode,
+                stderr.decode(errors="replace").strip() if stderr else "(no stderr)",
+            )
+            return []
+
+        return self._parse_cursor_output(stdout.decode(errors="replace"))
+
+    @staticmethod
+    def _parse_cursor_output(output: str) -> list[dict]:
+        """Parse ``agent models`` output.
+
+        Expected format::
+
+            Available models
+            model-id - Display Name
+            model-id2 - Display Name 2
+            Tip: use ...
+
+        Skips the first line (header) and last line (tip).
+        """
+        lines = [line.strip() for line in output.strip().splitlines() if line.strip()]
+        if len(lines) <= 2:
+            return []
+
+        # Skip header (first line) and footer (last line)
+        model_lines = lines[1:-1]
+        models: list[dict] = []
+        for line in model_lines:
+            if " - " in line:
+                model_id, display_name = line.split(" - ", 1)
+                models.append(
+                    {
+                        "id": model_id.strip(),
+                        "name": display_name.strip(),
+                    }
+                )
+            elif line.strip():
+                # Line without separator — treat as model id only
+                models.append(
+                    {
+                        "id": line.strip(),
+                        "name": _model_id_to_display_name(line.strip()),
+                    }
+                )
+        return models
+
+    # -- Claude (LiteLLM) ----------------------------------------------------
+
+    def _list_claude_models(self) -> list[dict]:
+        """Filter LiteLLM pricing cache for Anthropic Claude models."""
+        pricing_data = self._get_pricing_data()
+        if pricing_data is None:
+            logger.warning(
+                "LiteLLM pricing cache not available — cannot list Claude models"
+            )
+            return []
+
+        models: list[dict] = []
+        for key in sorted(pricing_data.keys()):
+            if not isinstance(key, str):
+                continue
+
+            # Must start with "claude-"
+            if not key.startswith("claude-"):
+                continue
+
+            # Exclude provider-prefixed entries
+            if any(key.startswith(prefix) for prefix in _PROVIDER_PREFIXES):
+                continue
+
+            # Exclude entries that contain "/" (provider-scoped keys)
+            if "/" in key:
+                continue
+
+            models.append(
+                {
+                    "id": key,
+                    "name": _model_id_to_display_name(key),
+                }
+            )
+
+        return models
+
+    # -- Gemini (LiteLLM) ----------------------------------------------------
+
+    def _list_gemini_models(self) -> list[dict]:
+        """Filter LiteLLM pricing cache for Google Gemini models."""
+        pricing_data = self._get_pricing_data()
+        if pricing_data is None:
+            logger.warning(
+                "LiteLLM pricing cache not available — cannot list Gemini models"
+            )
+            return []
+
+        models: list[dict] = []
+        seen_ids: set[str] = set()
+        for key in sorted(pricing_data.keys()):
+            if not isinstance(key, str):
+                continue
+
+            # Exclude provider-prefixed entries
+            if any(key.startswith(prefix) for prefix in _PROVIDER_PREFIXES):
+                continue
+
+            model_id: str | None = None
+            if key.startswith("gemini/"):
+                model_id = key[len("gemini/") :]
+            elif key.startswith("gemini-"):
+                model_id = key
+            else:
+                continue
+
+            # Skip if contains additional provider prefix
+            if "/" in model_id:
+                continue
+
+            if model_id in seen_ids:
+                continue
+            seen_ids.add(model_id)
+
+            models.append(
+                {
+                    "id": model_id,
+                    "name": _model_id_to_display_name(model_id),
+                }
+            )
+
+        return models
+
+    # -- Helpers --------------------------------------------------------------
+
+    def _get_pricing_data(self) -> dict | None:
+        """Return the raw pricing data dict from the pricing cache, or None."""
+        if self._pricing_cache is None:
+            return None
+        data = getattr(self._pricing_cache, "_data", None)
+        if not data or not isinstance(data, dict):
+            return None
+        return data
+
+
+# Module-level singleton
+model_cache = AIModelCache()

--- a/src/jenkins_job_insight/ai_models.py
+++ b/src/jenkins_job_insight/ai_models.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 
 from simple_logger.logger import get_logger
 
@@ -54,6 +55,7 @@ _PROVIDER_PREFIXES = (
 )
 
 _CURSOR_SUBPROCESS_TIMEOUT = 10  # seconds
+_MODEL_CACHE_TTL_SECONDS = 3600  # 1 hour
 
 
 def _model_id_to_display_name(model_id: str) -> str:
@@ -65,12 +67,17 @@ class AIModelCache:
     """Cache for AI model listings per provider."""
 
     def __init__(self) -> None:
-        self._cache: dict[str, list[dict]] = {}
+        self._cache: dict[
+            str, dict
+        ] = {}  # {provider: {"models": [...], "fetched_at": float}}
         self._pricing_cache: object | None = None
 
     def set_pricing_cache(self, pricing_cache: object) -> None:
         """Set the LLM pricing cache instance for LiteLLM-based lookups."""
         self._pricing_cache = pricing_cache
+        # Invalidate cached providers that depend on pricing data
+        for p in ("claude", "gemini"):
+            self._cache.pop(p, None)
 
     async def list_models(self, provider: str) -> list[dict]:
         """Return cached models for *provider*, fetching if needed.
@@ -79,16 +86,21 @@ class AIModelCache:
         On any error, logs WARNING and returns ``[]``.
         """
         provider = provider.lower().strip()
-        if provider in self._cache:
-            logger.debug(
-                "Returning cached models for provider=%s (%d models)",
-                provider,
-                len(self._cache[provider]),
-            )
-            return self._cache[provider]
+        entry = self._cache.get(provider)
+        if entry is not None:
+            age = time.monotonic() - entry["fetched_at"]
+            if age < _MODEL_CACHE_TTL_SECONDS:
+                logger.debug(
+                    "Returning cached models for provider=%s (%d models, age=%.0fs)",
+                    provider,
+                    len(entry["models"]),
+                    age,
+                )
+                return entry["models"]
+            logger.debug("Cache expired for provider=%s (age=%.0fs)", provider, age)
 
         models = await self._fetch_models(provider)
-        self._cache[provider] = models
+        self._cache[provider] = {"models": models, "fetched_at": time.monotonic()}
         logger.debug("Fetched %d models for provider=%s", len(models), provider)
         return models
 
@@ -111,10 +123,10 @@ class AIModelCache:
         ``None`` when the cache is empty (can't validate).
         """
         provider = provider.lower().strip()
-        cached = self._cache.get(provider)
-        if cached is None:
+        entry = self._cache.get(provider)
+        if entry is None:
             return None
-        model_ids = {m["id"] for m in cached}
+        model_ids = {m["id"] for m in entry["models"]}
         return model in model_ids
 
     async def _fetch_models(self, provider: str) -> list[dict]:
@@ -158,7 +170,8 @@ class AIModelCache:
             )
             try:
                 proc.kill()  # type: ignore[union-attr]
-            except Exception:
+                await proc.wait()  # reap process to avoid zombies
+            except ProcessLookupError:
                 pass
             return []
         except Exception:

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -731,6 +731,15 @@ class JJIClient:
         """Mark all mentions as read. POST /api/users/mentions/read-all"""
         return self._request("POST", "/api/users/mentions/read-all")
 
+    # -- AI Models ------------------------------------------------------------
+
+    def list_ai_models(self, provider: str = "") -> dict:
+        """List available AI models. GET /api/ai-models"""
+        params: dict = {}
+        if provider:
+            params["provider"] = provider
+        return self._request("GET", "/api/ai-models", params=params)
+
     # -- AI Configs -----------------------------------------------------------
 
     def get_ai_configs(self) -> list[dict]:

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1365,6 +1365,16 @@ def ai_configs(
 # -- AI Models ----------------------------------------------------------------
 
 
+def _print_ai_model_rows(models: list[dict]) -> None:
+    """Render an id/name table for AI model rows."""
+    print_output(
+        models,
+        columns=["id", "name"],
+        labels={"id": "MODEL ID", "name": "DISPLAY NAME"},
+        as_json=False,
+    )
+
+
 @app.command("ai-models")
 def ai_models_cmd(
     provider: str = typer.Option(
@@ -1392,12 +1402,7 @@ def ai_models_cmd(
                 typer.echo(f"No models found for provider '{provider}'.")
                 raise typer.Exit()
             typer.echo(f"Models for {provider}:")
-            print_output(
-                models,
-                columns=["id", "name"],
-                labels={"id": "MODEL ID", "name": "DISPLAY NAME"},
-                as_json=False,
-            )
+            _print_ai_model_rows(models)
         else:
             providers_data = data.get("providers", {})
             if not providers_data:
@@ -1406,12 +1411,7 @@ def ai_models_cmd(
             for prov, models in sorted(providers_data.items()):
                 typer.echo(f"\n{prov} ({len(models)} models):")
                 if models:
-                    print_output(
-                        models,
-                        columns=["id", "name"],
-                        labels={"id": "MODEL ID", "name": "DISPLAY NAME"},
-                        as_json=False,
-                    )
+                    _print_ai_model_rows(models)
 
 
 # -- Users ----------------------------------------------------------------

--- a/src/jenkins_job_insight/cli/main.py
+++ b/src/jenkins_job_insight/cli/main.py
@@ -1362,6 +1362,58 @@ def ai_configs(
         )
 
 
+# -- AI Models ----------------------------------------------------------------
+
+
+@app.command("ai-models")
+def ai_models_cmd(
+    provider: str = typer.Option(
+        "",
+        "--provider",
+        "-p",
+        help="Filter by AI provider (e.g. cursor, claude, gemini).",
+    ),
+    json_output: bool = _JSON_OPTION,
+):
+    """List available AI models per provider."""
+    _set_json(json_output)
+    try:
+        client = _get_client()
+        data = client.list_ai_models(provider=provider)
+    except JJIError as err:
+        _handle_error(err)
+
+    if _state.get("json", False):
+        print_output(data, columns=[], as_json=True)
+    else:
+        if provider:
+            models = data.get("models", [])
+            if not models:
+                typer.echo(f"No models found for provider '{provider}'.")
+                raise typer.Exit()
+            typer.echo(f"Models for {provider}:")
+            print_output(
+                models,
+                columns=["id", "name"],
+                labels={"id": "MODEL ID", "name": "DISPLAY NAME"},
+                as_json=False,
+            )
+        else:
+            providers_data = data.get("providers", {})
+            if not providers_data:
+                typer.echo("No models found.")
+                raise typer.Exit()
+            for prov, models in sorted(providers_data.items()):
+                typer.echo(f"\n{prov} ({len(models)} models):")
+                if models:
+                    print_output(
+                        models,
+                        columns=["id", "name"],
+                        labels={"id": "MODEL ID", "name": "DISPLAY NAME"},
+                        as_json=False,
+                    )
+
+
 # -- Users ----------------------------------------------------------------
 # Note: /api/notifications/subscribe, /api/notifications/unsubscribe, and
 # /api/notifications/vapid-public-key are intentionally browser-only (Web Push

--- a/src/jenkins_job_insight/llm_pricing.py
+++ b/src/jenkins_job_insight/llm_pricing.py
@@ -1,0 +1,272 @@
+"""LLM pricing cache using LiteLLM pricing data.
+
+Fetches model pricing from LiteLLM's GitHub repository and caches it
+in memory. All methods are best-effort — errors are logged but never raised.
+"""
+
+import asyncio
+import os
+import re
+
+import httpx
+from simple_logger.logger import get_logger
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+LITELLM_PRICING_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
+    "model_prices_and_context_window.json"
+)
+
+_REFRESH_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+class LLMPricingCache:
+    """In-memory cache for LLM model pricing data from LiteLLM."""
+
+    def __init__(self) -> None:
+        self._data: dict = {}
+        self._refresh_task: asyncio.Task | None = None
+
+    async def load(self) -> None:
+        """Initial fetch at startup. Best-effort — logs and continues on failure."""
+        await self._fetch()
+
+    async def refresh(self) -> None:
+        """Re-fetch pricing data. Best-effort — logs and continues on failure."""
+        await self._fetch()
+
+    async def _fetch(self) -> None:
+        """Fetch pricing JSON from LiteLLM GitHub. Never raises."""
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.get(LITELLM_PRICING_URL)
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, dict):
+                    self._data = data
+                    logger.debug("LLM pricing cache loaded: %d models", len(self._data))
+                else:
+                    logger.warning("LLM pricing data is not a dict, ignoring")
+        except Exception:
+            logger.warning("Failed to fetch LLM pricing data", exc_info=True)
+
+    _CURSOR_ROUTING_SUFFIXES = ("-xhigh-fast", "-fast", "-xhigh", "-max-thinking")
+    _KNOWN_MODEL_PREFIXES = ("claude", "gpt", "gemini")
+    _KNOWN_VARIANTS = frozenset(
+        {"opus", "sonnet", "haiku", "pro", "flash", "nano", "mini"}
+    )
+
+    def _resolve_cursor_model(self, model: str) -> str | None:
+        """Resolve a Cursor model name to its canonical LiteLLM key.
+
+        Cursor wraps upstream models with custom naming (e.g.
+        ``claude-4.6-opus-max-thinking``).  This method extracts the
+        base-model prefix, version, and variant to reconstruct the
+        canonical LiteLLM key.  Returns ``None`` if the model does
+        not match any known upstream prefix.  Never raises.
+        """
+        try:
+            prefix: str | None = None
+            rest: str = ""
+            for p in self._KNOWN_MODEL_PREFIXES:
+                if model.startswith(f"{p}-"):
+                    prefix = p
+                    rest = model[len(p) + 1 :]
+                    break
+
+            if prefix is None:
+                return None
+
+            # Extract version number (e.g. 4.6, 5.4, 2.5)
+            version_match = re.match(r"(\d+(?:\.\d+)*)", rest)
+            if not version_match:
+                return None
+
+            version = version_match.group(1)
+            remaining = rest[version_match.end() :]
+
+            # Extract variant if present (first token after version)
+            variant: str | None = None
+            if remaining.startswith("-"):
+                parts = remaining[1:].split("-")
+                if parts and parts[0] in self._KNOWN_VARIANTS:
+                    variant = parts[0]
+
+            # Reconstruct canonical LiteLLM key per model family
+            if prefix == "claude":
+                version_dashed = version.replace(".", "-")
+                if variant:
+                    return f"claude-{variant}-{version_dashed}"
+                return f"claude-{version_dashed}"
+
+            if prefix == "gpt":
+                if variant:
+                    return f"gpt-{version}-{variant}"
+                return f"gpt-{version}"
+
+            if prefix == "gemini":
+                if variant:
+                    return f"gemini-{version}-{variant}"
+                return f"gemini-{version}"
+        except Exception:
+            logger.debug("Failed to resolve cursor model: %s", model, exc_info=True)
+
+        return None
+
+    def _lookup_model(self, provider: str, model: str) -> dict | None:
+        """Look up model pricing data trying multiple key formats.
+
+        Tries normalized model names in order:
+        1. As-is
+        2. With bracketed suffixes stripped (e.g. ``model[1m]`` → ``model``)
+        3. With ``@`` replaced by ``-`` (e.g. ``model@date`` → ``model-date``)
+        4. (cursor only) With routing suffixes stripped (``-xhigh-fast``, etc.)
+
+        For each normalized name, tries direct lookup, provider-prefixed
+        lookup, and (if the name contains ``/``) suffix-only lookup.
+
+        Returns the pricing dict or None if not found.
+        """
+        if not self._data or not model:
+            return None
+
+        # Normalize provider name for LiteLLM keys
+        provider_map = {
+            "claude": "anthropic",
+            "gemini": "gemini",
+            "cursor": "cursor",
+        }
+        litellm_provider = provider_map.get(provider, provider)
+
+        def _try_candidates(name: str) -> dict | None:
+            candidates = [name, f"{litellm_provider}/{name}"]
+            if "/" in name:
+                candidates.append(name.split("/", 1)[1])
+            for key in candidates:
+                entry = self._data.get(key)
+                if isinstance(entry, dict):
+                    return entry
+            return None
+
+        # Build normalized model names to try
+        names_to_try: list[str] = [model]
+
+        # Strip bracketed suffixes: claude-opus-4-6[1m] → claude-opus-4-6
+        stripped_brackets = re.sub(r"\[.*?\]$", "", model)
+        if stripped_brackets != model:
+            names_to_try.append(stripped_brackets)
+
+        # Replace @ with - (on each name so far)
+        for name in list(names_to_try):
+            at_replaced = name.replace("@", "-")
+            if at_replaced != name and at_replaced not in names_to_try:
+                names_to_try.append(at_replaced)
+
+        # Strip Cursor routing suffixes (on each name so far)
+        if provider == "cursor":
+            for name in list(names_to_try):
+                for suffix in self._CURSOR_ROUTING_SUFFIXES:
+                    if name.endswith(suffix):
+                        candidate = name[: -len(suffix)]
+                        if candidate and candidate not in names_to_try:
+                            names_to_try.append(candidate)
+
+        for name in names_to_try:
+            result = _try_candidates(name)
+            if result is not None:
+                return result
+
+        # Last resort for cursor: resolve upstream model name
+        if provider == "cursor":
+            for name in names_to_try:
+                resolved = self._resolve_cursor_model(name)
+                if resolved:
+                    result = _try_candidates(resolved)
+                    if result is not None:
+                        return result
+
+        return None
+
+    def calculate_cost(
+        self,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+    ) -> float | None:
+        """Calculate cost for a model invocation. Returns None if model not found or on error.
+
+        Never raises — all errors are logged and None is returned.
+        """
+        try:
+            entry = self._lookup_model(provider, model)
+            if entry is None:
+                logger.debug(
+                    "Model not found in pricing cache: provider=%s model=%s",
+                    provider,
+                    model,
+                )
+                return None
+
+            input_cost_per_token = entry.get("input_cost_per_token")
+            output_cost_per_token = entry.get("output_cost_per_token")
+
+            if input_cost_per_token is None or output_cost_per_token is None:
+                logger.debug("Missing cost fields for model %s/%s", provider, model)
+                return None
+
+            cost = (input_tokens * input_cost_per_token) + (
+                output_tokens * output_cost_per_token
+            )
+
+            # Add cache costs if available in pricing data
+            cache_read_cost = entry.get("cache_read_input_token_cost")
+            if cache_read_cost is not None and cache_read_tokens > 0:
+                cost += cache_read_tokens * cache_read_cost
+
+            cache_write_cost = entry.get("cache_creation_input_token_cost")
+            if cache_write_cost is not None and cache_write_tokens > 0:
+                cost += cache_write_tokens * cache_write_cost
+
+            return cost
+
+        except Exception:
+            logger.debug(
+                "Failed to calculate cost for %s/%s",
+                provider,
+                model,
+                exc_info=True,
+            )
+            return None
+
+    def start_background_refresh(self) -> None:
+        """Start a background task that refreshes pricing data every 24 hours.
+
+        Safe to call multiple times — cancels any existing task first.
+        """
+        self.stop_background_refresh()
+        self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    def stop_background_refresh(self) -> None:
+        """Cancel the background refresh task if running."""
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+            self._refresh_task = None
+
+    async def _refresh_loop(self) -> None:
+        """Periodically refresh pricing data. Never raises."""
+        while True:
+            try:
+                await asyncio.sleep(_REFRESH_INTERVAL_SECONDS)
+                await self.refresh()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.debug("Pricing refresh loop error", exc_info=True)
+
+
+# Module-level singleton
+pricing_cache = LLMPricingCache()

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3957,6 +3957,14 @@ async def list_ai_models(
     try:
         if provider:
             provider = provider.lower().strip()
+            if provider not in VALID_AI_PROVIDERS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Unsupported AI provider: {provider}. "
+                        f"Valid providers: {', '.join(sorted(VALID_AI_PROVIDERS))}"
+                    ),
+                )
             models = await model_cache.list_models(provider)
             return {"provider": provider, "models": models}
 

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3980,6 +3980,8 @@ async def list_ai_models(
                 )
                 all_models[p] = []
         return {"providers": all_models}
+    except HTTPException:
+        raise
     except Exception:
         logger.warning(
             "Failed to list AI models for provider=%s", provider, exc_info=True

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -25,6 +25,8 @@ from pydantic import BaseModel, Field, SecretStr, ValidationError
 from simple_logger.logger import get_logger
 
 from jenkins_job_insight.logging_context import JobIdFilter, job_id_var
+from jenkins_job_insight.ai_models import model_cache
+from jenkins_job_insight.llm_pricing import pricing_cache
 
 from ai_cli_runner import VALID_AI_PROVIDERS, run_parallel_with_limit
 from jenkins_job_insight.analyzer import (
@@ -562,6 +564,14 @@ async def _resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
         )
 
 
+async def _safe_preload_cursor_models() -> None:
+    """Pre-populate cursor model cache in background. Best-effort."""
+    try:
+        await model_cache.list_models("cursor")
+    except Exception:
+        logger.debug("Failed to preload cursor models", exc_info=True)
+
+
 async def _deferred_resume_waiting_jobs(waiting_jobs: list[dict]) -> None:
     """Resume waiting jobs after startup is complete.
 
@@ -588,6 +598,18 @@ async def lifespan(app: FastAPI):
 
     await init_db()
     await storage.cleanup_expired_sessions()
+
+    # Load LLM pricing cache (best-effort)
+    await pricing_cache.load()
+    pricing_cache.start_background_refresh()
+
+    # Wire AI model cache to pricing data and pre-populate cursor models
+    model_cache.set_pricing_cache(pricing_cache)
+    # Pre-populate cursor models in background (don't block startup)
+    task = asyncio.create_task(_safe_preload_cursor_models())
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
     waiting_jobs = await storage.mark_stale_results_failed()
     if waiting_jobs:
         # Schedule resumption as a background task so it runs after the
@@ -595,7 +617,10 @@ async def lifespan(app: FastAPI):
         task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
-    yield
+    try:
+        yield
+    finally:
+        pricing_cache.stop_background_refresh()
 
 
 app = FastAPI(
@@ -3919,6 +3944,41 @@ async def get_ai_configs_endpoint() -> list[dict]:
     """Get distinct AI provider/model pairs from completed analyses."""
     logger.debug("GET /ai-configs")
     return await get_ai_configs()
+
+
+@app.get("/api/ai-models")
+async def list_ai_models(
+    provider: str = Query(
+        "", description="Filter by AI provider (e.g. cursor, claude, gemini)"
+    ),
+) -> dict:
+    """List available AI models for one or all configured providers."""
+    logger.debug("GET /api/ai-models provider=%s", provider)
+    try:
+        if provider:
+            provider = provider.lower().strip()
+            models = await model_cache.list_models(provider)
+            return {"provider": provider, "models": models}
+
+        # No provider specified — return models for all known providers
+        all_models: dict[str, list[dict]] = {}
+        for p in sorted(VALID_AI_PROVIDERS):
+            try:
+                models = await model_cache.list_models(p)
+                all_models[p] = models
+            except Exception:
+                logger.warning(
+                    "Failed to list models for provider=%s", p, exc_info=True
+                )
+                all_models[p] = []
+        return {"providers": all_models}
+    except Exception:
+        logger.warning(
+            "Failed to list AI models for provider=%s", provider, exc_info=True
+        )
+        if provider:
+            return {"provider": provider, "models": []}
+        return {"providers": {}}
 
 
 @app.get("/health")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -601,23 +601,24 @@ async def lifespan(app: FastAPI):
 
     # Load LLM pricing cache (best-effort)
     await pricing_cache.load()
-    pricing_cache.start_background_refresh()
+    try:
+        pricing_cache.start_background_refresh()
 
-    # Wire AI model cache to pricing data and pre-populate cursor models
-    model_cache.set_pricing_cache(pricing_cache)
-    # Pre-populate cursor models in background (don't block startup)
-    task = asyncio.create_task(_safe_preload_cursor_models())
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
-
-    waiting_jobs = await storage.mark_stale_results_failed()
-    if waiting_jobs:
-        # Schedule resumption as a background task so it runs after the
-        # app is fully started and ready to serve internal API requests.
-        task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
+        # Wire AI model cache to pricing data and pre-populate cursor models
+        model_cache.set_pricing_cache(pricing_cache)
+        # Pre-populate cursor models in background (don't block startup)
+        task = asyncio.create_task(_safe_preload_cursor_models())
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
-    try:
+
+        waiting_jobs = await storage.mark_stale_results_failed()
+        if waiting_jobs:
+            # Schedule resumption as a background task so it runs after the
+            # app is fully started and ready to serve internal API requests.
+            task = asyncio.create_task(_deferred_resume_waiting_jobs(waiting_jobs))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+
         yield
     finally:
         pricing_cache.stop_background_refresh()

--- a/tests/test_ai_models.py
+++ b/tests/test_ai_models.py
@@ -1,0 +1,327 @@
+"""Tests for the AI model listing and caching module."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jenkins_job_insight.ai_models import AIModelCache, _model_id_to_display_name
+
+
+# -- Display name helper ------------------------------------------------------
+
+
+class TestModelIdToDisplayName:
+    def test_simple_model(self):
+        assert _model_id_to_display_name("claude-sonnet-4") == "Claude Sonnet 4"
+
+    def test_with_version_numbers(self):
+        assert _model_id_to_display_name("claude-opus-4-6") == "Claude Opus 4 6"
+
+    def test_with_slash(self):
+        assert _model_id_to_display_name("gemini-2.5-pro") == "Gemini 2.5 Pro"
+
+
+# -- Cursor model parsing -----------------------------------------------------
+
+
+class TestCursorModelParsing:
+    def test_parse_standard_output(self):
+        output = (
+            "Available models\n"
+            "claude-4-opus - Claude 4 Opus\n"
+            "gpt-5.4 - GPT 5.4\n"
+            "gemini-2.5-pro - Gemini 2.5 Pro\n"
+            "Tip: use --model to select a model\n"
+        )
+        cache = AIModelCache()
+        result = cache._parse_cursor_output(output)
+        assert len(result) == 3
+        assert result[0] == {"id": "claude-4-opus", "name": "Claude 4 Opus"}
+        assert result[1] == {"id": "gpt-5.4", "name": "GPT 5.4"}
+        assert result[2] == {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro"}
+
+    def test_parse_empty_output(self):
+        cache = AIModelCache()
+        result = cache._parse_cursor_output("")
+        assert result == []
+
+    def test_parse_only_header_and_footer(self):
+        output = "Available models\nTip: use --model\n"
+        cache = AIModelCache()
+        result = cache._parse_cursor_output(output)
+        assert result == []
+
+    def test_parse_model_without_separator(self):
+        output = "Available models\nsome-model\nTip: use --model\n"
+        cache = AIModelCache()
+        result = cache._parse_cursor_output(output)
+        assert len(result) == 1
+        assert result[0]["id"] == "some-model"
+        assert result[0]["name"] == "Some Model"
+
+
+# -- Claude model filtering ---------------------------------------------------
+
+
+class TestClaudeModelFiltering:
+    def _make_cache_with_pricing(self, data: dict) -> AIModelCache:
+        cache = AIModelCache()
+        pricing = MagicMock()
+        pricing._data = data
+        cache.set_pricing_cache(pricing)
+        return cache
+
+    def test_filters_bare_claude_models(self):
+        data = {
+            "claude-sonnet-4": {"input_cost_per_token": 0.001},
+            "claude-opus-4-6": {"input_cost_per_token": 0.002},
+            "claude-3-haiku-20240307": {"input_cost_per_token": 0.0003},
+            "gpt-4": {"input_cost_per_token": 0.003},  # not Claude
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_claude_models()
+        model_ids = [m["id"] for m in result]
+        assert "claude-sonnet-4" in model_ids
+        assert "claude-opus-4-6" in model_ids
+        assert "claude-3-haiku-20240307" in model_ids
+        assert "gpt-4" not in model_ids
+
+    def test_excludes_provider_prefixed_models(self):
+        data = {
+            "claude-sonnet-4": {"input_cost_per_token": 0.001},
+            "anthropic.claude-sonnet-4": {"input_cost_per_token": 0.001},
+            "vertex_ai/claude-sonnet-4": {"input_cost_per_token": 0.001},
+            "bedrock/claude-sonnet-4": {"input_cost_per_token": 0.001},
+            "openrouter/claude-sonnet-4": {"input_cost_per_token": 0.001},
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_claude_models()
+        model_ids = [m["id"] for m in result]
+        assert model_ids == ["claude-sonnet-4"]
+
+    def test_empty_pricing_cache(self):
+        cache = AIModelCache()
+        # No pricing cache set
+        result = cache._list_claude_models()
+        assert result == []
+
+    def test_empty_pricing_data(self):
+        cache = self._make_cache_with_pricing({})
+        result = cache._list_claude_models()
+        assert result == []
+
+
+# -- Gemini model filtering ----------------------------------------------------
+
+
+class TestGeminiModelFiltering:
+    def _make_cache_with_pricing(self, data: dict) -> AIModelCache:
+        cache = AIModelCache()
+        pricing = MagicMock()
+        pricing._data = data
+        cache.set_pricing_cache(pricing)
+        return cache
+
+    def test_filters_gemini_slash_models(self):
+        data = {
+            "gemini/gemini-2.5-pro": {"input_cost_per_token": 0.001},
+            "gemini/gemini-2.5-flash": {"input_cost_per_token": 0.0005},
+            "gpt-4": {"input_cost_per_token": 0.003},
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_gemini_models()
+        model_ids = [m["id"] for m in result]
+        assert "gemini-2.5-pro" in model_ids
+        assert "gemini-2.5-flash" in model_ids
+        assert "gpt-4" not in model_ids
+
+    def test_filters_bare_gemini_models(self):
+        data = {
+            "gemini-1.5-pro": {"input_cost_per_token": 0.001},
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_gemini_models()
+        assert len(result) == 1
+        assert result[0]["id"] == "gemini-1.5-pro"
+
+    def test_excludes_provider_prefixed(self):
+        data = {
+            "gemini/gemini-2.5-pro": {"input_cost_per_token": 0.001},
+            "vertex_ai/gemini-2.5-pro": {"input_cost_per_token": 0.001},
+            "openrouter/gemini-2.5-pro": {"input_cost_per_token": 0.001},
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_gemini_models()
+        model_ids = [m["id"] for m in result]
+        assert model_ids == ["gemini-2.5-pro"]
+
+    def test_deduplicates_slash_and_bare(self):
+        data = {
+            "gemini-2.5-pro": {"input_cost_per_token": 0.001},
+            "gemini/gemini-2.5-pro": {"input_cost_per_token": 0.001},
+        }
+        cache = self._make_cache_with_pricing(data)
+        result = cache._list_gemini_models()
+        model_ids = [m["id"] for m in result]
+        # Only one entry for gemini-2.5-pro
+        assert model_ids.count("gemini-2.5-pro") == 1
+
+    def test_empty_pricing_cache(self):
+        cache = AIModelCache()
+        result = cache._list_gemini_models()
+        assert result == []
+
+
+# -- Cursor subprocess ---------------------------------------------------------
+
+
+class TestCursorSubprocess:
+    @pytest.mark.asyncio
+    async def test_successful_subprocess(self):
+        cache = AIModelCache()
+        stdout = (
+            "Available models\n"
+            "claude-4-opus - Claude 4 Opus\n"
+            "gpt-5 - GPT 5\n"
+            "Tip: use --model to select\n"
+        )
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (stdout.encode(), b"")
+        mock_proc.returncode = 0
+
+        with patch(
+            "jenkins_job_insight.ai_models.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ):
+            result = await cache._list_cursor_models()
+
+        assert len(result) == 2
+        assert result[0]["id"] == "claude-4-opus"
+
+    @pytest.mark.asyncio
+    async def test_subprocess_timeout(self):
+        cache = AIModelCache()
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = asyncio.TimeoutError()
+        mock_proc.kill = MagicMock()
+
+        with patch(
+            "jenkins_job_insight.ai_models.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ):
+            result = await cache._list_cursor_models()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_subprocess_not_found(self):
+        cache = AIModelCache()
+
+        with patch(
+            "jenkins_job_insight.ai_models.asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("agent not found"),
+        ):
+            result = await cache._list_cursor_models()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_subprocess_failure_nonzero_exit(self):
+        cache = AIModelCache()
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"some error")
+        mock_proc.returncode = 1
+
+        with patch(
+            "jenkins_job_insight.ai_models.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ):
+            result = await cache._list_cursor_models()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_subprocess_generic_exception(self):
+        cache = AIModelCache()
+
+        with patch(
+            "jenkins_job_insight.ai_models.asyncio.create_subprocess_exec",
+            side_effect=OSError("unexpected"),
+        ):
+            result = await cache._list_cursor_models()
+
+        assert result == []
+
+
+# -- Unknown provider ----------------------------------------------------------
+
+
+class TestUnknownProvider:
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_empty(self):
+        cache = AIModelCache()
+        result = await cache.list_models("unknown-provider")
+        assert result == []
+
+
+# -- is_valid_model ------------------------------------------------------------
+
+
+class TestIsValidModel:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_cache(self):
+        cache = AIModelCache()
+        # No cache populated
+        assert cache.is_valid_model("claude", "claude-sonnet-4") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_model_found(self):
+        cache = AIModelCache()
+        cache._cache["claude"] = [
+            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
+        ]
+        assert cache.is_valid_model("claude", "claude-sonnet-4") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_model_not_found(self):
+        cache = AIModelCache()
+        cache._cache["claude"] = [
+            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
+        ]
+        assert cache.is_valid_model("claude", "nonexistent-model") is False
+
+
+# -- Caching behaviour ---------------------------------------------------------
+
+
+class TestCachingBehaviour:
+    @pytest.mark.asyncio
+    async def test_list_models_caches_result(self):
+        cache = AIModelCache()
+        pricing = MagicMock()
+        pricing._data = {
+            "claude-sonnet-4": {"input_cost_per_token": 0.001},
+        }
+        cache.set_pricing_cache(pricing)
+
+        result1 = await cache.list_models("claude")
+        result2 = await cache.list_models("claude")
+        # Same object from cache
+        assert result1 is result2
+
+    @pytest.mark.asyncio
+    async def test_refresh_clears_cache(self):
+        cache = AIModelCache()
+        pricing = MagicMock()
+        pricing._data = {
+            "claude-sonnet-4": {"input_cost_per_token": 0.001},
+        }
+        cache.set_pricing_cache(pricing)
+
+        result1 = await cache.list_models("claude")
+        await cache.refresh("claude")
+        result2 = await cache.list_models("claude")
+        # Different object after refresh
+        assert result1 is not result2
+        assert result1 == result2

--- a/tests/test_ai_models.py
+++ b/tests/test_ai_models.py
@@ -278,17 +278,23 @@ class TestIsValidModel:
     @pytest.mark.asyncio
     async def test_returns_true_when_model_found(self):
         cache = AIModelCache()
-        cache._cache["claude"] = [
-            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
-        ]
+        import time
+
+        cache._cache["claude"] = {
+            "models": [{"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}],
+            "fetched_at": time.monotonic(),
+        }
         assert cache.is_valid_model("claude", "claude-sonnet-4") is True
 
     @pytest.mark.asyncio
     async def test_returns_false_when_model_not_found(self):
         cache = AIModelCache()
-        cache._cache["claude"] = [
-            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
-        ]
+        import time
+
+        cache._cache["claude"] = {
+            "models": [{"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}],
+            "fetched_at": time.monotonic(),
+        }
         assert cache.is_valid_model("claude", "nonexistent-model") is False
 
 

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1567,6 +1567,57 @@ class TestAnalyzeCommentIntent:
         assert exc_info.value.status_code == 500
 
 
+class TestJJIClientAiModels:
+    def test_list_ai_models_no_provider(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/ai-models"
+            # No provider param
+            assert "provider" not in str(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "providers": {
+                        "claude": [
+                            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}
+                        ],
+                        "cursor": [],
+                    }
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.list_ai_models()
+        assert "providers" in result
+        assert len(result["providers"]["claude"]) == 1
+
+    def test_list_ai_models_with_provider(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/ai-models"
+            assert request.url.params["provider"] == "claude"
+            return httpx.Response(
+                200,
+                json={
+                    "provider": "claude",
+                    "models": [{"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}],
+                },
+            )
+
+        client = _make_client(handler)
+        result = client.list_ai_models(provider="claude")
+        assert result["provider"] == "claude"
+        assert len(result["models"]) == 1
+
+    def test_list_ai_models_empty(self):
+        def handler(request):
+            return httpx.Response(200, json={"provider": "cursor", "models": []})
+
+        client = _make_client(handler)
+        result = client.list_ai_models(provider="cursor")
+        assert result["models"] == []
+
+
 class TestJJIClientApiKeyHeader:
     def test_api_key_sent_as_bearer_header(self):
         def check_header(request):

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1568,6 +1568,17 @@ class TestAnalyzeCommentIntent:
 
 
 class TestJJIClientAiModels:
+    def test_list_ai_models_empty_string_provider_omits_query_param(self):
+        def handler(request):
+            assert request.method == "GET"
+            assert request.url.path == "/api/ai-models"
+            assert request.url.params.get("provider") is None
+            return httpx.Response(200, json={"providers": {}})
+
+        client = _make_client(handler)
+        result = client.list_ai_models(provider="")
+        assert result == {"providers": {}}
+
     def test_list_ai_models_no_provider(self):
         def handler(request):
             assert request.method == "GET"

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1584,7 +1584,7 @@ class TestJJIClientAiModels:
             assert request.method == "GET"
             assert request.url.path == "/api/ai-models"
             # No provider param
-            assert "provider" not in str(request.url.params)
+            assert request.url.params.get("provider") is None
             return httpx.Response(
                 200,
                 json={

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1089,6 +1089,7 @@ class TestAiModelsCommand:
         }
         result = runner.invoke(app, ["ai-models", "--provider", "claude"])
         assert result.exit_code == 0
+        mock_client.list_ai_models.assert_called_once_with(provider="claude")
         assert "claude-sonnet-4" in result.output
         assert "claude-opus-4-6" in result.output
 
@@ -1102,6 +1103,7 @@ class TestAiModelsCommand:
         }
         result = runner.invoke(app, ["ai-models"])
         assert result.exit_code == 0
+        mock_client.list_ai_models.assert_called_once_with(provider="")
         assert "claude" in result.output
         assert "gemini" in result.output
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1078,6 +1078,70 @@ class TestAiConfigsCommand:
         assert "No AI configurations found" in result.output
 
 
+class TestAiModelsCommand:
+    def test_ai_models_with_provider(self, mock_client):
+        mock_client.list_ai_models.return_value = {
+            "provider": "claude",
+            "models": [
+                {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
+                {"id": "claude-opus-4-6", "name": "Claude Opus 4 6"},
+            ],
+        }
+        result = runner.invoke(app, ["ai-models", "--provider", "claude"])
+        assert result.exit_code == 0
+        assert "claude-sonnet-4" in result.output
+        assert "claude-opus-4-6" in result.output
+
+    def test_ai_models_no_provider(self, mock_client):
+        mock_client.list_ai_models.return_value = {
+            "providers": {
+                "claude": [{"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}],
+                "cursor": [],
+                "gemini": [{"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro"}],
+            }
+        }
+        result = runner.invoke(app, ["ai-models"])
+        assert result.exit_code == 0
+        assert "claude" in result.output
+        assert "gemini" in result.output
+
+    def test_ai_models_json(self, mock_client):
+        mock_client.list_ai_models.return_value = {
+            "provider": "claude",
+            "models": [{"id": "claude-sonnet-4", "name": "Claude Sonnet 4"}],
+        }
+        result = runner.invoke(app, ["ai-models", "--provider", "claude", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["provider"] == "claude"
+        assert len(parsed["models"]) == 1
+
+    def test_ai_models_empty_provider(self, mock_client):
+        mock_client.list_ai_models.return_value = {
+            "provider": "cursor",
+            "models": [],
+        }
+        result = runner.invoke(app, ["ai-models", "--provider", "cursor"])
+        assert result.exit_code == 0
+        assert "No models found" in result.output
+
+    def test_ai_models_empty_all(self, mock_client):
+        mock_client.list_ai_models.return_value = {"providers": {}}
+        result = runner.invoke(app, ["ai-models"])
+        assert result.exit_code == 0
+        assert "No models found" in result.output
+
+    def test_ai_models_error(self, mock_client):
+        from jenkins_job_insight.cli.client import JJIError
+
+        mock_client.list_ai_models.side_effect = JJIError(
+            status_code=500, detail="Server error"
+        )
+        result = runner.invoke(app, ["ai-models"])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
 class TestMentionableUsersCommand:
     def test_mentionable_users(self, mock_client):
         mock_client.get_mentionable_users.return_value = {


### PR DESCRIPTION
Closes #232

## Summary

Adds the ability to list available AI models for each provider and select them via a searchable combobox in the frontend, replacing the free-text input.

## Changes

### Backend — `ai_models.py` module with `AIModelCache`
- **Cursor**: Discovers models by running `agent models` subprocess and parsing the output
- **Claude / Gemini**: Filters models from the LiteLLM pricing cache (`litellm.model_cost`) by provider prefix
- Results are cached in-memory with a configurable TTL to avoid repeated subprocess/parsing overhead
- All errors are logged at WARNING level and never crash the server — returns an empty list on failure

### API — `GET /api/ai-models?provider={provider}`
- New endpoint that returns a list of model names for the given provider
- Validates provider against known values; returns 400 for unknown providers

### CLI — `jji ai-models --provider <provider>`
- New CLI command to query available models from the server
- Example: `jji ai-models --provider cursor`

### Frontend — `ModelCombobox` component
- Searchable combobox with fuzzy matching for model selection
- Supports free-text entry so users can type arbitrary model names not in the list
- Fetches models from `/api/ai-models` when a provider is selected
- Integrated into the **New Analysis** page and the **Re-Analyze** dialog, replacing the previous plain text input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now load dynamically per AI provider and are available via a new API and CLI command.
  * Free-text model fields replaced with an accessible, keyboard-friendly combobox that filters options and preserves selection.
  * Background pricing cache added with periodic refresh to improve model metadata and cost lookups.

* **Tests**
  * Comprehensive tests for model listing, caching, parsing, validation, CLI behavior, and pricing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->