### PR TITLE
feat: show running analysis count badge on Dashboard nav tab

### DIFF
--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -29,14 +29,26 @@ export function NavBar() {
   const location = useLocation()
   const { isAdmin, username } = useAuth()
   const [unreadCount, setUnreadCount] = useState(0)
+  const [activeCount, setActiveCount] = useState(0)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   const [feedbackEnabled, setFeedbackEnabled] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const activeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const fetchUnread = useCallback(async () => {
     try {
       const res = await api.get<{ count: number }>('/api/users/mentions/unread-count')
       setUnreadCount(res.count)
+    } catch {
+      // best-effort
+    }
+  }, [])
+
+  const fetchActiveCount = useCallback(async () => {
+    try {
+      const res = await api.get<Array<{ status: string }>>('/api/dashboard')
+      const active = res.filter(j => ['running', 'pending', 'waiting'].includes(j.status))
+      setActiveCount(active.length)
     } catch {
       // best-effort
     }
@@ -53,6 +65,15 @@ export function NavBar() {
 
   useEffect(() => {
     if (!username) return
+    fetchActiveCount()
+    activeIntervalRef.current = setInterval(fetchActiveCount, UNREAD_POLL_INTERVAL)
+    return () => {
+      if (activeIntervalRef.current) clearInterval(activeIntervalRef.current)
+    }
+  }, [username, fetchActiveCount])
+
+  useEffect(() => {
+    if (!username) return
     function handleMentionsUpdated() {
       fetchUnread()
     }
@@ -65,15 +86,19 @@ export function NavBar() {
     function handleVisibility() {
       if (document.visibilityState === 'visible') {
         fetchUnread()
+        fetchActiveCount()
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)
     return () => document.removeEventListener('visibilitychange', handleVisibility)
-  }, [username, fetchUnread])
+  }, [username, fetchUnread, fetchActiveCount])
 
-  // Clear stale unread count when user is logged out
+  // Clear stale counts when user is logged out
   useEffect(() => {
-    if (!username) setUnreadCount(0)
+    if (!username) {
+      setUnreadCount(0)
+      setActiveCount(0)
+    }
   }, [username])
 
   // Fetch server capabilities to check if feedback is enabled
@@ -128,6 +153,11 @@ export function NavBar() {
                 )}
               >
                 {label}
+                {to === '/' && activeCount > 0 && (
+                  <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-signal-orange px-1 text-[10px] font-bold text-white">
+                    {activeCount > 99 ? '99+' : activeCount}
+                  </span>
+                )}
                 {to === '/mentions' && unreadCount > 0 && (
                   <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-signal-blue px-1 text-[10px] font-bold text-white">
                     {unreadCount > 99 ? '99+' : unreadCount}

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -45,11 +45,11 @@ export function NavBar() {
     }
   }, [])
 
-  const fetchActiveCount = useCallback(async () => {
+  const fetchActiveCount = useCallback(async (ignore?: { current: boolean }) => {
     try {
-      const res = await api.get<Array<{ status: string }>>('/api/dashboard')
-      const active = res.filter(j => ['running', 'pending', 'waiting'].includes(j.status))
-      setActiveCount(active.length)
+      const res = await api.get<{ count: number }>('/api/dashboard/active-count')
+      if (ignore?.current) return
+      setActiveCount(res.count)
     } catch {
       // best-effort
     }
@@ -66,9 +66,11 @@ export function NavBar() {
 
   useEffect(() => {
     if (!username) return
-    fetchActiveCount()
-    activeIntervalRef.current = setInterval(fetchActiveCount, UNREAD_POLL_INTERVAL)
+    const ignore = { current: false }
+    fetchActiveCount(ignore)
+    activeIntervalRef.current = setInterval(() => fetchActiveCount(ignore), UNREAD_POLL_INTERVAL)
     return () => {
+      ignore.current = true
       if (activeIntervalRef.current) clearInterval(activeIntervalRef.current)
     }
   }, [username, fetchActiveCount])

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -156,8 +156,8 @@ export function NavBar() {
                 )}
               >
                 {label}
-                {to === '/' && <NavBadge count={activeCount} color="orange" />}
-                {to === '/mentions' && <NavBadge count={unreadCount} color="blue" />}
+                {to === '/' && <NavBadge count={activeCount} color="orange" tooltip={`${activeCount} ${activeCount === 1 ? 'analysis' : 'analyses'} running`} pulse />}
+                {to === '/mentions' && <NavBadge count={unreadCount} color="blue" tooltip={`${unreadCount} unread ${unreadCount === 1 ? 'mention' : 'mentions'}`} />}
               </Link>
             ))}
           </nav>

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { BookOpen, MessageSquarePlus, type LucideIcon } from 'lucide-react'
 import { UserBadge } from './UserBadge'
 import { FeedbackDialog } from '@/components/shared/FeedbackDialog'
+import { NavBadge } from '@/components/shared/NavBadge'
 import { useAuth } from '@/lib/auth'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
@@ -153,16 +154,8 @@ export function NavBar() {
                 )}
               >
                 {label}
-                {to === '/' && activeCount > 0 && (
-                  <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-signal-orange px-1 text-[10px] font-bold text-white">
-                    {activeCount > 99 ? '99+' : activeCount}
-                  </span>
-                )}
-                {to === '/mentions' && unreadCount > 0 && (
-                  <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-signal-blue px-1 text-[10px] font-bold text-white">
-                    {unreadCount > 99 ? '99+' : unreadCount}
-                  </span>
-                )}
+                {to === '/' && <NavBadge count={activeCount} color="orange" />}
+                {to === '/mentions' && <NavBadge count={unreadCount} color="blue" />}
               </Link>
             ))}
           </nav>

--- a/frontend/src/components/shared/NavBadge.tsx
+++ b/frontend/src/components/shared/NavBadge.tsx
@@ -1,14 +1,30 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
 interface NavBadgeProps {
   count: number
   color: 'orange' | 'blue'
+  tooltip: string
+  pulse?: boolean
 }
 
-export function NavBadge({ count, color }: NavBadgeProps) {
+export function NavBadge({ count, color, tooltip, pulse }: NavBadgeProps) {
   if (count <= 0) return null
   const bgClass = color === 'orange' ? 'bg-signal-orange' : 'bg-signal-blue'
   return (
-    <span className={`absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full ${bgClass} px-1 text-[10px] font-bold text-white`}>
-      {count > 99 ? '99+' : count}
-    </span>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={`absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full ${bgClass} px-1 text-[10px] font-bold text-white${pulse ? ' animate-pulse' : ''}`}>
+            {count > 99 ? '99+' : count}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }

--- a/frontend/src/components/shared/NavBadge.tsx
+++ b/frontend/src/components/shared/NavBadge.tsx
@@ -1,0 +1,14 @@
+interface NavBadgeProps {
+  count: number
+  color: 'orange' | 'blue'
+}
+
+export function NavBadge({ count, color }: NavBadgeProps) {
+  if (count <= 0) return null
+  const bgClass = color === 'orange' ? 'bg-signal-orange' : 'bg-signal-blue'
+  return (
+    <span className={`absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full ${bgClass} px-1 text-[10px] font-bold text-white`}>
+      {count > 99 ? '99+' : count}
+    </span>
+  )
+}

--- a/src/jenkins_job_insight/cli/client.py
+++ b/src/jenkins_job_insight/cli/client.py
@@ -181,6 +181,10 @@ class JJIClient:
         """List analysis jobs with dashboard metadata. GET /api/dashboard"""
         return self._request("GET", "/api/dashboard")
 
+    def get_active_count(self) -> dict:
+        """Get count of currently active analyses. GET /api/dashboard/active-count"""
+        return self._request("GET", "/api/dashboard/active-count")
+
     def get_result(self, job_id: str) -> dict:
         """Get a stored result by job_id. GET /results/{job_id}"""
         return self._request("GET", f"/results/{job_id}")

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3566,6 +3566,18 @@ async def delete_job_endpoint(
     return {"status": "deleted", "job_id": job_id}
 
 
+@app.get("/api/dashboard/active-count")
+async def get_active_analysis_count() -> dict:
+    """Get count of currently active analyses (running/pending/waiting)."""
+    logger.debug("GET /api/dashboard/active-count")
+    try:
+        count = await storage.count_active_analyses()
+        return {"count": count}
+    except Exception:
+        logger.warning("Failed to get active analysis count", exc_info=True)
+        return {"count": 0}
+
+
 @app.get("/api/dashboard")
 async def api_dashboard() -> list[dict]:
     """Return dashboard job list as JSON for the React frontend."""

--- a/src/jenkins_job_insight/main.py
+++ b/src/jenkins_job_insight/main.py
@@ -3572,10 +3572,13 @@ async def get_active_analysis_count() -> dict:
     logger.debug("GET /api/dashboard/active-count")
     try:
         count = await storage.count_active_analyses()
-        return {"count": count}
-    except Exception:
+    except Exception as exc:
         logger.warning("Failed to get active analysis count", exc_info=True)
-        return {"count": 0}
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to get active analysis count",
+        ) from exc
+    return {"count": count}
 
 
 @app.get("/api/dashboard")

--- a/src/jenkins_job_insight/storage.py
+++ b/src/jenkins_job_insight/storage.py
@@ -1643,7 +1643,25 @@ async def get_job_stats(job_name: str, exclude_job_id: str = "") -> dict:
     }
 
 
+ACTIVE_STATUSES = ("running", "pending", "waiting")
+
 DEFAULT_DASHBOARD_LIMIT = 500
+
+
+async def count_active_analyses() -> int:
+    """Return the number of analyses with an active status.
+
+    Active statuses are: running, pending, waiting.
+    Uses a lightweight COUNT query — no result_json is fetched.
+    """
+    placeholders = ",".join("?" for _ in ACTIVE_STATUSES)
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            f"SELECT COUNT(*) FROM results WHERE status IN ({placeholders})",
+            ACTIVE_STATUSES,
+        )
+        row = await cursor.fetchone()
+        return row[0] if row else 0
 
 
 async def list_results_for_dashboard(


### PR DESCRIPTION
## Summary

Closes #233

Adds an orange badge on the **Dashboard** nav tab showing the count of active analyses (running, pending, or waiting status).

## Changes

- **Orange count badge** on the Dashboard navigation tab displaying the number of currently active analyses (running/pending/waiting states)
- **Auto-hidden** when there are no active jobs — the badge disappears entirely rather than showing zero
- **Polls `/api/dashboard` every 30 seconds**, following the same polling pattern already used by the Mentions unread badge
- **Refreshes on tab visibility change** — when the user switches back to the browser tab, the count is immediately re-fetched
- **Clears on logout** — the badge resets when the user logs out, consistent with other session-scoped UI state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard link now shows an active-items badge (caps at "99+"); Mentions shows unread badge.
  * Badges consolidated into a unified nav badge and refresh independently on separate polling intervals and when returning to the page.

* **Bug Fixes**
  * Both unread and active counts clear on logout to avoid stale badge displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->